### PR TITLE
Make it possible to use the SoapClient with SOAP services that dont support Request or Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,28 @@ In the last part of the snippet you can see how the client works.
  It will use the generated value-objects to call the `RequestInterface` on the SoapClient.
  As a result the `ResultProviderInterface` will return the actual `ResultInterface` which contains the `getGreeting()` method.
  Pretty readable right?
+ 
+### My SOAP service does not work with Request / Response objects
+
+In older SOAP services, it is possible that it is impossible to request with a `RequestInterface`.
+ Those services typically require multiple SOAP arguments in the method.
+ This is why we created a `MixedArgumentRequestInterface`.
+ With this interface, you can still use our SOAP client, but send multiple arguments to the SOAP service.
+
+```php
+$request = new MultiArgumentRequest(['argument1', 'argument2'])
+$response = $client->someMethodWithMultipleArguments($request)
+```
+
+When the SOAP service is returning an internal PHP type, the result is being wrapped with a `MixedResult` class.
+  This way, you don't have to worry about the internal type of the SOAP response.
+  
+```php
+/** @var MixedResult $result */
+$result = $client->someMethodWithInternalTypeResult($request);
+$actualResponse = $response->getResponse();
+```
+
 
 ## Hooking in with events
 

--- a/spec/Phpro/SoapClient/Type/MixedResultSpec.php
+++ b/spec/Phpro/SoapClient/Type/MixedResultSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\Phpro\SoapClient\Type;
+
+use Phpro\SoapClient\Type\MixedResult;
+use Phpro\SoapClient\Type\ResultInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * Class MixedResultSpec
+ *
+ * @package spec\Phpro\SoapClient\Type
+ * @mixin MixedResult
+ */
+class MixedResultSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('actualResult');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MixedResult::class);
+    }
+
+    function it_is_a_result()
+    {
+        $this->shouldImplement(ResultInterface::class);
+    }
+
+    function it_contains_the_mixed_result()
+    {
+        $this->getResult()->shouldBe('actualResult');
+    }
+}

--- a/spec/Phpro/SoapClient/Type/MultiArgumentRequestSpec.php
+++ b/spec/Phpro/SoapClient/Type/MultiArgumentRequestSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace spec\Phpro\SoapClient\Type;
+
+use Phpro\SoapClient\Type\MultiArgumentRequest;
+use Phpro\SoapClient\Type\MultiArgumentRequestInterface;
+use Phpro\SoapClient\Type\RequestInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * Class MultiArgumentRequestSpec
+ *
+ * @package spec\Phpro\SoapClient\Type
+ * @mixin MultiArgumentRequest
+ */
+class MultiArgumentRequestSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(['arg1', 'arg2']);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MultiArgumentRequest::class);
+    }
+
+    function it_is_a_multiple_argument_request()
+    {
+        $this->shouldImplement(MultiArgumentRequestInterface::class);
+        $this->shouldImplement(RequestInterface::class);
+    }
+
+    function it_has_multiple_arguments()
+    {
+        $this->getArguments()->shouldBe(['arg1', 'arg2']);
+    }
+}

--- a/src/Phpro/SoapClient/Type/MixedResult.php
+++ b/src/Phpro/SoapClient/Type/MixedResult.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Phpro\SoapClient\Type;
+
+/**
+ * Class MixedResult
+ *
+ * @package Phpro\SoapClient\Type
+ */
+class MixedResult implements ResultInterface
+{
+    /**
+     * @var mixed
+     */
+    private $result;
+
+    /**
+     * MixedResult constructor.
+     *
+     * @param mixed $result
+     */
+    public function __construct($result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+}

--- a/src/Phpro/SoapClient/Type/MultiArgumentRequest.php
+++ b/src/Phpro/SoapClient/Type/MultiArgumentRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Phpro\SoapClient\Type;
+
+/**
+ * Class MultiArgumentRequest
+ *
+ * @package Phpro\SoapClient\Type
+ */
+class MultiArgumentRequest implements MultiArgumentRequestInterface
+{
+    /**
+     * @var array
+     */
+    private $arguments;
+
+    /**
+     * MultiArgumentRequest constructor.
+     *
+     * @param array $arguments
+     */
+    public function __construct(array $arguments)
+    {
+        $this->arguments = $arguments;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+}

--- a/src/Phpro/SoapClient/Type/MultiArgumentRequestInterface.php
+++ b/src/Phpro/SoapClient/Type/MultiArgumentRequestInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phpro\SoapClient\Type;
+
+/**
+ * Class MultiArgumentRequestInterface
+ *
+ * @package Phpro\SoapClient\Type\Legacy
+ */
+interface MultiArgumentRequestInterface extends RequestInterface
+{
+    /**
+     * @return array
+     */
+    public function getArguments();
+}


### PR DESCRIPTION
This PR contains a `MixedResult` and `MultiArgumentRequestInterface` to make it possible to let this SOAP client work with older SOAP services that don't support Request and Result types.