### PR TITLE
Added ConstructorAssemblerOptions

### DIFF
--- a/docs/code-generation/assemblers.md
+++ b/docs/code-generation/assemblers.md
@@ -65,6 +65,41 @@ Example output:
     }
 ```
 
+Generating type-hints is disabled by default, but can be enabled by passing `ConstructorAssemblerOptions` instance to the constructor with the option `withTypeHints` set to true.
+
+Example
+```php
+new ConstructorAssembler((new ConstructorAssemblerOptions())->withTypeHints())
+```
+
+```php
+    /**
+     * Constructor
+     *
+     * @var string $prop1
+     * @var int $prop2
+     */
+    public function __construct(string $prop1, int $prop2)
+    {
+        $this->prop1 = $prop1;
+        $this->prop2 = $prop2;
+    }
+```
+
+Generating doc blocks is enabled by default, but can be disabled by passing `ConstructorAssemblerOptions` instance to the constructor with the option `withDocBlocks` set to false. This is normally used in conjunction with `withTypeHints`
+
+Example
+```php
+new ConstructorAssembler((new ConstructorAssemblerOptions())->withDocBlocks(false)->withTypeHints())
+```
+
+```php
+    public function __construct(string $prop1, int $prop2)
+    {
+        $this->prop1 = $prop1;
+        $this->prop2 = $prop2;
+    }
+```
 
 ## FluentSetterAssembler
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
@@ -82,13 +82,19 @@ class ConstructorAssembler implements AssemblerInterface
             $constructor->setParameter(array_merge([
                 'name' => $property->getName(),
             ], $withTypeHints));
-            $docblock->setTag([
-                'name' => 'var',
-                'description' => sprintf('%s $%s', $property->getType(), $property->getName())
-            ]);
+
+            if ($this->options->useDocBlocks()) {
+                $docblock->setTag([
+                    'name' => 'var',
+                    'description' => sprintf('%s $%s', $property->getType(), $property->getName())
+                ]);
+            }
         }
 
-        $constructor->setDocBlock($docblock);
+        if ($this->options->useDocBlocks()) {
+            $constructor->setDocBlock($docblock);
+        }
+
         $constructor->setBody(implode($constructor::LINE_FEED, $body));
 
         return $constructor;

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
@@ -17,6 +17,21 @@ use Zend\Code\Generator\MethodGenerator;
 class ConstructorAssembler implements AssemblerInterface
 {
     /**
+     * @var ConstructorAssemblerOptions
+     */
+    private $options;
+
+    /**
+     * ConstructorAssembler constructor.
+     *
+     * @param ConstructorAssemblerOptions $options
+     */
+    public function __construct(ConstructorAssemblerOptions $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
      * @param ContextInterface $context
      *
      * @return bool
@@ -62,9 +77,11 @@ class ConstructorAssembler implements AssemblerInterface
 
         foreach ($type->getProperties() as $property) {
             $body[] = sprintf('$this->%1$s = $%1$s;', $property->getName());
-            $constructor->setParameter([
-                'name' => $property->getName()
-            ]);
+            $withTypeHints = $this->options->useTypeHints() ? ['type' => $property->getType()] : [];
+
+            $constructor->setParameter(array_merge([
+                'name' => $property->getName(),
+            ], $withTypeHints));
             $docblock->setTag([
                 'name' => 'var',
                 'description' => sprintf('%s $%s', $property->getType(), $property->getName())

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssemblerOptions.php
@@ -17,6 +17,11 @@ class ConstructorAssemblerOptions
     private $typeHints = false;
 
     /**
+     * @var bool
+     */
+    private $docBlocks = true;
+
+    /**
      * @return ConstructorAssemblerOptions
      */
     public static function create(): ConstructorAssemblerOptions
@@ -43,5 +48,26 @@ class ConstructorAssemblerOptions
     public function useTypeHints(): bool
     {
         return $this->typeHints;
+    }
+
+    /**
+     * @param bool $withDocBlocks
+     *
+     * @return ConstructorAssemblerOptions
+     */
+    public function withDocBlocks(bool $withDocBlocks = true): ConstructorAssemblerOptions
+    {
+        $new = clone $this;
+        $new->docBlocks = $withDocBlocks;
+
+        return $new;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useDocBlocks(): bool
+    {
+        return $this->docBlocks;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssemblerOptions.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\CodeGenerator\Assembler;
+
+/**
+ * Class ConstructorAssemblerOptions
+ *
+ * @package Phpro\SoapClient\CodeGenerator\Assembler
+ */
+class ConstructorAssemblerOptions
+{
+    /**
+     * @var bool
+     */
+    private $withTypeHints = false;
+
+    /**
+     * @return ConstructorAssemblerOptions
+     */
+    public static function create(): ConstructorAssemblerOptions
+    {
+        return new self();
+    }
+
+    /**
+     * @param bool $withTypeHints
+     *
+     * @return ConstructorAssemblerOptions
+     */
+    public function withTypeHints(bool $withTypeHints = true): ConstructorAssemblerOptions
+    {
+        $new = clone $this;
+        $new->withTypeHints = $withTypeHints;
+
+        return $new;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useTypeHints(): bool
+    {
+        return $this->withTypeHints;
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssemblerOptions.php
@@ -14,7 +14,7 @@ class ConstructorAssemblerOptions
     /**
      * @var bool
      */
-    private $withTypeHints = false;
+    private $typeHints = false;
 
     /**
      * @return ConstructorAssemblerOptions
@@ -32,7 +32,7 @@ class ConstructorAssemblerOptions
     public function withTypeHints(bool $withTypeHints = true): ConstructorAssemblerOptions
     {
         $new = clone $this;
-        $new->withTypeHints = $withTypeHints;
+        $new->typeHints = $withTypeHints;
 
         return $new;
     }
@@ -42,6 +42,6 @@ class ConstructorAssemblerOptions
      */
     public function useTypeHints(): bool
     {
-        return $this->withTypeHints;
+        return $this->typeHints;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -29,7 +29,7 @@ RULESET;
     new Rules\TypenameMatchesRule(
         new Rules\MultiRule([
             new Rules\AssembleRule(new Assembler\RequestAssembler()),
-            new Rules\AssembleRule(new Assembler\ConstructorAssembler()),
+            new Rules\AssembleRule(new Assembler\ConstructorAssembler(new Assembler\ConstructorAssemblerOptions()),
         ]),
         '%s'
     )

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
@@ -4,6 +4,7 @@ namespace PhproTest\SoapClient\Unit\CodeGenerator\Assembler;
 
 use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
 use Phpro\SoapClient\CodeGenerator\Assembler\ConstructorAssembler;
+use Phpro\SoapClient\CodeGenerator\Assembler\ConstructorAssemblerOptions;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
@@ -21,7 +22,7 @@ class ConstructorAssemblerTest extends TestCase
      */
     function it_is_an_assembler()
     {
-        $assembler = new ConstructorAssembler();
+        $assembler = new ConstructorAssembler(new ConstructorAssemblerOptions());
         $this->assertInstanceOf(AssemblerInterface::class, $assembler);
     }
     
@@ -30,7 +31,7 @@ class ConstructorAssemblerTest extends TestCase
      */
     function it_can_assemble_type_context()
     {
-        $assembler = new ConstructorAssembler();
+        $assembler = new ConstructorAssembler(new ConstructorAssemblerOptions());
         $context = $this->createContext();
         $this->assertTrue($assembler->canAssemble($context));
     }
@@ -40,7 +41,7 @@ class ConstructorAssemblerTest extends TestCase
      */
     function it_assembles_a_type()
     {
-        $assembler = new ConstructorAssembler();
+        $assembler = new ConstructorAssembler(new ConstructorAssemblerOptions());
         $context = $this->createContext();
         $assembler->assemble($context);
 
@@ -61,6 +62,51 @@ class MyType
     {
         \$this->prop1 = \$prop1;
         \$this->prop2 = \$prop2;
+    }
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @test
+     */
+    function it_assembles_a_type_with_type_hints()
+    {
+        $assembler = new ConstructorAssembler((new ConstructorAssemblerOptions())->withTypeHints());
+        $class = new ClassGenerator('MyType', 'MyNamespace');
+        $type = new Type('MyNamespace', 'MyType', [
+            'prop1' => 'string',
+            'prop2' => 'int',
+            'prop3' => 'SomeClass',
+        ]);
+
+        $context =  new TypeContext($class, $type);
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+    /**
+     * Constructor
+     *
+     * @var string \$prop1
+     * @var int \$prop2
+     * @var \MyNamespace\SomeClass \$prop3
+     */
+    public function __construct(string \$prop1, int \$prop2, \MyNamespace\SomeClass \$prop3)
+    {
+        \$this->prop1 = \$prop1;
+        \$this->prop2 = \$prop2;
+        \$this->prop3 = \$prop3;
     }
 
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
@@ -118,6 +118,40 @@ CODE;
     }
 
     /**
+     * @test
+     */
+    function it_assembles_a_type_with_no_doc_blocks()
+    {
+        $assembler = new ConstructorAssembler(
+            (new ConstructorAssemblerOptions())
+                ->withDocBlocks(false)
+                ->withTypeHints(true)
+        );
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+    public function __construct(string \$prop1, int \$prop2)
+    {
+        \$this->prop1 = \$prop1;
+        \$this->prop2 = \$prop2;
+    }
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
      * @return TypeContext
      */
     private function createContext()

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -32,7 +32,7 @@ return Config::create()
         new Rules\TypenameMatchesRule(
             new Rules\MultiRule([
                 new Rules\AssembleRule(new Assembler\RequestAssembler()),
-                new Rules\AssembleRule(new Assembler\ConstructorAssembler()),
+                new Rules\AssembleRule(new Assembler\ConstructorAssembler(new Assembler\ConstructorAssemblerOptions()),
             ]),
             '/Request$/i'
         )


### PR DESCRIPTION
Added ConstructorAssemblerOptions so we can enable type hinting for constructors. This is a BC break so we need a new version cutting.

Resolves https://github.com/phpro/soap-client/issues/193

## Todo

- [x] Update Docs 