### PR TITLE
Add docblocks to single argument methods too

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
@@ -7,7 +7,11 @@ use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\AssemblerException;
+use Phpro\SoapClient\Exception\SoapException;
 use Phpro\SoapClient\Type\MultiArgumentRequest;
+use Phpro\SoapClient\Type\RequestInterface;
+use Phpro\SoapClient\Type\ResultInterface;
+use Zend\Code\Generator\ClassGenerator;
 use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\MethodGenerator;
 use Zend\Code\Generator\ParameterGenerator;
@@ -36,22 +40,26 @@ class ClientMethodAssembler implements AssemblerInterface
         try {
             $param = $this->createParamsFromContext($context);
             $class->removeMethod($method->getMethodName());
-            $methodGeneratorConfig = [
-                'name' => $method->getMethodName(),
-                'parameters' => [$param],
-                'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
-                'body' => sprintf(
-                    'return $this->call(\'%s\', $%s);',
-                    Normalizer::getClassNameFromFQN($param->getType()),
-                    $param->getName()
-                ),
-                'returntype' => $method->getNamespacedReturnType(),
-            ];
-            if ($context->isMultiArgument()) {
-                $methodGeneratorConfig['docblock'] = $this->generateMultiArgumentDocblock($context);
-            }
+            $docblock = $context->isMultiArgument() ?
+                $this->generateMultiArgumentDocblock($context) :
+                $this->generateSingleArgumentDocblock($context);
 
-            $class->addMethodFromGenerator(MethodGenerator::fromArray($methodGeneratorConfig));
+            $class->addMethodFromGenerator(
+                MethodGenerator::fromArray(
+                    [
+                        'name' => $method->getMethodName(),
+                        'parameters' => [$param],
+                        'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
+                        'body' => sprintf(
+                            'return $this->call(\'%s\', $%s);',
+                            Normalizer::getClassNameFromFQN($param->getType()),
+                            $param->getName()
+                        ),
+                        'returntype' => $method->getNamespacedReturnType(),
+                        'docblock' => $docblock,
+                    ]
+                )
+            );
         } catch (\Exception $e) {
             throw AssemblerException::fromException($e);
         }
@@ -87,6 +95,8 @@ class ClientMethodAssembler implements AssemblerInterface
      */
     private function generateMultiArgumentDocblock(ClientMethodContext $context): DocBlockGenerator
     {
+        $class = $context->getClass();
+        $method = $context->getMethod();
         $description = ['MultiArgumentRequest with following params:'.PHP_EOL];
         foreach ($context->getMethod()->getParameters() as $parameter) {
             $description[] = $parameter->getType().' $'.$parameter->getName();
@@ -97,9 +107,97 @@ class ClientMethodAssembler implements AssemblerInterface
                 'longdescription' => implode(PHP_EOL, $description),
                 'tags' => [
                     ['name' => 'param', 'description' => MultiArgumentRequest::class],
-                    ['name' => 'return', 'description' => $context->getMethod()->getReturnType()],
+                    [
+                        'name' => 'return',
+                        'description' => sprintf(
+                            '%s|%s',
+                            $this->generateClassNameAndAddImport(ResultInterface::class, $class),
+                            $this->generateClassNameAndAddImport(
+                                $method->getNamespacedReturnType(),
+                                $class,
+                                true
+                            )
+                        ),
+                    ],
                 ],
             ]
         );
+    }
+
+    /**
+     * @param ClientMethodContext $context
+     *
+     * @return DocBlockGenerator
+     */
+    private function generateSingleArgumentDocblock(ClientMethodContext $context): DocBlockGenerator
+    {
+        $method = $context->getMethod();
+        $class = $context->getClass();
+        $param = current($method->getParameters());
+
+        return DocBlockGenerator::fromArray(
+            [
+                'tags' => [
+                    [
+                        'name' => 'param',
+                        'description' => sprintf(
+                            '%s|%s $%s',
+                            $this->generateClassNameAndAddImport(RequestInterface::class, $class),
+                            $this->generateClassNameAndAddImport($param->getType(), $class, true),
+                            $param->getName()
+                        ),
+                    ],
+                    [
+                        'name' => 'return',
+                        'description' => sprintf(
+                            '%s|%s',
+                            $this->generateClassNameAndAddImport(ResultInterface::class, $class),
+                            $this->generateClassNameAndAddImport(
+                                $method->getNamespacedReturnType(),
+                                $class,
+                                true
+                            )
+                        ),
+
+                    ],
+                    [
+                        'name' => 'throws',
+                        'description' => $this->generateClassNameAndAddImport(
+                            SoapException::class,
+                            $class
+                        ),
+                    ],
+                ],
+            ]
+        )->setWordWrap(false);
+    }
+
+    /**
+     * @param string $fqcn Fully qualified class name.
+     * @param ClassGenerator $class Class generator object.
+     * @param bool $prefixed
+     *
+     * @return string
+     */
+    protected function generateClassNameAndAddImport(string $fqcn, ClassGenerator $class, $prefixed = false): string
+    {
+        $prefix = '';
+        $fqcn = ltrim($fqcn, '\\');
+        $parts = explode('\\', $fqcn);
+        $className = array_pop($parts);
+        if ($prefixed) {
+            $prefix = array_pop($parts);
+        }
+        $classNamespace = implode('\\', $parts);
+        $currentNamespace = (string)$class->getNamespaceName();
+        if ($prefixed) {
+            $className = $prefix.'\\'.$className;
+            $fqcn = $classNamespace.'\\'.$prefix;
+        }
+        if ($classNamespace !== $currentNamespace || !\in_array($fqcn, $class->getUses(), true)) {
+            $class->addUse($fqcn);
+        }
+
+        return $className;
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -41,10 +41,10 @@ class ClientMethodAssemblerTest extends TestCase
     {
         // ClassGenerator $class, ClientMethod $method
         $class = new ClassGenerator();
-        $class->setNamespaceName('MyNamespace');
+        $class->setNamespaceName('Vendor\\MyNamespace');
         $method = ClientMethod::createFromExtSoapFunctionString(
             'ReturnType functionName(ParamType $param)',
-            'MyTypeNamespace'
+            'Vendor\\MyTypeNamespace'
         );
 
         return new ClientMethodContext($class, $method);
@@ -57,10 +57,10 @@ class ClientMethodAssemblerTest extends TestCase
     {
         // ClassGenerator $class, ClientMethod $method
         $class = new ClassGenerator();
-        $class->setNamespaceName('MyNamespace');
+        $class->setNamespaceName('Vendor\\MyNamespace');
         $method = ClientMethod::createFromExtSoapFunctionString(
             'ReturnType functionName(ParamType $param, OtherParamType $param2)',
-            'MyTypeNamespace'
+            'Vendor\\MyTypeNamespace'
         );
 
         return new ClientMethodContext($class, $method);
@@ -77,12 +77,22 @@ class ClientMethodAssemblerTest extends TestCase
 
         $code = $context->getClass()->generate();
         $expected = <<<CODE
-namespace MyNamespace;
+namespace Vendor\MyNamespace;
+
+use Phpro\SoapClient\Type\RequestInterface;
+use Phpro\SoapClient\Type\ResultInterface;
+use Vendor\MyTypeNamespace;
+use Phpro\SoapClient\Exception\SoapException;
 
 class  extends \Phpro\SoapClient\Client
 {
 
-    public function functionName(\MyTypeNamespace\ParamType \$param) : \MyTypeNamespace\ReturnType
+    /**
+     * @param RequestInterface|MyTypeNamespace\ParamType \$param
+     * @return ResultInterface|MyTypeNamespace\ReturnType
+     * @throws SoapException
+     */
+    public function functionName(\Vendor\MyTypeNamespace\ParamType \$param) : \Vendor\MyTypeNamespace\ReturnType
     {
         return \$this->call('ParamType', \$param);
     }
@@ -106,7 +116,10 @@ CODE;
 
         $code = $context->getClass()->generate();
         $expected = <<<CODE
-namespace MyNamespace;
+namespace Vendor\MyNamespace;
+
+use Phpro\SoapClient\Type\ResultInterface;
+use Vendor\MyTypeNamespace;
 
 class  extends \Phpro\SoapClient\Client
 {
@@ -114,13 +127,13 @@ class  extends \Phpro\SoapClient\Client
     /**
      * MultiArgumentRequest with following params:
      *
-     * MyTypeNamespace\ParamType \$param
-     * MyTypeNamespace\OtherParamType \$param2
+     * Vendor\MyTypeNamespace\ParamType \$param
+     * Vendor\MyTypeNamespace\OtherParamType \$param2
      *
      * @param Phpro\SoapClient\Type\MultiArgumentRequest
-     * @return ReturnType
+     * @return ResultInterface|MyTypeNamespace\ReturnType
      */
-    public function functionName(\Phpro\SoapClient\Type\MultiArgumentRequest \$multiArgumentRequest) : \MyTypeNamespace\ReturnType
+    public function functionName(\Phpro\SoapClient\Type\MultiArgumentRequest \$multiArgumentRequest) : \Vendor\MyTypeNamespace\ReturnType
     {
         return \$this->call('MultiArgumentRequest', \$multiArgumentRequest);
     }


### PR DESCRIPTION
I tried to make the params and return type itself into a non fqcn too, unfortunately zend code always prefixes those with a backslash.