### PR TITLE
Wsdl provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ $ composer require phpro/soap-client
   - [NtlmMiddleware](docs/middlewares.md#ntlmmiddleware)
   - [WsaMiddleware](docs/middlewares.md#wsamiddleware)
   - [WsseMiddleware](docs/middlewares.md#wssemiddleware)
+- [Select a WSDL Provider](docs/wsdl-providers.md)
 
 
 ## Customize the code generation

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -16,6 +16,7 @@ Next, you can use one of the built-in middlewares:
 - [WsaMiddleware](#wsamiddleware)
 - [WsseMiddleware](#wssemiddleware)
 - [RemoveEmptyNodesMiddleware](#removeemptynodesmiddleware)
+- [Wsdl/DisableExtensionsMiddleware](#wsdldisableextensionsmiddleware)
 
 Can't find the middleware you were looking for?
 [It is always possible to create your own one!](#creating-your-own-middleware)
@@ -120,9 +121,26 @@ $clientBuilder->addMiddleware(new RemoveEmptyNodesMiddleware());
 ```
 
 
+### Wsdl/DisableExtensionsMiddleware
+
+The default SOAP client does not support `wsdl:required` attributes since there is no SOAP extension mechanism in PHP.
+You will retrieve this exception: "[SoapFault] SOAP-ERROR: Parsing WSDL: Unknown required WSDL extension" 
+when the WSDL does contain required SOAP extensions.
+ 
+This middleware can be used to set the "wsdl:required" 
+property to false on the fly so that you don't have to change the WSDL on the server.
+
+**Usage**
+```php
+$wsdlProvier = GuzzleWsdlProvider::create($client);
+$wsdlProvider->addMiddleware(new DisableExtensionsMiddleware());
+$clientBuilder->withWsdlProvider($wsdlProvider);
+```
+
+
 ## Creating your own middleware
 
-Didn't found the middleware you needed? No worries! It is very easy to create your own middleware.
+Didn't find the middleware you needed? No worries! It is very easy to create your own middleware.
 We currently added a thin layer above [Guzzle middlewares](http://docs.guzzlephp.org/en/latest/handlers-and-middleware.html#middleware) 
 to make it easy to modify PSR-7 request and responses.
 

--- a/docs/wsdl-providers.md
+++ b/docs/wsdl-providers.md
@@ -1,0 +1,103 @@
+# Get in control of the WSDL file
+
+The built-in SOAP client does not give you control on how the WSDL is downloaded to the system.
+ Therefor we've created a `WsdlProvider` mechanism that can be customized to your demands.
+
+
+General configuration:
+
+```php
+$clientBuilder = new ClientBuilder($clientFactory, $wsdl, $soapOptions);
+$clientBuilder->withWsdlProvider($provider);
+$client = $clientBuilder->build();
+```
+
+Here is a list of built-in providers:
+
+- [GuzzleWsdlProvider](#guzzlewsdlprovider)
+- [LocalWsdlProvider](#localwsdlprovider)
+- [MixedWsdlProvider](#mixedwsdlprovider)
+
+Can't find the wsdl provider you were looking for?
+[It is always possible to create your own one!](#creating-your-own-wsdl-provider)
+
+## GuzzleWsdlProvider
+
+The guzzle WSDL provider can be used for downloading remote WSDLs.
+It has support for [middlewares](middlewares.md) so that you have full control over the HTTP request and response.
+This way, you will always be able to download and manipulate the WSDL file even if it secured with e.g. NTLM.
+
+**Configuration**
+```php
+$provider = GuzzleWsdlProvider::create($client);
+
+// Optional location:
+$provider->setLocation('/some/destination/file.wsdl');
+
+// Middlewares support:
+$provider->addMiddleware($middleware);
+```
+
+*Note:* If you want to cache the WSDL so that you don't have to download it on every request, you can use the built-in caching options:
+
+```php
+$clientBuilder = new ClientBuilder($clientFactory, $wsdl, [
+    'cache_wsdl' => WSDL_CACHE_BOTH,
+]);
+```
+
+To change the TTL of the cache, you can adjust following `php.ini` setting:
+
+```php
+# See: http://php.net/manual/en/soap.configuration.php
+soap.wsdl_cache_ttl: 86400
+```
+
+
+## LocalWsdlProvider
+
+The local WSDL provider can be used to load a local file.
+It contains an additional check to make sure that the WSDL file exists and throws a `WsdlException` if it does not exist.
+
+**Configuration**
+```php
+$clientBuilder = new ClientBuilder($clientFactory, $wsdl, $soapOptions);
+$clientBuilder->withWsdlProvider(LocalWsdlProvider::create());
+$client = $clientBuilder->build();
+```
+
+
+## MixedWsdlProvider
+
+The mixed WSDL provider is used by default. 
+You can pass every string you would normally pass to the built-in SOAP client's wsdl option.
+No additional checks are executed, the loading of the file will be handled by the internal `SoapClient` class.
+
+**Configuration**
+```php
+$clientBuilder = new ClientBuilder($clientFactory, $wsdl, $soapOptions);
+$clientBuilder->withWsdlProvider(new MixedWsdlProvider());
+$client = $clientBuilder->build();
+```
+
+
+## Creating your own WSDL provider
+
+Didn't find the WSDL provider you needed? No worries! It is very easy to create your own WSDL provider.
+The only thing you'll need to do is implement the WsdlProviderInterface:
+
+
+```php
+class MyWsdlProvider extends \Phpro\SoapClient\Wsdl\Provider\WsdlProviderInterface
+{
+    /**
+     * The result of this method should be the link to the WSDL that can be used by the PHP soap-client.
+     *
+     * {@inheritdoc}
+     */
+    public function provide(string $source)
+    {
+        return $source;
+    }
+}
+```

--- a/spec/Phpro/SoapClient/Exception/WsdlExceptionSpec.php
+++ b/spec/Phpro/SoapClient/Exception/WsdlExceptionSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\Phpro\SoapClient\Exception;
+
+use Phpro\SoapClient\Exception\RuntimeException;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Phpro\SoapClient\Exception\WsdlException;
+
+class WsdlExceptionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(WsdlException::class);
+    }
+
+    function it_should_be_an_exception()
+    {
+        $this->shouldHaveType(RuntimeException::class);
+    }
+}

--- a/spec/Phpro/SoapClient/Wsdl/Provider/GuzzleWsdlProviderSpec.php
+++ b/spec/Phpro/SoapClient/Wsdl/Provider/GuzzleWsdlProviderSpec.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace spec\Phpro\SoapClient\Wsdl\Provider;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Phpro\SoapClient\Exception\WsdlException;
+use Phpro\SoapClient\Middleware\MiddlewareInterface;
+use Phpro\SoapClient\Middleware\MiddlewareSupportingInterface;
+use Phpro\SoapClient\Util\Filesystem;
+use Phpro\SoapClient\Wsdl\Provider\GuzzleWsdlProvider;
+use Phpro\SoapClient\Wsdl\Provider\WsdlProviderInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class GuzzleWsdlProviderSpec extends ObjectBehavior
+{
+    function let(ClientInterface $client, Filesystem $filesystem, HandlerStack $handlerStack)
+    {
+        $this->beConstructedWith($client, $filesystem);
+        $client->getConfig('handler')->willReturn($handlerStack);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(GuzzleWsdlProvider::class);
+    }
+
+    function it_is_a_wsdl_provider()
+    {
+        $this->shouldImplement(WsdlProviderInterface::class);
+    }
+
+    function it_supports_middlewares()
+    {
+        $this->shouldImplement(MiddlewareSupportingInterface::class);
+    }
+
+    function it_can_load_wsdl_from_url(ClientInterface $client, Filesystem $filesystem)
+    {
+        $filesystem->fileExists(Argument::any())->willReturn(true);
+        $client->request('GET', $wsdl = 'some.wsdl')->willReturn(new Response(200, [], $body = 'wsdl'));
+
+        $filesystem->putFileContents(Argument::any(), $body)->shouldBeCalled();
+
+        $this->provide($wsdl)->shouldBeString();
+    }
+
+    function it_can_store_a_wsdl_to_a_specific_location(ClientInterface $client, Filesystem $filesystem)
+    {
+        $destination = 'destination.wsdl';
+        $filesystem->fileExists($destination)->willReturn(true);
+        $client->request('GET', $wsdl = 'some.wsdl')->willReturn(new Response(200, [], $body = 'wsdl'));
+
+        $filesystem->putFileContents($destination, $body)->shouldBeCalled();
+
+        $this->setLocation($destination);
+        $this->provide($wsdl)->shouldBeString();
+    }
+
+    function it_throws_an_exception_if_the_destination_file_does_not_exist(Filesystem $filesystem)
+    {
+        $filesystem->fileExists(Argument::any())->willReturn(false);
+
+        $this->shouldThrow(WsdlException::class)->duringProvide('some.wsdl');
+    }
+
+    function it_throws_an_exception_if_the_remote_file_does_not_exist(ClientInterface $client, Filesystem $filesystem)
+    {
+        $filesystem->fileExists(Argument::any())->willReturn(true);
+        $client->request('GET', $wsdl = 'some.wsdl')->willThrow(new \Exception('invalid request'));
+        $this->shouldThrow(WsdlException::class)->duringProvide('some.wsdl');
+    }
+
+    function it_can_handle_middlewares(ClientInterface $client, Filesystem $filesystem, HandlerStack $handlerStack, MiddlewareInterface $middleware)
+    {
+        $middleware->getName()->willReturn('middleware_name');
+        $handlerStack->push($middleware, 'middleware_name')->shouldBeCalled();
+        $handlerStack->remove($middleware)->shouldBeCalled();
+
+
+        $destination = 'destination.wsdl';
+        $filesystem->fileExists($destination)->willReturn(true);
+        $client->request('GET', $wsdl = 'some.wsdl')->willReturn(new Response(200, [], $body = 'wsdl'));
+
+        $filesystem->putFileContents($destination, $body)->shouldBeCalled();
+
+        $this->addMiddleware($middleware);
+        $this->setLocation($destination);
+        $this->provide($wsdl)->shouldBeString();
+    }
+}

--- a/spec/Phpro/SoapClient/Wsdl/Provider/LocalWsdlProviderSpec.php
+++ b/spec/Phpro/SoapClient/Wsdl/Provider/LocalWsdlProviderSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace spec\Phpro\SoapClient\Wsdl\Provider;
+
+use Phpro\SoapClient\Exception\WsdlException;
+use Phpro\SoapClient\Util\Filesystem;
+use Phpro\SoapClient\Wsdl\Provider\LocalWsdlProvider;
+use Phpro\SoapClient\Wsdl\Provider\WsdlProviderInterface;
+use PhpSpec\ObjectBehavior;
+
+class LocalWsdlProviderSpec extends ObjectBehavior
+{
+    function let(Filesystem $filesystem)
+    {
+        $this->beConstructedWith($filesystem);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(LocalWsdlProvider::class);
+    }
+
+    function it_is_a_wsdl_provider()
+    {
+        $this->shouldImplement(WsdlProviderInterface::class);
+    }
+
+    function it_provides_an_existing_file(Filesystem $filesystem)
+    {
+        $filesystem->fileExists($file = 'some.wsdl')->willReturn(true);
+        $this->provide($file)->shouldBe($file);
+    }
+
+    function it_throws_an_exception_if_a_file_does_not_exist(Filesystem $filesystem)
+    {
+        $filesystem->fileExists($file = 'some.wsdl')->willReturn(false);
+        $this->shouldThrow(WsdlException::class)->duringProvide($file);
+    }
+}

--- a/spec/Phpro/SoapClient/Wsdl/Provider/MixedWsdlProviderSpec.php
+++ b/spec/Phpro/SoapClient/Wsdl/Provider/MixedWsdlProviderSpec.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace spec\Phpro\SoapClient\Wsdl\Provider;
+
+use Phpro\SoapClient\Wsdl\Provider\MixedWsdlProvider;
+use Phpro\SoapClient\Wsdl\Provider\WsdlProviderInterface;
+use PhpSpec\ObjectBehavior;
+
+class MixedWsdlProviderSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MixedWsdlProvider::class);
+    }
+
+    function it_is_a_wsdl_provider()
+    {
+        $this->shouldImplement(WsdlProviderInterface::class);
+    }
+
+    function it_provides_the_source_as_destination()
+    {
+        $this->provide('source')->shouldBe('source');
+    }
+}

--- a/src/Phpro/SoapClient/Exception/WsdlException.php
+++ b/src/Phpro/SoapClient/Exception/WsdlException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Phpro\SoapClient\Exception;
+
+/**
+ * Class WsdlException
+ *
+ * @package Phpro\SoapClient\Exception
+ */
+class WsdlException extends RuntimeException
+{
+    /**
+     * @param $path
+     *
+     * @return WsdlException
+     */
+    public static function notFound($path)
+    {
+        return new self(
+            sprintf('The WSDL could not be loaded from location: %s', $path)
+        );
+    }
+
+    /**
+     * @param \Throwable $exception
+     *
+     * @return WsdlException
+     */
+    public static function fromException(\Throwable $exception)
+    {
+        return new self(
+            $exception->getMessage(),
+            $exception->getCode(),
+            $exception
+        );
+    }
+}

--- a/src/Phpro/SoapClient/Middleware/Wsdl/DisableExtensionsMiddleware.php
+++ b/src/Phpro/SoapClient/Middleware/Wsdl/DisableExtensionsMiddleware.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Phpro\SoapClient\Middleware\Wsdl;
+
+use Phpro\SoapClient\Middleware\Middleware;
+use Phpro\SoapClient\Xml\WsdlXml;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class DisableExtensionsMiddleware
+ *
+ * @package Phpro\SoapClient\Middleware\Wsdl
+ */
+class DisableExtensionsMiddleware extends Middleware
+{
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'wsdl_disable_extensions';
+    }
+
+    /**
+     * @param ResponseInterface $response
+     *
+     * @return ResponseInterface
+     */
+    public function afterResponse(ResponseInterface $response)
+    {
+        $xml = WsdlXml::fromStream($response->getBody());
+
+        /** @var \DOMElement $node */
+        foreach ($xml->xpath('//wsdl:binding//*[@wsdl:required]') as $node) {
+            $node->setAttributeNS($xml->getRootNamespace(), 'wsdl:required', 'false');
+        }
+
+        return $response->withBody($xml->toStream());
+    }
+}

--- a/src/Phpro/SoapClient/Wsdl/Provider/GuzzleWsdlProvider.php
+++ b/src/Phpro/SoapClient/Wsdl/Provider/GuzzleWsdlProvider.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Phpro\SoapClient\Wsdl\Provider;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\HandlerStack;
+use InvalidArgumentException;
+use Phpro\SoapClient\Exception\WsdlException;
+use Phpro\SoapClient\Middleware\MiddlewareInterface;
+use Phpro\SoapClient\Middleware\MiddlewareSupportingInterface;
+use Phpro\SoapClient\Util\Filesystem;
+
+/**
+ * Class LocalWsdlProvider
+ *
+ * @package Phpro\SoapClient\Wsdl\Provider
+ */
+class GuzzleWsdlProvider implements WsdlProviderInterface, MiddlewareSupportingInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var MiddlewareInterface[]
+     */
+    private $middlewares = [];
+
+    /**
+     * @var string
+     */
+    private $location = '';
+
+    /**
+     * GuzzleWsdlProvider constructor.
+     *
+     * @param ClientInterface $client
+     * @param Filesystem      $filesystem
+     */
+    public function __construct(ClientInterface $client, Filesystem $filesystem)
+    {
+        $this->client = $client;
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * @param ClientInterface $client
+     *
+     * @return GuzzleWsdlProvider
+     */
+    public static function createForClient(ClientInterface $client)
+    {
+        return new self($client, new Filesystem());
+    }
+
+    /**
+     * @param MiddlewareInterface $middleware
+     */
+    public function addMiddleware(MiddlewareInterface $middleware)
+    {
+        $this->middlewares[] = $middleware;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocation(): string
+    {
+        return $this->location;
+    }
+
+    /**
+     * @param string $location
+     */
+    public function setLocation(string $location)
+    {
+        $this->location = $location;
+    }
+
+    /**
+     * @param string $source
+     *
+     * @return string
+     * @throws \Phpro\SoapClient\Exception\WsdlException
+     */
+    public function provide(string $source): string
+    {
+        $this->registerMiddlewares();
+        $location = $this->getLocation() ?: tempnam(sys_get_temp_dir(), 'phpro-soap-client-wsdl');
+
+        if (!$this->filesystem->fileExists($location)) {
+            throw WsdlException::notFound($source);
+        }
+
+        try {
+            $response = $this->client->request('GET', $source);
+            $this->filesystem->putFileContents($location, (string) $response->getBody());
+        } catch (\Exception $exception) {
+            throw WsdlException::fromException($exception);
+        }
+
+        $this->unregisterMiddlewares();
+
+        return $location;
+    }
+
+    /**
+     * @return HandlerStack
+     * @throws \Phpro\SoapClient\Exception\InvalidArgumentException
+     */
+    private function fetchHandlerStack(): HandlerStack
+    {
+        $guzzleHandler = $this->client->getConfig('handler');
+        if (!$guzzleHandler instanceof HandlerStack) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Current guzzle client handler "%s" does not support middlewares. Use the HandlerStack instead.',
+                    get_class($guzzleHandler)
+                )
+            );
+        }
+
+        return $guzzleHandler;
+    }
+
+    /**
+     * Register the middlewares before fetching the results.
+     */
+    private function registerMiddlewares()
+    {
+        $handlerStack = $this->fetchHandlerStack();
+        foreach ($this->middlewares as $middleware) {
+            $handlerStack->push($middleware, $middleware->getName());
+        }
+    }
+
+    /**
+     * Unregister the middlewares so that they are only used for fetching the WSDLs
+     */
+    private function unregisterMiddlewares()
+    {
+        $handlerStack = $this->fetchHandlerStack();
+        foreach ($this->middlewares as $middleware) {
+            $handlerStack->remove($middleware);
+        }
+    }
+}

--- a/src/Phpro/SoapClient/Wsdl/Provider/LocalWsdlProvider.php
+++ b/src/Phpro/SoapClient/Wsdl/Provider/LocalWsdlProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Phpro\SoapClient\Wsdl\Provider;
+
+use Phpro\SoapClient\Exception\WsdlException;
+use Phpro\SoapClient\Util\Filesystem;
+
+/**
+ * Class LocalWsdlProvider
+ *
+ * @package Phpro\SoapClient\Wsdl\Provider
+ */
+class LocalWsdlProvider implements WsdlProviderInterface
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * LocalWsdlProvider constructor.
+     *
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    /**
+     * @return LocalWsdlProvider
+     */
+    public static function create()
+    {
+        return new self(new Filesystem());
+    }
+
+    /**
+     * @param string $source
+     *
+     * @return string
+     */
+    public function provide(string $source): string
+    {
+        if (!$this->filesystem->fileExists($source)) {
+            throw WsdlException::notFound($source);
+        }
+
+        return $source;
+    }
+}

--- a/src/Phpro/SoapClient/Wsdl/Provider/MixedWsdlProvider.php
+++ b/src/Phpro/SoapClient/Wsdl/Provider/MixedWsdlProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Phpro\SoapClient\Wsdl\Provider;
+
+/**
+ * Class MixedWsdlProvider
+ *
+ * @package Phpro\SoapClient\Wsdl\Provider
+ */
+class MixedWsdlProvider implements WsdlProviderInterface
+{
+    /**
+     * This provider passes the user input directly as output.
+     * It will let the PHP Soap-client handle errors.
+     *
+     * {@inheritdoc}
+     */
+    public function provide(string $source)
+    {
+        return $source;
+    }
+}

--- a/src/Phpro/SoapClient/Wsdl/Provider/WsdlProviderInterface.php
+++ b/src/Phpro/SoapClient/Wsdl/Provider/WsdlProviderInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Phpro\SoapClient\Wsdl\Provider;
+
+use Phpro\SoapClient\Exception\WsdlException;
+
+/**
+ * Interface WsdlProviderInterface
+ *
+ * @package Phpro\SoapClient\Wsdl\Provider
+ */
+interface WsdlProviderInterface
+{
+    /**
+     * The provider uses a source path and will return a target path that can be used by the soap-client.
+     *
+     * @param string $source
+     *
+     * @return string
+     * @throws WsdlException
+     */
+    public function provide(string $source);
+}

--- a/src/Phpro/SoapClient/Xml/WsdlXml.php
+++ b/src/Phpro/SoapClient/Xml/WsdlXml.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Phpro\SoapClient\Xml;
+
+use DOMDocument;
+
+/**
+ * Class WsdlXml
+ *
+ * @package Phpro\SoapClient\Xml
+ */
+class WsdlXml extends Xml
+{
+    /**
+     * SoapXml constructor.
+     *
+     * @param DOMDocument $xml
+     */
+    public function __construct(DOMDocument $xml)
+    {
+        parent::__construct($xml);
+
+        // Register some default namespaces for easy access:
+        $this->registerNamespace('wsdl', $this->getWsdlNamespaceUri());
+    }
+
+    /**
+     * @return string
+     */
+    public function getWsdlNamespaceUri()
+    {
+        return $this->getRootNamespace();
+    }
+}

--- a/src/Phpro/SoapClient/Xml/Xml.php
+++ b/src/Phpro/SoapClient/Xml/Xml.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Phpro\SoapClient\Xml;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use Psr\Http\Message\StreamInterface;
+use Zend\Diactoros\Stream;
+
+/**
+ * Class Xml
+ *
+ * @package Phpro\SoapClient\Xml
+ */
+class Xml
+{
+    /**
+     * @var DOMDocument
+     */
+    private $xml;
+
+    /**
+     * @var DOMXPath
+     */
+    private $xpath;
+
+    /**
+     * SoapXml constructor.
+     *
+     * @param DOMDocument $xml
+     */
+    public function __construct(DOMDocument $xml)
+    {
+        $this->xml = $xml;
+        $this->xpath = new DOMXPath($xml);
+    }
+
+    /**
+     * @return string
+     */
+    public function getRootNamespace()
+    {
+        return $this->getRootElement()->namespaceURI;
+    }
+
+    /**
+     * @param string $prefix
+     * @param string $namespaceUri
+     */
+    public function registerNamespace(string $prefix, string $namespaceUri)
+    {
+        $this->xpath->registerNamespace($prefix, $namespaceUri);
+    }
+
+    /**
+     * @return DOMDocument
+     */
+    public function getXmlDocument()
+    {
+        return $this->xml;
+    }
+
+    /**
+     * @return DOMElement
+     */
+    public function getRootElement()
+    {
+        return $this->xml->documentElement;
+    }
+
+    /**
+     * @param $expression
+     *
+     * @return \DOMNodeList
+     */
+    public function xpath($expression)
+    {
+        return $this->xpath->query($expression);
+    }
+
+    /**
+     * @param StreamInterface $stream
+     *
+     * @return Xml
+     * @throws \RuntimeException
+     */
+    public static function fromStream(StreamInterface $stream): Xml
+    {
+        $xml = new DOMDocument();
+        $xml->loadXML($stream->getContents());
+
+        return new self($xml);
+    }
+
+    /**
+     * @param string $content
+     *
+     * @return Xml
+     */
+    public static function fromString(string $content): Xml
+    {
+        $xml = new DOMDocument();
+        $xml->loadXML($content);
+
+        return new self($xml);
+    }
+
+    /**
+     * @return StreamInterface
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     */
+    public function toStream(): StreamInterface
+    {
+        $stream = new Stream('php://memory', 'r+');
+        $stream->write($this->toString());
+        $stream->rewind();
+
+        return $stream;
+    }
+
+    /**
+     * @return string
+     */
+    public function toString(): string
+    {
+        return $this->xml->saveXML();
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Middleware/Wsdl/DisableExtensionsMiddlewareTest.php
+++ b/test/PhproTest/SoapClient/Unit/Middleware/Wsdl/DisableExtensionsMiddlewareTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\Middleware\Wsdl;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Phpro\SoapClient\Middleware\MiddlewareInterface;
+use Phpro\SoapClient\Middleware\Wsdl\DisableExtensionsMiddleware;
+use Phpro\SoapClient\Xml\WsdlXml;
+
+/**
+ * Class BasicAuthMiddleware
+ *
+ * @package PhproTest\SoapClient\Unit\Middleware
+ */
+class DisableExtensionsMiddlewareTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var MockHandler
+     */
+    private $handler;
+
+    /**
+     * @var DisableExtensionsMiddleware
+     */
+    private $middleware;
+
+    /***
+     * Initialize all basic objects
+     */
+    protected function setUp()
+    {
+        $this->handler = new MockHandler([]);
+        $this->middleware = new DisableExtensionsMiddleware();
+        $stack = new HandlerStack($this->handler);
+        $stack->push($this->middleware);
+        $this->client = new Client(['handler' => $stack]);
+    }
+
+    /**
+     * @test
+     */
+    function it_is_a_middleware()
+    {
+        $this->assertInstanceOf(MiddlewareInterface::class, $this->middleware);
+    }
+
+    /**
+     * @test
+     */
+    function it_has_a_name()
+    {
+        $this->assertEquals('wsdl_disable_extensions', $this->middleware->getName());
+    }
+
+    /**
+     * @test
+     */
+    function it_removes_required_wsdl_extensions()
+    {
+        $this->handler->append(new Response(
+            200,
+            [],
+            file_get_contents(FIXTURE_DIR . '/wsdl/wsdl-extensions.wsdl'))
+        );
+
+        $response = $this->client->send(new Request('POST', '/'));
+        $xml = WsdlXml::fromStream($response->getBody());
+        $xpath = '//wsdl:binding/wsaw:UsingAddressing[@wsdl:required="%s"]';
+
+        $this->assertEquals(0, $xml->xpath(sprintf($xpath, 'true'))->length, 'Still got required WSDL extensions.');
+        $this->assertEquals(1, $xml->xpath(sprintf($xpath, 'false'))->length, 'Cannot find any deactivated WSDL extensions.');
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Xml/SoapXmlTest.php
+++ b/test/PhproTest/SoapClient/Unit/Xml/SoapXmlTest.php
@@ -3,6 +3,7 @@
 namespace PhproTest\SoapClient\Unit\Xml;
 
 use Phpro\SoapClient\Xml\SoapXml;
+use Phpro\SoapClient\Xml\Xml;
 use Zend\Diactoros\Stream;
 
 /**
@@ -25,6 +26,14 @@ class SoapXmlTest extends \PHPUnit_Framework_TestCase
     {
         $this->xml = new \DOMDocument();
         $this->xml->load(FIXTURE_DIR . '/soap/empty-request-with-head-and-body.xml');
+    }
+
+    /**
+     * @test
+     */
+    function it_extends_the_base_xml_class()
+    {
+        $this->assertInstanceOf(Xml::class, new SoapXml($this->xml));
     }
 
     /**

--- a/test/PhproTest/SoapClient/Unit/Xml/WsdlXmlTest.php
+++ b/test/PhproTest/SoapClient/Unit/Xml/WsdlXmlTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\Xml;
+
+use Phpro\SoapClient\Xml\WsdlXml;
+use Phpro\SoapClient\Xml\Xml;
+use Zend\Diactoros\Stream;
+
+/**
+ * Class WsdlXmlTest
+ *
+ * @package PhproTest\SoapClient\Unit\Xml
+ */
+class WsdlXmlTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var \DOMDocument
+     */
+    private $xml;
+
+    /**
+     * Load basic soap XML on startup
+     */
+    public function setUp()
+    {
+        $this->xml = new \DOMDocument();
+        $this->xml->load(FIXTURE_DIR . '/wsdl/wheater-ws.wsdl');
+    }
+
+    /**
+     * @test
+     */
+    function it_extends_the_base_xml_class()
+    {
+        $this->assertInstanceOf(Xml::class, new WsdlXml($this->xml));
+    }
+
+    /**
+     * @test
+     */
+    function it_knows_the_wsdl_namespace_uri()
+    {
+        $xml = new WsdlXml($this->xml);
+        $this->assertEquals(
+            'http://schemas.xmlsoap.org/wsdl/',
+            $xml->getWsdlNamespaceUri()
+        );
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Xml/XmlTest.php
+++ b/test/PhproTest/SoapClient/Unit/Xml/XmlTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\Xml;
+
+use Phpro\SoapClient\Xml\Xml;
+use Zend\Diactoros\Stream;
+
+/**
+ * Class XmlTest
+ *
+ * @package PhproTest\SoapClient\Unit\Xml
+ */
+class XmlTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var \DOMDocument
+     */
+    private $xml;
+
+    /**
+     * Load basic soap XML on startup
+     */
+    public function setUp()
+    {
+        $this->xml = new \DOMDocument();
+        $this->xml->load(FIXTURE_DIR . '/soap/empty-request-with-head-and-body.xml');
+    }
+
+    /**
+     * @test
+     */
+    function it_knows_the_root_namespace_uri()
+    {
+        $xml = new Xml($this->xml);
+        $this->assertEquals(
+            'http://www.w3.org/2003/05/soap-envelope/',
+            $xml->getRootNamespace()
+        );
+    }
+
+    /**
+     * @test
+     */
+    function it_is_possible_to_register_an_xpath_namespace()
+    {
+        $xml = new Xml($this->xml);
+        $xml->registerNamespace('s', $xml->getRootNamespace());
+        $this->assertEquals(
+            $xml->xpath('/s:Envelope')->item(0),
+            $this->xml->documentElement
+        );
+    }
+
+    /**
+     * @test
+     */
+    function it_is_possible_to_run_xpath_queries()
+    {
+        $xml = new Xml($this->xml);
+        $this->assertEquals(
+            $xml->xpath('/soap:Envelope')->item(0),
+            $this->xml->documentElement
+        );
+    }
+
+    /**
+     * @test
+     */
+    function it_can_access_the_xml_document()
+    {
+        $xml = new Xml($this->xml);
+        $this->assertEquals($this->xml, $xml->getXmlDocument());
+    }
+
+    /**
+     * @test
+     */
+    function it_can_access_the_root_element()
+    {
+        $xml = new Xml($this->xml);
+        $this->assertEquals($this->xml->documentElement, $xml->getRootElement());
+    }
+
+    /**
+     * @test
+     */
+    function it_is_possible_to_create_from_a_psr7_stream()
+    {
+        $rawXml = $this->xml->saveXML();
+        $stream = new Stream('php://memory', 'r+');
+        $stream->write($rawXml);
+        $stream->rewind();
+
+        $xml = Xml::fromStream($stream);
+        $this->assertEquals($rawXml, $xml->getXmlDocument()->saveXML());
+    }
+
+    /**
+     * @test
+     */
+    function it_is_possible_to_create_from_a_string()
+    {
+        $rawXml = $this->xml->saveXML();
+        $xml = Xml::fromString($rawXml);
+        $this->assertEquals($rawXml, $xml->getXmlDocument()->saveXML());
+    }
+
+
+    /**
+     * @test
+     */
+    function it_can_convert_to_a_psr7_stream()
+    {
+        $rawXml = $this->xml->saveXML();
+        $xml = new Xml($this->xml);
+        $stream = $xml->toStream();
+
+        $this->assertEquals($rawXml, (string)$stream);
+    }
+
+    /**
+     * @test
+     */
+    function it_can_convert_to_a_string()
+    {
+        $rawXml = $this->xml->saveXML();
+        $xml = new Xml($this->xml);
+
+        $this->assertEquals($rawXml, $xml->toString());
+    }
+}

--- a/test/fixtures/wsdl/wsdl-extensions.wsdl
+++ b/test/fixtures/wsdl/wsdl-extensions.wsdl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+    xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl">
+    <wsdl:binding name="ExentionsSOAP11Binding">
+        <wsaw:UsingAddressing wsdl:required="true"/>
+    </wsdl:binding>
+</wsdl:definitions>


### PR DESCRIPTION
This PR adds support for WSDL Providers as mentioned in https://github.com/phpro/soap-client/issues/22.
It also contains an additional manipulator to make sure PHP doesn't have to load soap extensions as discussed in https://github.com/phpro/soap-client/issues/20.