### PR TITLE
Binary can't find autoload.php

### DIFF
--- a/bin/soap-client
+++ b/bin/soap-client
@@ -1,19 +1,19 @@
 #!/usr/bin/env php
 <?php
 
-define('SOAP_PATH', realpath(__DIR__ . '/..'));
-
-if (is_file($autoload = getcwd() . '/vendor/autoload.php')) {
-    require $autoload;
-} elseif (is_file($autoload = getcwd() . '/../../autoload.php')) {
-    require $autoload;
+for($i=4; $i>=0; --$i) {
+    $autoloadFiles[] = str_pad('/vendor/autoload.php', 20 + ($i * 3), '/..', STR_PAD_LEFT);
 }
 
-if (is_file($autoload = __DIR__ . '/../vendor/autoload.php')) {
-    require($autoload);
-} elseif (is_file($autoload = __DIR__ . '/../../../autoload.php')) {
-    require($autoload);
-} else {
+foreach ($autoloadFiles as $file) {
+    if (file_exists(__DIR__ . $file)) {
+        require __DIR__ . $file;
+        define('SOAP_PATH', realpath(__DIR__ . '/..'));
+        break;
+    }
+}
+
+if (!defined('SOAP_PATH')) {
     fwrite(STDERR,
         'You must set up the project dependencies, run the following commands:' . PHP_EOL .
         'curl -s http://getcomposer.org/installer | php' . PHP_EOL .


### PR DESCRIPTION
This fixes an issue where the binary couldn't find the composer `autoload.php`.
This was caused due to the double checking if existing files.

I removed the old behavior and added a simple list where the autoload.php could be located.