### PR TITLE
Forcing requirement of SOAP and XML extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
   ],
   "require": {
     "php": "^7.0",
+    "ext-soap": "*",
+    "ext-xml": "*",
     "doctrine/collections": "~1.3",
     "psr/log": "^1.0",
     "symfony/console": "~2.8|~3.0|~4.0",


### PR DESCRIPTION
Reinstalling project on a new machine made me notice those extensions are required. They should be specified at the composer file :)