### PR TITLE
Change addSoapHeader to applySoapHeaders

### DIFF
--- a/src/Phpro/SoapClient/Client.php
+++ b/src/Phpro/SoapClient/Client.php
@@ -39,14 +39,12 @@ class Client implements ClientInterface
     }
 
     /**
-     * @param SoapHeader $soapHeader
-     *
+     * @param SoapHeader|SoapHeader[] $soapHeaders
      * @return $this
      */
-    public function addSoapHeader(SoapHeader $soapHeader)
+    public function applySoapHeaders($soapHeaders)
     {
-        $this->soapClient->__setSoapHeaders($soapHeader);
-
+        $this->soapClient->__setSoapHeaders($soapHeaders);
         return $this;
     }
 


### PR DESCRIPTION
Function name addSoapHeader made me assume it could be called multiple times.
Passing an array was not possible due to the type hint.