### PR TITLE
Always add getters to every generated type

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -19,9 +19,8 @@ return Config::create()
 BODY;
 
     const RULESET_DEFAULT = <<<RULESET
-->addRule(
-    new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions()))
-)
+->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
+->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler())
 RULESET;
 
 

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -18,8 +18,14 @@ return Config::create()
 
 BODY;
 
+    const RULESET_DEFAULT = <<<RULESET
+->addRule(
+    new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions()))
+)
+RULESET;
 
-    const RULESET = <<<RULESET
+
+    const RULESET_REQUEST_RESPONSE = <<<RULESET
 ->addRule(
     new Rules\TypenameMatchesRule(
         new Rules\MultiRule([
@@ -33,7 +39,6 @@ BODY;
     new Rules\TypenameMatchesRule(
         new Rules\MultiRule([
             new Rules\AssembleRule(new Assembler\ResultAssembler()),
-            new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())),
         ]),
         '%s'
     )
@@ -54,11 +59,12 @@ RULESET;
 
     /**
      * @param FileGenerator $file
+     * @param string $ruleset
      * @return string
      */
-    private function getIndentedRuleSet(FileGenerator $file): string
+    private function parseIndentedRuleSet(FileGenerator $file, string $ruleset): string
     {
-        return $file->getIndentation().preg_replace('/\n/', sprintf("\n%s", $file->getIndentation()), self::RULESET);
+        return $file->getIndentation().preg_replace('/\n/', sprintf("\n%s", $file->getIndentation()), $ruleset).PHP_EOL;
     }
 
     /**
@@ -76,10 +82,14 @@ RULESET;
         foreach ($context->getSetters() as $name => $value) {
             $body .= $this->generateSetter($name, $value, $file);
         }
+
+        $body .= $this->parseIndentedRuleSet($file, self::RULESET_DEFAULT);
+
         if ($context->getRequestRegex() !== '' && $context->getResponseRegex() !== '') {
-            $ruleset = $this->getIndentedRuleSet($file);
-            $body .= sprintf($ruleset, $context->getRequestRegex(), $context->getResponseRegex());
+            $rules = $this->parseIndentedRuleSet($file, self::RULESET_REQUEST_RESPONSE);
+            $body .= sprintf($rules, $context->getRequestRegex(), $context->getResponseRegex());
         }
+
         $file->setBody($body.';'.PHP_EOL);
 
         return $file->generate();

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -20,7 +20,7 @@ BODY;
 
     const RULESET_DEFAULT = <<<RULESET
 ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
-->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler())
+->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler()))
 RULESET;
 
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -27,7 +27,7 @@ return Config::create()
     ->setClassmapName('Classmap')
     ->setClassmapNamespace('App\\\\Classmap')
     ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
-    ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler())
+    ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler()))
     ->addRule(
         new Rules\TypenameMatchesRule(
             new Rules\MultiRule([
@@ -87,7 +87,7 @@ return Config::create()
     ->setClassmapName('Classmap')
     ->setClassmapNamespace('App\\\\Classmap')
     ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
-    ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler())
+    ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler()))
 ;
 
 CONTENT;

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -27,6 +27,9 @@ return Config::create()
     ->setClassmapName('Classmap')
     ->setClassmapNamespace('App\\\\Classmap')
     ->addRule(
+        new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions()))
+    )
+    ->addRule(
         new Rules\TypenameMatchesRule(
             new Rules\MultiRule([
                 new Rules\AssembleRule(new Assembler\RequestAssembler()),
@@ -39,11 +42,11 @@ return Config::create()
         new Rules\TypenameMatchesRule(
             new Rules\MultiRule([
                 new Rules\AssembleRule(new Assembler\ResultAssembler()),
-                new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())),
             ]),
             '/Response$/i'
         )
-    );
+    )
+;
 
 CONTENT;
         $context = new ConfigContext();
@@ -67,7 +70,7 @@ CONTENT;
 
     public function testGenerateWithoutRegex()
     {
-        $expected =         $expected = <<<CONTENT
+        $expected = <<<CONTENT
 <?php
 
 use Phpro\SoapClient\CodeGenerator\Assembler;
@@ -84,6 +87,9 @@ return Config::create()
     ->setClassmapDestination('src/classmap')
     ->setClassmapName('Classmap')
     ->setClassmapNamespace('App\\\\Classmap')
+    ->addRule(
+        new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions()))
+    )
 ;
 
 CONTENT;

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -26,9 +26,8 @@ return Config::create()
     ->setClassmapDestination('src/classmap')
     ->setClassmapName('Classmap')
     ->setClassmapNamespace('App\\\\Classmap')
-    ->addRule(
-        new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions()))
-    )
+    ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
+    ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler())
     ->addRule(
         new Rules\TypenameMatchesRule(
             new Rules\MultiRule([
@@ -87,9 +86,8 @@ return Config::create()
     ->setClassmapDestination('src/classmap')
     ->setClassmapName('Classmap')
     ->setClassmapNamespace('App\\\\Classmap')
-    ->addRule(
-        new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions()))
-    )
+    ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
+    ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler())
 ;
 
 CONTENT;


### PR DESCRIPTION
This small change adds getters by default - even if you don't add request / response regex.
This makes the client easier to use by default when using the new wizard command.

Sample code:

```php
<?php

use Phpro\SoapClient\CodeGenerator\Assembler;
use Phpro\SoapClient\CodeGenerator\Rules;
use Phpro\SoapClient\CodeGenerator\Config\Config;

return Config::create()
    ->setWsdl('wsdl.xml')
    ->setTypeDestination('src/type')
    ->setTypeNamespace('App\\\\Type')
    ->setClientDestination('src/client')
    ->setClientName('Client')
    ->setClientNamespace('App\\\\Client')
    ->setClassmapDestination('src/classmap')
    ->setClassmapName('Classmap')
    ->setClassmapNamespace('App\\\\Classmap')
    ->addRule(
        new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions()))
    )
    ->addRule(
        new Rules\TypenameMatchesRule(
            new Rules\MultiRule([
                new Rules\AssembleRule(new Assembler\RequestAssembler()),
                new Rules\AssembleRule(new Assembler\ConstructorAssembler()),
            ]),
            '/Request$/i'
        )
    )
    ->addRule(
        new Rules\TypenameMatchesRule(
            new Rules\MultiRule([
                new Rules\AssembleRule(new Assembler\ResultAssembler()),
            ]),
            '/Response$/i'
        )
    )
;

```