### PR TITLE
Feature/move zend code dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,13 @@
     "symfony/event-dispatcher": "~2.8|~3.0",
     "symfony/filesystem": "~2.8|~3.0",
     "symfony/process": "~2.8|~3.0",
-    "zendframework/zend-code": "^3.0.4",
     "zendframework/zend-diactoros": "^1.3"
   },
   "require-dev": {
     "guzzlehttp/guzzle": "^6.2",
     "http-interop/http-factory-guzzle": "0.1.0",
-    "ocramius/proxy-manager": "^2.0.2",
     "ocramius/package-versions": "^1.1.2",
+    "ocramius/proxy-manager": "^2.0.2",
     "php-vcr/php-vcr": "^1.3.2",
     "php-vcr/phpunit-testlistener-vcr": "^2.0",
     "phpro/grumphp": "~0.11",
@@ -34,7 +33,8 @@
     "phpspec/prophecy": "~1.6",
     "phpunit/phpunit": "~5.0",
     "robrichards/wse-php": "^2.0",
-    "squizlabs/php_codesniffer": "~2.7"
+    "squizlabs/php_codesniffer": "~2.7",
+    "zendframework/zend-code": "^3.0.4"
   },
   "suggest": {
     "doctrine/common": "For caching SOAP responses",

--- a/docs/cli/generate-classmap.md
+++ b/docs/cli/generate-classmap.md
@@ -1,8 +1,13 @@
 # Generating class maps
 
+Before you can generate code, you'll need to add some additional dev dependencies to your project:
+```sh
+composer require --dev zendframework/zend-code:^3.0.4
+```
+
 When the value-objects are generated, we need to tell SOAP about how the PHP classes are mapped to the XSD types.
  This is done by a class map, which can be a really boring manual task.
- Luckily a class map generator is added, which you can use to parse the classmap from the WSDL (**Make sure you have the development dependencies installed**).
+ Luckily a class map generator is added, which you can use to parse the classmap from the WSDL.
 
 ```sh
 $ soap-client generate:classmap                                                                                                                                    [16:13:31]

--- a/docs/cli/generate-classmap.md
+++ b/docs/cli/generate-classmap.md
@@ -2,7 +2,7 @@
 
 When the value-objects are generated, we need to tell SOAP about how the PHP classes are mapped to the XSD types.
  This is done by a class map, which can be a really boring manual task.
- Luckily a class map generator is added, which you can use to parse the classmap from the WSDL.
+ Luckily a class map generator is added, which you can use to parse the classmap from the WSDL (**Make sure you have the development dependencies installed**).
 
 ```sh
 $ soap-client generate:classmap                                                                                                                                    [16:13:31]

--- a/docs/cli/generate-types.md
+++ b/docs/cli/generate-types.md
@@ -1,6 +1,6 @@
 # Generating Value-objects
 
-Basic value-objects can be generated automatically.
+Basic value-objects can be generated automatically (**Make sure you have the development dependencies installed**).
 
 ```sh
 $ soap-client generate:types

--- a/docs/cli/generate-types.md
+++ b/docs/cli/generate-types.md
@@ -1,6 +1,11 @@
 # Generating Value-objects
 
-Basic value-objects can be generated automatically (**Make sure you have the development dependencies installed**).
+Before you can generate code, you'll need to add some additional dev dependencies to your project:
+```sh
+composer require --dev zendframework/zend-code:^3.0.4
+```
+
+Basic value-objects can be generated automatically.
 
 ```sh
 $ soap-client generate:types


### PR DESCRIPTION
This PR moves the zend-code dependency to the development dependencies. The zend-code dependency is only needed for development purposes.