### PR TITLE
Don't generate use statement for the same namespace

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/UseAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/UseAssembler.php
@@ -7,6 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\AssemblerException;
+use Zend\Code\Generator\ClassGenerator;
 
 /**
  * Class UseAssembler
@@ -51,6 +52,10 @@ class UseAssembler implements AssemblerInterface
     {
         $class = $context->getClass();
 
+        if ($this->usesTheSameNamespace($class)) {
+            return;
+        }
+
         try {
             $uses = $class->getUses();
 
@@ -62,5 +67,14 @@ class UseAssembler implements AssemblerInterface
         } catch (\Exception $e) {
             throw AssemblerException::fromException($e);
         }
+    }
+
+    /**
+     * @param ClassGenerator $class
+     * @return bool
+     */
+    private function usesTheSameNamespace(ClassGenerator $class)
+    {
+        return $this->useName === $class->getNamespaceName();
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/UseAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/UseAssembler.php
@@ -75,6 +75,22 @@ class UseAssembler implements AssemblerInterface
      */
     private function usesTheSameNamespace(ClassGenerator $class)
     {
-        return $this->useName === $class->getNamespaceName();
+        $namespaceName = (string) $class->getNamespaceName();
+
+        if ($this->usesGlobalNamespace($namespaceName)) {
+            return true;
+        }
+
+        return in_array($namespaceName, [$this->useName, $this->getClassUseNamespaceName()]);
+    }
+
+    private function usesGlobalNamespace(string $namespaceName): bool
+    {
+        return '' === $namespaceName && false === strpos($this->useName, '\\');
+    }
+
+    private function getClassUseNamespaceName(): string
+    {
+        return substr($this->useName, 0, strrpos($this->useName, '\\'));
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
@@ -154,6 +154,82 @@ CODE;
     }
 
     /**
+     * @test
+     */
+    function it_does_not_assemble_use_for_the_same_namespace_but_different_class()
+    {
+        $assembler = new UseAssembler('MyNamespace\\SomeOtherClass');
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @test
+     */
+    function it_does_not_assemble_use_for_the_global_namespace()
+    {
+        $assembler = new UseAssembler('SomeOtherClass');
+        $class = new ClassGenerator('MyType');
+        $type = new Type('', 'MyType', []);
+        $context = new TypeContext($class, $type);
+
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+class MyType
+{
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+
+    /**
+     * @test
+     */
+    function it_assembles_use_for_the_different_namespace()
+    {
+        $assembler = new UseAssembler('DifferentNamespace\\SomeOtherClass');
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+use DifferentNamespace\SomeOtherClass;
+
+class MyType
+{
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
      * @return TypeContext
      */
     private function createContext()

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
@@ -130,6 +130,30 @@ CODE;
     }
 
     /**
+     * @test
+     */
+    function it_does_not_assemble_use_for_the_same_namespace()
+    {
+        $assembler = new UseAssembler('MyNamespace');
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
      * @return TypeContext
      */
     private function createContext()


### PR DESCRIPTION
Fixes `UseAssembler` preventing from generating `use` statement for the same namespace as of the current class.