### PR TITLE
Fixed authorization header for HTTP Basic Auth

### DIFF
--- a/src/Phpro/SoapClient/Middleware/BasicAuthMiddleware.php
+++ b/src/Phpro/SoapClient/Middleware/BasicAuthMiddleware.php
@@ -48,7 +48,7 @@ class BasicAuthMiddleware extends Middleware
     public function beforeRequest(callable $handler, RequestInterface $request, array $options)
     {
         $request = $request->withHeader(
-            'Authentication',
+            'Authorization',
             sprintf('Basic %s', base64_encode(
                 sprintf('%s:%s', $this->username, $this->password)
             ))

--- a/test/PhproTest/SoapClient/Unit/Middleware/BasicAuthMiddlewareTest.php
+++ b/test/PhproTest/SoapClient/Unit/Middleware/BasicAuthMiddlewareTest.php
@@ -72,6 +72,6 @@ class BasicAuthMiddlewareTest extends \PHPUnit_Framework_TestCase
         $sentRequest = $this->handler->getLastRequest();
         $this->assertEquals(
             sprintf('Basic %s', base64_encode('username:password')),
-            $sentRequest->getHeader('Authentication')[0]);
+            $sentRequest->getHeader('Authorization')[0]);
     }
 }


### PR DESCRIPTION
HTTP Basic Auth middleware isn't using the correct header name. It should be Authorization.