### PR TITLE
Fix client generation for methods with multiple arguments

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Parser/FunctionStringParserSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Parser/FunctionStringParserSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Parser;
 
+use Phpro\SoapClient\CodeGenerator\Model\Parameter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Phpro\SoapClient\CodeGenerator\Parser\FunctionStringParser;
@@ -13,7 +14,7 @@ use Phpro\SoapClient\CodeGenerator\Parser\FunctionStringParser;
 class FunctionStringParserSpec extends ObjectBehavior
 {
     function let() {
-        $this->beConstructedWith('TestResponse Test(Test $parameters)', 'MyParameterNamespace');
+        $this->beConstructedWith('TestResponse Test(Test1 $parameter1, Test2 $parameter2)', 'MyParameterNamespace');
     }
 
     function it_is_initializable()
@@ -22,7 +23,16 @@ class FunctionStringParserSpec extends ObjectBehavior
     }
 
     function it_should_parse_parameters() {
-        $this->parseParameters()->shouldHaveCount(1);
+        $result = $this->parseParameters();
+        $result->shouldHaveCount(2);
+
+        $result[0]->shouldHaveType(Parameter::class);
+        $result[0]->getName()->shouldBe('Test1');
+        $result[0]->getType()->shouldBe('MyParameterNamespace\Test1');
+
+        $result[1]->shouldHaveType(Parameter::class);
+        $result[1]->getName()->shouldBe('Test2');
+        $result[1]->getType()->shouldBe('MyParameterNamespace\Test2');
     }
 
     function it_should_parse_name() {

--- a/src/Phpro/SoapClient/CodeGenerator/Parser/FunctionStringParser.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Parser/FunctionStringParser.php
@@ -37,9 +37,9 @@ class FunctionStringParser
     {
         preg_match('/\((.*)\)/', $this->functionString, $properties);
         $parameters = [];
-        $properties = explode(',', $properties[1]);
+        $properties = preg_split('/,\s?/', $properties[1]);
         foreach ($properties as $property) {
-            list($type) = explode(' ', $property);
+            list($type) = explode(' ', trim($property));
             $parameters[] = new Parameter($type, $this->parameterNamespace.'\\'.$type);
         }
 


### PR DESCRIPTION
Fixes #158 

During generation of client methods with multiple errors, the client types could not be detected based on a space before the parameters:

Error:
```
"Provided type "Type\Type\" is invalid: must conform "/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*(\\[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)*$/"
```

```
HumansInSe getHumansInSe(string $pUsername, string $pPassword, string $pHumanID)

phpro/soap-client/src/Phpro/SoapClient/CodeGenerator/Parser/FunctionStringParser.php:48:
array(3) {
  [0] =>
  string(17) "string $pUsername"
  [1] =>
  string(18) " string $pPassword"
  [2] =>
  string(17) " string $pHumanID"
}
```


This PR Fixes the error.