### PR TITLE
Add validator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Creating a great OO SOAP client means that you'll have to create a lot of code.
 
 It is important keep your code clean. This is why we added an event-listener to your Soap client.
  You can hook in at every important step of the SOAP flow.
- This way it is possible to add logging, caching and error handling with event subscribers. 
+ This way it is possible to add logging, validation, caching and error handling with event subscribers. 
  Pretty cool right?!
 
 Implementing SOAP extensions is a real pain in the ass.
@@ -87,6 +87,7 @@ $ composer require phpro/soap-client
 - [Add type converters.](docs/type-converter.md)
 - [Listen to events.](docs/events.md)
   - [Logger plugin](docs/plugins/logger.md)
+  - [Validator plugin](docs/plugins/validator.md)
   - [Caching plugin](docs/plugins/caching.md)
 - [Specify your data transfer handler.](docs/handlers.md)
   - [SoapHandle](docs/handlers.md#soaphandle)

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "symfony/event-dispatcher": "~2.8|~3.0",
     "symfony/filesystem": "~2.8|~3.0",
     "symfony/process": "~2.8|~3.0",
+    "symfony/validator": "~2.8|~3.0",
     "zendframework/zend-diactoros": "^1.3"
   },
   "require-dev": {

--- a/docs/events.md
+++ b/docs/events.md
@@ -21,5 +21,5 @@ $dispatcher->addSubscriber(new ResponseFailedSubscriber());
 This package ships with some default subscriber plugins:
 
 - [Logger plugin](plugins/logger.md)
+- [Validator plugin](docs/plugins/validator.md)
 - [Caching plugin](plugins/caching.md)
-

--- a/docs/plugins/validator.md
+++ b/docs/plugins/validator.md
@@ -1,0 +1,12 @@
+# Validator plugin
+
+It is possible to use the [Symfony validator component](https://symfony.com/doc/current/components/validator.html)
+to validate your request objects before sending them to the server.
+Since some servers return very cryptographic errors, 
+the validation of request components could save you a lot of time during development.
+
+The validator plugin is activated automatically when you attach a `ValidatorInterface` to the `ClientBuilder`.
+It will hook in to the Request event and will throw a `RequestException`
+when your request object doesn't contain valid data.
+
+No more crappy error messages from the soap server!

--- a/docs/plugins/validator.md
+++ b/docs/plugins/validator.md
@@ -5,7 +5,8 @@ to validate your request objects before sending them to the server.
 Since some servers return very cryptographic errors, 
 the validation of request components could save you a lot of time during development.
 
-The validator plugin is activated automatically when you attach a `ValidatorInterface` to the `ClientBuilder`.
+The validator plugin is activated automatically when you attach a `ValidatorInterface` `
+to the `ClientBuilder::withValidator()`.
 It will hook in to the Request event and will throw a `RequestException`
 when your request object doesn't contain valid data.
 

--- a/spec/Phpro/SoapClient/Plugin/ValidatorPluginSpec.php
+++ b/spec/Phpro/SoapClient/Plugin/ValidatorPluginSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace spec\Phpro\SoapClient\Plugin;
+
+use Phpro\SoapClient\Client;
+use Phpro\SoapClient\Event\RequestEvent;
+use Phpro\SoapClient\Exception\RequestException;
+use Phpro\SoapClient\Type\RequestInterface;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Phpro\SoapClient\Plugin\ValidatorPlugin;
+
+class ValidatorPluginSpec extends ObjectBehavior
+{
+    function let(ValidatorInterface $validator)
+    {
+        $this->beConstructedWith($validator);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ValidatorPlugin::class);
+    }
+
+    function it_should_be_an_event_subscriber()
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+    function it_throws_exception_on_invalid_requests(
+        ValidatorInterface $validator,
+        Client $client,
+        RequestInterface $request,
+        ConstraintViolation $violation
+    ) {
+        $event = new RequestEvent($client->getWrappedObject(), 'method', $request->getWrappedObject());
+        $violation->__toString()->willReturn('error');
+        $validator->validate($request)->willReturn(new ConstraintViolationList([$violation->getWrappedObject()]));
+        $this->shouldThrow(RequestException::class)->duringOnClientRequest($event);
+    }
+
+    function it_does_not_throw_exception_onnvalid_requests(
+        ValidatorInterface $validator,
+        Client $client,
+        RequestInterface $request
+    ) {
+        $event = new RequestEvent($client->getWrappedObject(), 'method', $request->getWrappedObject());
+        $validator->validate($request)->willReturn(new ConstraintViolationList([]));
+        $this->shouldNotThrow(RequestException::class)->duringOnClientRequest($event);
+    }
+}

--- a/src/Phpro/SoapClient/ClientBuilder.php
+++ b/src/Phpro/SoapClient/ClientBuilder.php
@@ -6,6 +6,7 @@ use Phpro\SoapClient\Exception\InvalidArgumentException;
 use Phpro\SoapClient\Middleware\MiddlewareInterface;
 use Phpro\SoapClient\Middleware\MiddlewareSupportingInterface;
 use Phpro\SoapClient\Plugin\LogPlugin;
+use Phpro\SoapClient\Plugin\ValidatorPlugin;
 use Phpro\SoapClient\Soap\ClassMap\ClassMapCollection;
 use Phpro\SoapClient\Soap\ClassMap\ClassMapInterface;
 use Phpro\SoapClient\Soap\Handler\HandlerInterface;
@@ -19,6 +20,7 @@ use Phpro\SoapClient\Wsdl\Provider\WsdlProviderInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Class ClientBuilder
@@ -56,6 +58,11 @@ class ClientBuilder
      * @var LoggerInterface|null
      */
     private $logger;
+
+    /**
+     * @var ValidatorInterface|null
+     */
+    private $validator;
 
     /**
      * @var HandlerInterface|null
@@ -105,6 +112,14 @@ class ClientBuilder
     public function withLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+    }
+
+    /**
+     * @param ValidatorInterface $validator
+     */
+    public function withValidator(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
     }
 
     /**
@@ -204,6 +219,10 @@ class ClientBuilder
 
         if ($this->logger) {
             $this->dispatcher->addSubscriber(new LogPlugin($this->logger));
+        }
+
+        if ($this->validator) {
+            $this->dispatcher->addSubscriber(new ValidatorPlugin($this->validator));
         }
 
         return $this->clientFactory->factory($soapClient, $this->dispatcher);

--- a/src/Phpro/SoapClient/Plugin/ValidatorPlugin.php
+++ b/src/Phpro/SoapClient/Plugin/ValidatorPlugin.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Phpro\SoapClient\Plugin;
+
+use Phpro\SoapClient\Event\RequestEvent;
+use Phpro\SoapClient\Events;
+use Phpro\SoapClient\Exception\RequestException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Class ValidatorPlugin
+ *
+ * @package Phpro\SoapClient\Plugin
+ */
+class ValidatorPlugin implements EventSubscriberInterface
+{
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * Constructor
+     *
+     * @param ValidatorInterface $validator
+     */
+    public function __construct(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    /**
+     * @param RequestEvent $event
+     *
+     * @throws \Phpro\SoapClient\Exception\RequestException
+     */
+    public function onClientRequest(RequestEvent $event)
+    {
+        $errors = $this->validator->validate($event->getRequest());
+
+        if (count($errors)) {
+            throw new RequestException((string) $errors);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::REQUEST  => 'onClientRequest',
+        ];
+    }
+}


### PR DESCRIPTION
It is possible to use the [Symfony validator component](https://symfony.com/doc/current/components/validator.html) to validate your request objects before sending them to the server.
Since some servers return very cryptographic errors, the validation of request components could save you a lot of time during development.

The validator plugin is activated automatically when you attach a `ValidatorInterface` to the `ClientBuilder`. It will hook in to the Request event and will throw a `RequestException` when your request object doesn't contain valid data.

No more crappy error messages from the soap server!
