### PR TITLE
JsonSerializable Assembler

### DIFF
--- a/docs/code-generation/assemblers.md
+++ b/docs/code-generation/assemblers.md
@@ -13,6 +13,7 @@ to generate the code you want to add to the generated SOAP types.
 - [GetterAssembler](#getterassembler)
 - [InterfaceAssembler](#interfaceassembler)
 - [IteratorAssembler](#iteratorassembler)
+- [JsonSerializableAssembler](#jsonserializableassembler)
 - [PropertyAssembler](#propertyassembler)
 - [RequestAssembler](#requestassembler)
 - [ResultAssembler](#resultassembler)
@@ -129,7 +130,6 @@ class MyType implements Iterator
 }
 ```
 
-
 ## IteratorAssembler
 
 The `IteratorAssembler` can be used for SOAP types that contain a list of another SOAP type.
@@ -155,6 +155,31 @@ class MyType implements IteratorAggregate
 }
 ```
 
+## JsonSerializableAssembler
+
+The `JsonSerializableAssembler` can be used if you want to JSON serialize your SOAP objects. 
+This could be handy for logging JSON serialized request / response data which makes your logs smaller.
+
+Example output:
+
+```php
+use JsonSerializable;
+
+class MyType implements JsonSerializable
+{
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'prop1' => \$this->prop1,
+            'prop2' => \$this->prop2,
+        ];
+    }
+}
+```
 
 ## PropertyAssembler
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/JsonSerializableAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/JsonSerializableAssembler.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Assembler;
+
+use JsonSerializable;
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use Phpro\SoapClient\Exception\AssemblerException;
+use Zend\Code\Generator\ClassGenerator;
+use Zend\Code\Generator\DocBlockGenerator;
+use Zend\Code\Generator\MethodGenerator;
+
+/**
+ * Class JsonSerializableAssembler
+ *
+ * @package Phpro\SoapClient\CodeGenerator\Assembler
+ */
+class JsonSerializableAssembler implements AssemblerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function canAssemble(ContextInterface $context)
+    {
+        return $context instanceof TypeContext;
+    }
+
+    /**
+     * @param ContextInterface|TypeContext $context
+     *
+     * @throws AssemblerException
+     */
+    public function assemble(ContextInterface $context)
+    {
+        try {
+            $interfaceAssembler = new InterfaceAssembler(JsonSerializable::class);
+            if ($interfaceAssembler->canAssemble($context)) {
+                $interfaceAssembler->assemble($context);
+            }
+
+            $this->implementJsonSerialize($context->getType(), $context->getClass());
+        } catch (\Exception $e) {
+            throw AssemblerException::fromException($e);
+        }
+    }
+
+    /**
+     * @param Type $type
+     * @param ClassGenerator $class
+     *
+     * @throws \Zend\Code\Generator\Exception\InvalidArgumentException
+     */
+    private function implementJsonSerialize(Type $type, ClassGenerator $class)
+    {
+        $methodName = 'jsonSerialize';
+        $class->removeMethod($methodName);
+        $class->addMethodFromGenerator(
+            MethodGenerator::fromArray([
+                'name' => $methodName,
+                'parameters' => [],
+                'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
+                'body' => $this->generateJsonSerializeBody($type, $class),
+                'docblock' => DocBlockGenerator::fromArray([
+                    'tags' => [
+                        [
+                            'name' => 'return',
+                            'description' => 'array'
+                        ]
+                    ]
+                ])
+            ])
+        );
+    }
+
+    /**
+     * @param Type $type
+     * @param ClassGenerator $class
+     *
+     * @return string
+     */
+    private function generateJsonSerializeBody(Type $type, ClassGenerator $class): string
+    {
+        $lines = [];
+        $lines[] = 'return [';
+
+        foreach ($type->getProperties() as $property) {
+            $lines[] = sprintf('%1$s\'%2$s\' => $this->%2$s,', $class->getIndentation(), $property->getName());
+        }
+
+        $lines[] = '];';
+
+        return implode($class::LINE_FEED, $lines);
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Assembler;
+
+use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
+use Phpro\SoapClient\CodeGenerator\Assembler\JsonSerializableAssembler;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use Zend\Code\Generator\ClassGenerator;
+
+/**
+ * Class JsonSerializableAssemblerTest
+ *
+ * @package PhproTest\SoapClient\Unit\CodeGenerator\Assembler
+ */
+class JsonSerializableAssemblerTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     */
+    function it_is_an_assembler()
+    {
+        $assembler = new JsonSerializableAssembler();
+        $this->assertInstanceOf(AssemblerInterface::class, $assembler);
+    }
+
+    /**
+     * @test
+     */
+    function it_can_assemble_type_context()
+    {
+        $assembler = new JsonSerializableAssembler();
+        $context = $this->createContext();
+        $this->assertTrue($assembler->canAssemble($context));
+    }
+
+    /**
+     * @test
+     */
+    function it_assembles_a_type()
+    {
+        $assembler = new JsonSerializableAssembler();
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+use JsonSerializable;
+
+class MyType implements JsonSerializable
+{
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'prop1' => \$this->prop1,
+            'prop2' => \$this->prop2,
+        ];
+    }
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @return TypeContext
+     */
+    private function createContext()
+    {
+        $class = new ClassGenerator('MyType', 'MyNamespace');
+        $type = new Type('MyNamespace', 'MyType', [
+            'prop1' => 'array',
+            'prop2' => 'array',
+        ]);
+
+        return new TypeContext($class, $type);
+    }
+}


### PR DESCRIPTION
This new assembler makes it possible to JSON serialize all SOAP types. This could be used to log smaller versions of the request / responses etc.