### PR TITLE
Add ExtendAssembler

### DIFF
--- a/docs/code-generation/assemblers.md
+++ b/docs/code-generation/assemblers.md
@@ -8,6 +8,7 @@ to generate the code you want to add to the generated SOAP types.
 
 - [ClassMapAssembler](#classmapassembler)
 - [ConstructorAssembler](#constructorassembler)
+- [ExtendAssembler](#extendassembler)
 - [FinalClassAssembler](#finalclassassembler)
 - [FluentSetterAssembler](#fluentsetterassembler)
 - [GetterAssembler](#getterassembler)
@@ -92,6 +93,21 @@ Example output:
 ```php
 
 final class MyType
+{
+
+
+}
+
+```
+## ExtendAssembler
+
+The `ExtendAssembler` will add a parent class to the generated class.
+
+Example output:
+
+```php
+
+class MyType extends DType
 {
 
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendAssembler.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Assembler;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\Exception\AssemblerException;
+use Zend\Code\Generator\ClassGenerator;
+
+/**
+ * Class ExtendAssembler
+ *
+ * @package Phpro\SoapClient\CodeGenerator\Assembler
+ */
+class ExtendAssembler implements AssemblerInterface
+{
+    /**
+     * @var string
+     */
+    private $extendedClassName;
+
+    /**
+     * ExtendedAssembler constructor.
+     *
+     * @param $extendedClassName
+     */
+    public function __construct($extendedClassName)
+    {
+        $this->extendedClassName = $extendedClassName;
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canAssemble(ContextInterface $context)
+    {
+        return $context instanceof TypeContext;
+    }
+
+    /**
+     * @param ContextInterface|TypeContext $context
+     */
+    public function assemble(ContextInterface $context)
+    {
+        $class = $context->getClass();
+        $extendedClassName = $this->extendedClassName;
+
+        if ($this->isExtendingItself($class)) {
+            return;
+        }
+
+        try {
+            $useAssembler = new UseAssembler($extendedClassName);
+            if ($useAssembler->canAssemble($context)) {
+                $useAssembler->assemble($context);
+            }
+
+            $class->setExtendedClass($extendedClassName);
+
+        } catch (\Exception $e) {
+            throw AssemblerException::fromException($e);
+        }
+    }
+
+    /**
+     * @param ClassGenerator $class
+     * @return bool
+     */
+    private function isExtendingItself(ClassGenerator $class)
+    {
+        $fullClassName = $class->getNamespaceName() . '\\' . $class->getName();
+
+        return $this->extendedClassName === $fullClassName;
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendAssembler.php
@@ -58,7 +58,6 @@ class ExtendAssembler implements AssemblerInterface
             }
 
             $class->setExtendedClass($extendedClassName);
-
         } catch (\Exception $e) {
             throw AssemblerException::fromException($e);
         }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendAssembler.php
@@ -22,9 +22,9 @@ class ExtendAssembler implements AssemblerInterface
     /**
      * ExtendedAssembler constructor.
      *
-     * @param $extendedClassName
+     * @param string $extendedClassName
      */
-    public function __construct($extendedClassName)
+    public function __construct(string $extendedClassName)
     {
         $this->extendedClassName = $extendedClassName;
     }
@@ -67,7 +67,7 @@ class ExtendAssembler implements AssemblerInterface
      * @param ClassGenerator $class
      * @return bool
      */
-    private function isExtendingItself(ClassGenerator $class)
+    private function isExtendingItself(ClassGenerator $class): bool
     {
         $fullClassName = $class->getNamespaceName() . '\\' . $class->getName();
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Assembler;
+
+use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
+use Phpro\SoapClient\CodeGenerator\Assembler\ExtendAssembler;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use Zend\Code\Generator\ClassGenerator;
+
+/**
+ * Class ExtendAssemblerTest
+ *
+ * @package PhproTest\SoapClient\Unit\CodeGenerator\Assembler
+ */
+class ExtendAssemblerTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     */
+    function it_is_an_assembler()
+    {
+        $assembler = new ExtendAssembler(\ArrayIterator::class);
+        $this->assertInstanceOf(AssemblerInterface::class, $assembler);
+    }
+
+    /**
+     * @test
+     */
+    function it_can_assemble_type_context()
+    {
+        $assembler = new ExtendAssembler(\ArrayIterator::class);
+        $context = $this->createContext();
+        $this->assertTrue($assembler->canAssemble($context));
+    }
+
+    /**
+     * @test
+     */
+    function it_assembles_a_type()
+    {
+        $assembler = new ExtendAssembler(\ArrayIterator::class);
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+use ArrayIterator;
+
+class MyType extends ArrayIterator
+{
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @test
+     */
+    function it_assembles_a_type_with_extended_class_name_equal_to_generated_class_name()
+    {
+        $assembler = new ExtendAssembler('MyNamespace\\MyType');
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @return TypeContext
+     */
+    private function createContext()
+    {
+        $class = new ClassGenerator('MyType', 'MyNamespace');
+        $type = new Type('MyNamespace', 'MyType', [
+            'prop1' => 'string',
+            'prop2' => 'int'
+        ]);
+
+        return new TypeContext($class, $type);
+    }
+}


### PR DESCRIPTION
Adds ExtendAssembler which adds `extend` to the generated class.
This was pretty helpful for the API I dealt with where all requests extended `BaseRequest` class.