### PR TITLE
Add option to override default converters - fix #106

### DIFF
--- a/spec/Phpro/SoapClient/ClientBuilderSpec.php
+++ b/spec/Phpro/SoapClient/ClientBuilderSpec.php
@@ -5,6 +5,14 @@ namespace spec\Phpro\SoapClient;
 use Phpro\SoapClient\Client;
 use Phpro\SoapClient\ClientBuilder;
 use Phpro\SoapClient\ClientFactory;
+use Phpro\SoapClient\Soap\ClassMap\ClassMapCollection;
+use Phpro\SoapClient\Soap\SoapClientFactory;
+use Phpro\SoapClient\Soap\TypeConverter\DateTimeTypeConverter;
+use Phpro\SoapClient\Soap\TypeConverter\DateTypeConverter;
+use Phpro\SoapClient\Soap\TypeConverter\DecimalTypeConverter;
+use Phpro\SoapClient\Soap\TypeConverter\DoubleTypeConverter;
+use Phpro\SoapClient\Soap\TypeConverter\TypeConverterCollection;
+use Phpro\SoapClient\Soap\TypeConverter\TypeConverterInterface;
 use PhpSpec\ObjectBehavior;
 
 class ClientBuilderSpec extends ObjectBehavior
@@ -22,6 +30,43 @@ class ClientBuilderSpec extends ObjectBehavior
 
     function it_should_load_a_new_client()
     {
+        $this->build()->shouldBeAnInstanceOf(Client::class);
+    }
+
+    function it_should_add_default_converters_to_client()
+    {
+        $this->createSoapClientFactory()->shouldBeLike(
+            new SoapClientFactory(new ClassMapCollection(), new TypeConverterCollection([
+                new DateTimeTypeConverter(),
+                new DateTypeConverter(),
+                new DecimalTypeConverter(),
+                new DoubleTypeConverter()
+            ])));
+
+        $this->build()->shouldBeAnInstanceOf(Client::class);
+    }
+
+    function it_should_has_option_to_override_default_converters(
+        DateTimeTypeConverter $myDateTimeTypeConverter
+    ) {
+        $myDateTimeTypeConverter
+            ->getTypeNamespace()
+            ->willReturn('http://www.w3.org/2001/XMLSchema');
+        $myDateTimeTypeConverter
+            ->getTypeName()
+            ->willReturn('dateTime');
+
+        $this->shouldNotThrow(\InvalidArgumentException::class);
+        $this->addTypeConverter($myDateTimeTypeConverter);
+
+        $this->createSoapClientFactory()->shouldBeLike(
+            new SoapClientFactory(new ClassMapCollection(), new TypeConverterCollection([
+                $myDateTimeTypeConverter->getWrappedObject(),
+                new DateTypeConverter(),
+                new DecimalTypeConverter(),
+                new DoubleTypeConverter()
+            ])));
+
         $this->build()->shouldBeAnInstanceOf(Client::class);
     }
 }

--- a/spec/Phpro/SoapClient/ClientBuilderSpec.php
+++ b/spec/Phpro/SoapClient/ClientBuilderSpec.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace spec\Phpro\SoapClient;
+
+use Phpro\SoapClient\Client;
+use Phpro\SoapClient\ClientBuilder;
+use Phpro\SoapClient\ClientFactory;
+use PhpSpec\ObjectBehavior;
+
+class ClientBuilderSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $wsdl = realpath(__DIR__ . '/../../../test/fixtures/wsdl/wheater-ws.wsdl');
+        $this->beConstructedWith(new ClientFactory(Client::class), $wsdl, []);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ClientBuilder::class);
+    }
+
+    function it_should_load_a_new_client()
+    {
+        $this->build()->shouldBeAnInstanceOf(Client::class);
+    }
+}


### PR DESCRIPTION
Hi,
this fixes #106.

To make this works first we move adding default converters at the end of building instead on construction but before we call factory on SoapClientFactory.
Therefore it makes possible to attach custom converters to replace built-in defaults.