### PR TITLE
Add ClientMethodMatchesRule

### DIFF
--- a/docs/code-generation/rules.md
+++ b/docs/code-generation/rules.md
@@ -11,6 +11,7 @@ The goal of a rule is to run a code assembler.
 # Built-in rules
 
 - [AssemblerRule](#assemblerrule)
+- [ClientMethodMatchesRule](#clientmethodmatchesrule)
 - [MultiRule](#multirule)
 - [PopertynameMatchesRule](#propertynamematchesrule)
 - [TypeMapRule](#TypeMapRule)
@@ -29,6 +30,26 @@ The `AssemblerRule` will always apply an assembler in the right context.
 This way, the code is added during every code generation command.
 
 In the example above, a getter will be created for every property in the SOAP type.
+
+## ClientMethodMatchesRule
+
+```php
+use My\Project\CodeGenerator\Assembler as CustomAssembler;
+use Phpro\SoapClient\CodeGenerator\Assembler;
+use Phpro\SoapClient\CodeGenerator\Rules;
+
+new Rules\ClientMethodMatchesRule(
+    new Rules\AssembleRule(new CustomAssembler\RemoveClientMethodAssembler()),
+    '/demoSetup$/'
+)
+```
+
+The `ClientMethodMatchesRule` can be used in the types generation command and contains a subRule and a regular expression.
+The subRule is mostly a regular AssembleRule, but can be any class that implements the RuleInterface.
+The regular expression will be matched against the method name added to the generated Client. 
+If the regular expression matches and the subRule is accepted, the defined assembler will run.
+ 
+In the example above, a custom `RemoveClientMethodAssembler` is is used to remove the `demoSetup` method from the Client completely.
 
 ## MultiRule
 

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRuleSpec.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
+use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
+use Phpro\SoapClient\CodeGenerator\Rules\ClientMethodMatchesRule;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * Class ClientMethodMatchesRuleSpec
+ *
+ * @package spec\Phpro\SoapClient\CodeGenerator\Rules
+ * @mixin ClientMethodMatchesRule
+ */
+class ClientMethodMatchesRuleSpec extends ObjectBehavior
+{
+
+    function let(RuleInterface $subRule)
+    {
+        $this->beConstructedWith($subRule, '/^myClientMethod$/');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ClientMethodMatchesRule::class);
+    }
+
+    function it_is_a_rule()
+    {
+        $this->shouldImplement(RuleInterface::class);
+    }
+
+    function it_can_not_apply_to_regular_context(ContextInterface $context)
+    {
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_apply_to_client_method_context(RuleInterface $subRule, ClientMethodContext $context)
+    {
+        $context->getMethod()->willReturn(new ClientMethod('myClientMethod', [], 'string'));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(true);
+    }
+
+    function it_can_not_apply_on_unmatched_regex(RuleInterface $subRule, ClientMethodContext $context)
+    {
+        $context->getMethod()->willReturn(new ClientMethod('myInvalidClientMethod', [], 'string'));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_not_apply_if_subrule_does_not_apply(RuleInterface $subRule, ClientMethodContext $context)
+    {
+        $context->getMethod()->willReturn(new ClientMethod('myClientMethod', [], 'string'));
+        $subRule->appliesToContext($context)->willReturn(false);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_applies_subrule_when_applied(RuleInterface $subRule, ContextInterface $context)
+    {
+        $subRule->apply($context)->shouldBeCalled();
+        $this->apply($context);
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRule.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
+
+/**
+ * Class ClientMethodMatchesRule
+ *
+ * @package Phpro\SoapClient\CodeGenerator\Rules
+ */
+class ClientMethodMatchesRule implements RuleInterface
+{
+    /**
+     * @var RuleInterface
+     */
+    private $subRule;
+
+    /**
+     * @var string
+     */
+    private $regex;
+
+    /**
+     * TypenameMatchingAssembleRule constructor.
+     *
+     * @param RuleInterface $subRule
+     * @param string        $regex
+     */
+    public function __construct(RuleInterface $subRule, string $regex)
+    {
+        $this->subRule = $subRule;
+        $this->regex = $regex;
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function appliesToContext(ContextInterface $context): bool
+    {
+        if (!$context instanceof ClientMethodContext) {
+            return false;
+        }
+
+        $method = $context->getMethod();
+        if (!preg_match($this->regex, $method->getMethodName())) {
+            return false;
+        }
+
+        return $this->subRule->appliesToContext($context);
+    }
+
+    /**
+     * @param ContextInterface $context
+     */
+    public function apply(ContextInterface $context)
+    {
+        $this->subRule->apply($context);
+    }
+}


### PR DESCRIPTION
Allows the code generation config to use regex patterns to run certain assemblers against matching methods added to generated Client.

See #118.