### PR TITLE
Normalize class names in typehints when generating code

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -57,7 +57,7 @@ class Property
             return $this->type;
         }
 
-        return '\\'.$this->namespace.'\\'.$this->type;
+        return '\\'.$this->namespace.'\\'.Normalizer::normalizeClassname($this->type);
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Parser/FunctionStringParser.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Parser/FunctionStringParser.php
@@ -42,6 +42,7 @@ class FunctionStringParser
         foreach ($properties as $property) {
             list($type, $name) = explode(' ', trim($property));
             $name = Normalizer::normalizeProperty($name);
+            $type = Normalizer::normalizeClassname($type);
             $parameters[] = new Parameter($name, $this->parameterNamespace.'\\'.$type);
         }
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -154,6 +154,40 @@ CODE;
     }
 
     /**
+     * @test
+     */
+    function it_assembles_with_normalised_class_name()
+    {
+        $options = (new GetterAssemblerOptions())->withReturnType();
+        $assembler = new GetterAssembler($options);
+
+        $context = $this->createContext('prop4');
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+    /**
+     * @return \\ns1\\MyResponse
+     */
+    public function getProp4() : \\ns1\\MyResponse
+    {
+        return \$this->prop4;
+    }
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
      * @param string $propertyName
      * @return PropertyContext
      */
@@ -163,6 +197,7 @@ CODE;
             'prop1' => 'string',
             'prop2' => 'int',
             'prop3' => 'boolean',
+            'prop4' => 'My_Response',
         ];
 
         $class = new ClassGenerator('MyType', 'MyNamespace');


### PR DESCRIPTION
Resolves #191.

This change takes a lighter approach that doesn't change the public API - instead, it only fixes the references to class names in docblocks and typehints that were previously broken.