### PR TITLE
Client Generation: Add DocBlocks to methods

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
@@ -7,6 +7,10 @@ use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 use Phpro\SoapClient\CodeGenerator\Model\Parameter;
 use Phpro\SoapClient\Exception\AssemblerException;
+use Phpro\SoapClient\Exception\SoapException;
+use Phpro\SoapClient\Type\RequestInterface;
+use Phpro\SoapClient\Type\ResultInterface;
+use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\MethodGenerator;
 
 /**
@@ -52,6 +56,27 @@ class ClientMethodAssembler implements AssemblerInterface
                         ),
                         // TODO: Use normalizer once https://github.com/phpro/soap-client/pull/61 is merged
                         'returntype' => '\\'.$method->getParameterNamespace().'\\'.$method->getReturnType(),
+                        'docblock' => DocBlockGenerator::fromArray([
+                            'tags' => [
+                                [
+                                    'name' => 'param',
+                                    'description' => sprintf(
+                                        '\%s|\%s $%s',
+                                        RequestInterface::class,
+                                        $param->getType(),
+                                        $param->getName()
+                                    ),
+                                ],
+                                [
+                                    'name' => 'return',
+                                    'description' => '\\' . ResultInterface::class,
+                                ],
+                                [
+                                    'name' => 'throws',
+                                    'description' => '\\' . SoapException::class,
+                                ],
+                            ]
+                        ])->setWordWrap(false),
                     ]
                 )
             );

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
@@ -64,7 +64,7 @@ class ClientMethodAssembler implements AssemblerInterface
                                     'description' => sprintf(
                                         '%s|%s $%s',
                                         $this->generateShortClassNameAndAddImport(RequestInterface::class, $class),
-                                        $this->generateShortClassNameAndAddImport($param->getType(), $class),
+                                        $this->getPrefixedClassNameAndAddImport($param->getType(), $class),
                                         $param->getName()
                                     ),
                                 ],
@@ -73,7 +73,7 @@ class ClientMethodAssembler implements AssemblerInterface
                                     'description' => sprintf(
                                         '%s|%s',
                                         $this->generateShortClassNameAndAddImport(ResultInterface::class, $class),
-                                        $this->generateShortClassNameAndAddImport(
+                                        $this->getPrefixedClassNameAndAddImport(
                                             $method->getParameterNamespace().'\\'.$method->getReturnType(),
                                             $class
                                         )
@@ -115,6 +115,29 @@ class ClientMethodAssembler implements AssemblerInterface
 
         if ($classNamespace !== $currentNamespace || ! in_array($fqnClassName, $classGenerator->getUses())) {
             $classGenerator->addUse($fqnClassName);
+        }
+
+        return $className;
+    }
+
+    /**
+     * @param string         $fqnClassName   Fully qualified class name.
+     * @param ClassGenerator $classGenerator Class generator object.
+     *
+     * @return string
+     */
+    protected function getPrefixedClassNameAndAddImport(string $fqnClassName, ClassGenerator $classGenerator): string
+    {
+        $fqnClassName = ltrim($fqnClassName, '\\');
+        $parts = explode('\\', $fqnClassName);
+        $className = array_pop($parts);
+        $prefix = array_pop($parts);
+        $className = $prefix . '\\' . $className;
+        $classNamespace = implode('\\', $parts) . '\\' . $prefix;
+        $currentNamespace = (string) $classGenerator->getNamespaceName();
+
+        if ($classNamespace !== $currentNamespace || ! in_array($fqnClassName, $classGenerator->getUses())) {
+            $classGenerator->addUse(ltrim($classNamespace, '\\'));
         }
 
         return $className;

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -66,6 +66,11 @@ namespace MyNamespace;
 class  extends \Phpro\SoapClient\Client
 {
 
+    /**
+     * @param \Phpro\SoapClient\Type\RequestInterface|\MyTypeNamespace\ParamType \$ParamType
+     * @return \Phpro\SoapClient\Type\ResultInterface
+     * @throws \Phpro\SoapClient\Exception\SoapException
+     */
     public function functionName(\MyTypeNamespace\ParamType \$ParamType) : \MyTypeNamespace\ReturnType
     {
         return \$this->call('ParamType', \$ParamType);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -64,17 +64,16 @@ class ClientMethodAssemblerTest extends TestCase
 namespace MyNamespace;
 
 use Phpro\SoapClient\Type\RequestInterface;
-use MyTypeNamespace\ParamType;
 use Phpro\SoapClient\Type\ResultInterface;
-use MyTypeNamespace\ReturnType;
+use MyTypeNamespace;
 use Phpro\SoapClient\Exception\SoapException;
 
 class  extends \Phpro\SoapClient\Client
 {
 
     /**
-     * @param RequestInterface|ParamType \$ParamType
-     * @return ResultInterface|ReturnType
+     * @param RequestInterface|MyTypeNamespace\ParamType \$ParamType
+     * @return ResultInterface|MyTypeNamespace\ReturnType
      * @throws SoapException
      */
     public function functionName(\MyTypeNamespace\ParamType \$ParamType) : \MyTypeNamespace\ReturnType

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -63,13 +63,19 @@ class ClientMethodAssemblerTest extends TestCase
         $expected = <<<CODE
 namespace MyNamespace;
 
+use Phpro\SoapClient\Type\RequestInterface;
+use MyTypeNamespace\ParamType;
+use Phpro\SoapClient\Type\ResultInterface;
+use MyTypeNamespace\ReturnType;
+use Phpro\SoapClient\Exception\SoapException;
+
 class  extends \Phpro\SoapClient\Client
 {
 
     /**
-     * @param \Phpro\SoapClient\Type\RequestInterface|\MyTypeNamespace\ParamType \$ParamType
-     * @return \Phpro\SoapClient\Type\ResultInterface
-     * @throws \Phpro\SoapClient\Exception\SoapException
+     * @param RequestInterface|ParamType \$ParamType
+     * @return ResultInterface|ReturnType
+     * @throws SoapException
      */
     public function functionName(\MyTypeNamespace\ParamType \$ParamType) : \MyTypeNamespace\ReturnType
     {


### PR DESCRIPTION
First pass. 

Note that the documented return type, and the return type declarations are not currently the same, as it's possible that the return type may be wrong (#121).

WordWrap is disabled, otherwise the FQN of the classes results in tags that are invalid (or at least not recognised by PhpStorm):

```php
/**
 * @param
 * \Phpro\SoapClient\Type\RequestInterface|\GAA\CorpManagerApi\SoapTypes\IsBlocked $IsBlocked
```

Results in client methods like:

![screenshot 2017-12-30 14 53 06](https://user-images.githubusercontent.com/88371/34455176-2ad81b08-ed71-11e7-9aa9-c472a15ae9a8.png)



See #117 

