### PR TITLE
Fixes #36

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Config/ConfigSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Config/ConfigSpec.php
@@ -117,7 +117,7 @@ class ConfigSpec extends ObjectBehavior
     public function it_has_a_type_namespace()
     {
         $this->setTypeNamespace($value = 'TypeNamespace');
-        $this->getTypesNamespace()->shouldBe($value);
+        $this->getTypeNamespace()->shouldBe($value);
     }
 
     public function it_has_a_client_namespace()

--- a/spec/Phpro/SoapClient/CodeGenerator/Config/ConfigSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Config/ConfigSpec.php
@@ -31,12 +31,6 @@ class ConfigSpec extends ObjectBehavior
         $this->shouldImplement(ConfigInterface::class);
     }
 
-    function it_has_a_namespace()
-    {
-        $this->setNamespace($value = 'MyNamespace');
-        $this->getNamespace()->shouldReturn($value);
-    }
-
     function it_has_a_wsdl()
     {
         $this->setWsdl($value = 'http://myservice/some.wsdl');
@@ -67,15 +61,9 @@ class ConfigSpec extends ObjectBehavior
         $this->shouldThrow(InvalidArgumentException::class)->duringGetWsdl();
     }
 
-    function it_has_a_destination()
+    function it_requires_a_typedestination()
     {
-        $this->setDestination($value = 'destination/folder');
-        $this->getDestination()->shouldReturn($value);
-    }
-
-    function it_requires_a_destination()
-    {
-        $this->shouldThrow(InvalidArgumentException::class)->duringGetDestination();
+        $this->shouldThrow(InvalidArgumentException::class)->duringGetTypeDestination();
     }
 
     function it_has_a_ruleset()
@@ -88,7 +76,7 @@ class ConfigSpec extends ObjectBehavior
     {
         $this->getSoapOptions()->shouldBe(
             [
-                'trace'      => false,
+                'trace' => false,
                 'exceptions' => true,
                 'keep_alive' => true,
                 'cache_wsdl' => WSDL_CACHE_NONE,
@@ -124,5 +112,16 @@ class ConfigSpec extends ObjectBehavior
     {
         $this->setClientNamespace($value = 'ClientNamespace');
         $this->getClientNamespace()->shouldBe($value);
+    }
+
+    public function it_requires_a_client_namespace()
+    {
+        $this->shouldThrow(InvalidArgumentException::class)->duringGetClientNamespace();
+    }
+
+    public function it_has_a_client_name()
+    {
+        $this->setClientName($value = 'ClientName');
+        $this->getClientName()->shouldBe($value);
     }
 }

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/PropertySpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/PropertySpec.php
@@ -16,7 +16,7 @@ class PropertySpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('name', 'type');
+        $this->beConstructedWith('name', 'Type', 'My\Namespace');
     }
 
     function it_is_initializable()
@@ -31,7 +31,7 @@ class PropertySpec extends ObjectBehavior
 
     function it_has_a_type()
     {
-        $this->getType()->shouldReturn('type');
+        $this->getType()->shouldReturn('\\My\\Namespace\\Type');
     }
 
     function it_has_a_getter_name()

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/PropertynameMatchesRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/PropertynameMatchesRuleSpec.php
@@ -43,21 +43,21 @@ class PropertynameMatchesRuleSpec extends ObjectBehavior
 
     function it_can_apply_to_property_context( RuleInterface $subRule, PropertyContext $context)
     {
-        $context->getProperty()->willReturn(new Property('MyProperty', 'string'));
+        $context->getProperty()->willReturn(new Property('MyProperty', 'string', 'ns1'));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_not_apply_on_invalid_regex(RuleInterface $subRule, PropertyContext $context)
     {
-        $context->getProperty()->willReturn(new Property('InvalidTypeName', 'string'));
+        $context->getProperty()->willReturn(new Property('InvalidTypeName', 'string', 'ns1'));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
     function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, PropertyContext $context)
     {
-        $context->getProperty()->willReturn(new Property('MyProperty', 'string'));
+        $context->getProperty()->willReturn(new Property('MyProperty', 'string', 'ns1'));
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
@@ -80,7 +80,7 @@ class Config implements ConfigInterface
     public function __construct(string $wsdl = '', string $destination = '')
     {
         $this->setWsdl($wsdl);
-        $this->setDestination($destination);
+        $this->setTypeDestination($destination);
         $this->ruleSet = new RuleSet([
             new Rules\AssembleRule(new Assembler\PropertyAssembler()),
             new Rules\AssembleRule(new Assembler\ClassMapAssembler()),
@@ -99,31 +99,8 @@ class Config implements ConfigInterface
 
     /**
      * @return string
-     * @throws InvalidArgumentException
-     * @deprecated use getTypeNamespace or getClientNamespace instead
      */
-    public function getNamespace(): string
-    {
-        return $this->typeNamespace;
-    }
-
-    /**
-     * @param string $namespace
-     *
-     * @return Config
-     * @deprecated use setTypeNamespace of setClientNamespace instead
-     */
-    public function setNamespace(string $namespace): self
-    {
-        $this->typeNamespace = Normalizer::normalizeNamespace($namespace);
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTypeNamespace()
+    public function getTypeNamespace(): string
     {
         return $this->typeNamespace;
     }
@@ -133,7 +110,7 @@ class Config implements ConfigInterface
      *
      * @return Config
      */
-    public function setTypeNamespace($namespace)
+    public function setTypeNamespace($namespace): self
     {
         $this->typeNamespace = Normalizer::normalizeNamespace($namespace);
 
@@ -200,33 +177,6 @@ class Config implements ConfigInterface
     public function setSoapOptions(array $soapOptions)
     {
         $this->soapOptions = $soapOptions;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     * @throws InvalidArgumentException
-     * @deprecated
-     */
-    public function getDestination(): string
-    {
-        if (!$this->typeDestination) {
-            throw InvalidArgumentException::destinationConfigurationIsMissing();
-        }
-
-        return $this->typeDestination;
-    }
-
-    /**
-     * @param string $destination
-     *
-     * @return Config
-     * @deprecated
-     */
-    public function setDestination(string $destination): self
-    {
-        $this->typeDestination = rtrim($destination, '/\\');
 
         return $this;
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
@@ -29,7 +29,7 @@ class Config implements ConfigInterface
     /**
      * @var string
      */
-    protected $typesNamespace = '';
+    protected $typeNamespace = '';
 
     /**
      * @var
@@ -104,7 +104,7 @@ class Config implements ConfigInterface
      */
     public function getNamespace(): string
     {
-        return $this->typesNamespace;
+        return $this->typeNamespace;
     }
 
     /**
@@ -115,7 +115,7 @@ class Config implements ConfigInterface
      */
     public function setNamespace(string $namespace): self
     {
-        $this->typesNamespace = Normalizer::normalizeNamespace($namespace);
+        $this->typeNamespace = Normalizer::normalizeNamespace($namespace);
 
         return $this;
     }
@@ -123,9 +123,9 @@ class Config implements ConfigInterface
     /**
      * @return string
      */
-    public function getTypesNamespace()
+    public function getTypeNamespace()
     {
-        return $this->typesNamespace;
+        return $this->typeNamespace;
     }
 
     /**
@@ -135,7 +135,7 @@ class Config implements ConfigInterface
      */
     public function setTypeNamespace($namespace)
     {
-        $this->typesNamespace = Normalizer::normalizeNamespace($namespace);
+        $this->typeNamespace = Normalizer::normalizeNamespace($namespace);
 
         return $this;
     }
@@ -303,18 +303,6 @@ class Config implements ConfigInterface
         $this->clientNamespace = $clientNamespace;
 
         return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTypeNamespace()
-    {
-        if (!$this->typesNamespace) {
-            throw InvalidArgumentException::typeNamespaceIsMissing();
-        }
-
-        return $this->typesNamespace;
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Config/ConfigInterface.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/ConfigInterface.php
@@ -14,12 +14,6 @@ interface ConfigInterface
 {
     /**
      * @return string
-     * @deprecated use getClientNamespace or getTypeNamespace instead
-     */
-    public function getNamespace(): string;
-
-    /**
-     * @return string
      */
     public function getWsdl(): string;
 
@@ -27,12 +21,6 @@ interface ConfigInterface
      * array
      */
     public function getSoapOptions(): array;
-
-    /**
-     * @return string
-     * @deprecated Use getTypeDestination or getClientDestination instead
-     */
-    public function getDestination(): string;
 
     /**
      * @return string

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -33,7 +33,7 @@ class Property
      * @param string $type
      * @param string $namespace
      */
-    public function __construct(string $name, string $type, string $namespace = '')
+    public function __construct(string $name, string $type, string $namespace)
     {
         $this->name = Normalizer::normalizeProperty($name);
         $this->type = Normalizer::normalizeDataType($type);

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -22,15 +22,22 @@ class Property
     private $type;
 
     /**
+     * @var string
+     */
+    private $namespace;
+
+    /**
      * Property constructor.
      *
      * @param string $name
      * @param string $type
+     * @param string $namespace
      */
-    public function __construct(string $name, string $type)
+    public function __construct(string $name, string $type, string $namespace = '')
     {
         $this->name = Normalizer::normalizeProperty($name);
         $this->type = Normalizer::normalizeDataType($type);
+        $this->namespace = Normalizer::normalizeNamespace($namespace);
     }
 
     /**
@@ -46,7 +53,11 @@ class Property
      */
     public function getType(): string
     {
-        return $this->type;
+        if (Normalizer::isKnownType($this->type)) {
+            return $this->type;
+        }
+
+        return '\\'.$this->namespace.'\\'.$this->type;
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
@@ -48,7 +48,7 @@ class Type
         $this->name = Normalizer::normalizeClassname($xsdName);
 
         foreach ($properties as $property => $type) {
-            $this->properties[] = new Property($property, $type);
+            $this->properties[] = new Property($property, $type, $this->namespace);
         }
     }
 

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -10,6 +10,21 @@ namespace Phpro\SoapClient\CodeGenerator\Util;
 class Normalizer
 {
 
+    private static $normalizations = [
+        'long'     => 'int',
+        'short'    => 'int',
+        'datetime' => '\\DateTime',
+        'date'     => '\\DateTime',
+        'boolean'  => 'bool',
+        'decimal'  => 'float',
+        'double'   => 'float',
+        'string'   => 'string',
+        'self'     => 'self',
+        'callable' => 'callable',
+        'iterable' => 'iterable',
+        'array'    => 'array',
+    ];
+
     /**
      * @param string $namespace
      *
@@ -47,19 +62,14 @@ class Normalizer
      */
     public static function normalizeDataType(string $type): string
     {
-        $normalizations = [
-            'long'     => 'int',
-            'short'    => 'int',
-            'datetime' => '\\DateTime',
-            'date'     => '\\DateTime',
-            'boolean'  => 'bool',
-            'decimal'  => 'float',
-            'double'   => 'float',
-        ];
-
         $searchType = strtolower($type);
 
-        return array_key_exists($searchType, $normalizations) ? $normalizations[$searchType] : $type;
+        return array_key_exists($searchType, self::$normalizations) ? self::$normalizations[$searchType] : $type;
+    }
+
+    public static function isKnownType(string $type): bool
+    {
+        return \in_array($type, self::$normalizations, true);
     }
 
     /**
@@ -70,7 +80,7 @@ class Normalizer
      */
     public static function generatePropertyMethod(string $prefix, string $property): string
     {
-        return strtolower($prefix) . ucfirst(self::normalizeProperty($property));
+        return strtolower($prefix).ucfirst(self::normalizeProperty($property));
     }
 
     /**
@@ -95,7 +105,7 @@ class Normalizer
     {
         $use = $useName;
         if (!empty($useAlias)) {
-            $use .= ' as ' . $useAlias;
+            $use .= ' as '.$useAlias;
         }
 
         return $use;

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
@@ -91,7 +91,7 @@ class GenerateClientCommand extends Command
         }
 
         $soapClient = new SoapClient($config->getWsdl(), $config->getSoapOptions());
-        $methodMap = ClientMethodMap::fromSoapClient($soapClient, $config->getTypesNamespace());
+        $methodMap = ClientMethodMap::fromSoapClient($soapClient, $config->getTypeNamespace());
         $client = new Client($config->getClientName(), $config->getClientNamespace(), $methodMap);
         $generator = new ClientGenerator($config->getRuleSet());
         $fileGenerator = new FileGenerator();

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -164,7 +164,7 @@ CODE;
         $type = new Type('MyNamespace', 'MyType', [
             'prop1' => 'string',
         ]);
-        $property = new Property('prop1', 'string');
+        $property = new Property('prop1', 'string', 'ns1');
 
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -101,7 +101,7 @@ class MyType
 {
 
     /**
-     * @param foobar \$prop1
+     * @param \\MyNamespace\\foobar \$prop1
      * @return \$this
      */
     public function setProp1(\$prop1)
@@ -138,7 +138,7 @@ class MyType
 {
 
     /**
-     * @param foobar \$prop1
+     * @param \MyNamespace\\foobar \$prop1
      * @return \$this
      */
     public function setProp1(\$prop1) : \MyNamespace\MyType
@@ -178,7 +178,7 @@ CODE;
         $type = new Type('MyNamespace', 'MyType', [
             'prop1' => 'foobar',
         ]);
-        $property = new Property('prop1', 'foobar');
+        $property = new Property('prop1', 'foobar', 'MyNamespace');
 
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -167,7 +167,7 @@ CODE;
 
         $class = new ClassGenerator('MyType', 'MyNamespace');
         $type = new Type('MyNamespace', 'MyType', $properties);
-        $property = new Property($propertyName, $properties[$propertyName]);
+        $property = new Property($propertyName, $properties[$propertyName], 'ns1');
 
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
@@ -82,7 +82,7 @@ CODE;
         $type = new Type('MyNamespace', 'MyType', [
             'prop1' => 'string'
         ]);
-        $property = new Property('prop1', 'string');
+        $property = new Property('prop1', 'string', 'ns1');
 
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
@@ -46,7 +46,7 @@ class InterfaceAssemblerTest extends TestCase
         $assembler = new InterfaceAssembler('MyUsedClass');
         $class = new ClassGenerator('MyType', 'MyNamespace');
         $type = new Type('MyNamespace', 'MyType', []);
-        $property = new Property('prop1', 'string');
+        $property = new Property('prop1', 'string', 'ns1');
         $context = new PropertyContext($class, $type, $property);
         $this->assertTrue($assembler->canAssemble($context));
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
@@ -175,7 +175,7 @@ CODE;
             'prop1' => 'string',
             'prop2' => 'int',
         ]);
-        $property = new Property('prop1', 'string');
+        $property = new Property('prop1', 'string', 'ns1');
 
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
@@ -56,7 +56,7 @@ class MyType implements ResultProviderInterface
 {
 
     /**
-     * @return SomeClass|ResultInterface
+     * @return \MyNamespace\SomeClass|ResultInterface
      */
     public function getResult()
     {

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
@@ -80,7 +80,7 @@ CODE;
             'prop1' => 'string',
             'prop2' => 'int'
         ]);
-        $property = new Property('prop1', 'string');
+        $property = new Property('prop1', 'string', 'ns1');
 
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
@@ -46,7 +46,7 @@ class UseAssemblerTest extends TestCase
         $assembler = new UseAssembler('MyUsedClass');
         $class = new ClassGenerator('MyType', 'MyNamespace');
         $type = new Type('MyNamespace', 'MyType', []);
-        $property = new Property('prop1', 'string');
+        $property = new Property('prop1', 'string', 'ns1');
         $context = new PropertyContext($class, $type, $property);
         $this->assertTrue($assembler->canAssemble($context));
     }


### PR DESCRIPTION
Return types were not yet enabled for getters in the types.
This PR fixes that.

There also was a a double method for the typeNamespace, this has been normalized to a single function that is in line with the others.