### PR TITLE
Use late static binding for the named constructors in XML class.

### DIFF
--- a/src/Phpro/SoapClient/Xml/Xml.php
+++ b/src/Phpro/SoapClient/Xml/Xml.php
@@ -90,7 +90,7 @@ class Xml
         $xml = new DOMDocument();
         $xml->loadXML($stream->getContents());
 
-        return new self($xml);
+        return new static($xml);
     }
 
     /**
@@ -103,7 +103,7 @@ class Xml
         $xml = new DOMDocument();
         $xml->loadXML($content);
 
-        return new self($xml);
+        return new static($xml);
     }
 
     /**


### PR DESCRIPTION
This makes sure the named constructors return the correct object when called from a subclass.

Fixes #57