### PR TITLE
Normalization fixes

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ClientMethodSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ClientMethodSpec.php
@@ -38,6 +38,12 @@ class ClientMethodSpec extends ObjectBehavior
         $this->getReturnType()->shouldBe('CreditResponse');
     }
 
+    function it_transforms_return_type()
+    {
+        $this->beConstructedWith('testMethod', [], 'credit_response', 'ParamNamespace');
+        $this->getReturnType()->shouldBe('CreditResponse');
+    }
+
     function it_has_a_parameter_namespace()
     {
         $this->getParameterNamespace()->shouldBe('ParamNamespace');

--- a/spec/Phpro/SoapClient/CodeGenerator/Util/NormalizerSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Util/NormalizerSpec.php
@@ -36,6 +36,18 @@ class NormalizerSpec extends ObjectBehavior
         $this->normalizeClassname('my-./final*type_123')->shouldReturn('MyFinalType123');
     }
 
+    function it_can_normalize_method_names()
+    {
+        $this->normalizeMethodName('myMethod')->shouldReturn('myMethod');
+        $this->normalizeMethodName('final')->shouldReturn('finalCall');
+        $this->normalizeMethodName('Final')->shouldReturn('finalCall');
+        $this->normalizeMethodName('UpperCased')->shouldReturn('upperCased');
+        $this->normalizeMethodName('my-./*method_123')->shouldReturn('myMethod123');
+        $this->normalizeMethodName('123hello')->shouldReturn('hello123');
+        $this->normalizeMethodName('123final')->shouldReturn('final123');
+        $this->normalizeMethodName('123')->shouldReturn('call123');
+    }
+
     function it_noramizes_properties()
     {
         $this->normalizeProperty('prop1')->shouldReturn('prop1');

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
@@ -47,12 +47,12 @@ class ClientMethodAssembler implements AssemblerInterface
             $class->addMethodFromGenerator(
                 MethodGenerator::fromArray(
                     [
-                        'name' => $method->getMethodName(),
+                        'name' => Normalizer::normalizeMethodName($method->getMethodName()),
                         'parameters' => [$param],
                         'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
                         'body' => sprintf(
                             'return $this->call(\'%s\', $%s);',
-                            Normalizer::getClassNameFromFQN($param->getType()),
+                            $method->getMethodName(),
                             $param->getName()
                         ),
                         'returntype' => $method->getNamespacedReturnType(),

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethod.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethod.php
@@ -107,6 +107,6 @@ class ClientMethod
      */
     public function getReturnType(): string
     {
-        return $this->returnType;
+        return Normalizer::normalizeClassname($this->returnType);
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -57,7 +57,7 @@ class Property
             return $this->type;
         }
 
-        return '\\'.$this->namespace.'\\'.$this->type;
+        return '\\'.$this->namespace.'\\'.Normalizer::normalizeClassname($this->type);
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Parser/FunctionStringParser.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Parser/FunctionStringParser.php
@@ -42,6 +42,7 @@ class FunctionStringParser
         foreach ($properties as $property) {
             list($type, $name) = explode(' ', trim($property));
             $name = Normalizer::normalizeProperty($name);
+            $type = Normalizer::normalizeClassname($type);
             $parameters[] = new Parameter($name, $this->parameterNamespace.'\\'.$type);
         }
 

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -101,16 +101,17 @@ class Normalizer
 
     /**
      * @param string $name
+     * @param string $suffix
      *
      * @return string
      */
-    private static function normalizeReservedKeywords(string $name): string
+    private static function normalizeReservedKeywords(string $name, string $suffix): string
     {
         if (!\in_array(strtolower($name), self::$reservedKeywords, true)) {
             return $name;
         }
 
-        return $name.'Type';
+        return $name.$suffix;
     }
 
     /**
@@ -142,13 +143,32 @@ class Normalizer
     }
 
     /**
+     * @param string $method
+     *
+     * @return string
+     */
+    public static function normalizeMethodName(string $method): string
+    {
+        // Methods cant start with a number in PHP - move it after text
+        $method = preg_replace('{^([0-9]*)(.*)}', '$2$1', $method);
+        if (is_numeric($method)) {
+            $method = 'call' . $method;
+        }
+
+        // Methods cant be named after reserved keywords.
+        $method = self::normalizeReservedKeywords($method, 'Call');
+
+        return lcfirst(self::camelCase($method, '{[^a-z0-9]+}i'));
+    }
+
+    /**
      * @param string $name
      *
      * @return string
      */
     public static function normalizeClassname(string $name): string
     {
-        $name = self::normalizeReservedKeywords($name);
+        $name = self::normalizeReservedKeywords($name, 'Type');
 
         return ucfirst(self::camelCase($name, '{[^a-z0-9]+}i'));
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -154,7 +154,7 @@ CODE;
         $class = new ClassGenerator();
         $class->setNamespaceName('Vendor\\MyNamespace');
         $method = ClientMethod::createFromExtSoapFunctionString(
-            'ReturnType function_name(param_type $param)',
+            'return_type function_name(param_type $param)',
             'Vendor\\MyTypeNamespace'
         );
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -94,7 +94,7 @@ class  extends \Phpro\SoapClient\Client
      */
     public function functionName(\Vendor\MyTypeNamespace\ParamType \$param) : \Vendor\MyTypeNamespace\ReturnType
     {
-        return \$this->call('ParamType', \$param);
+        return \$this->call('functionName', \$param);
     }
 
 
@@ -135,13 +135,59 @@ class  extends \Phpro\SoapClient\Client
      */
     public function functionName(\Phpro\SoapClient\Type\MultiArgumentRequest \$multiArgumentRequest) : \Vendor\MyTypeNamespace\ReturnType
     {
-        return \$this->call('MultiArgumentRequest', \$multiArgumentRequest);
+        return \$this->call('functionName', \$multiArgumentRequest);
     }
 
 
 }
 
 CODE;
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @test
+     */
+    function it_assembles_a_method_with_underscore_param_type()
+    {
+        $assembler = new ClientMethodAssembler();
+        $class = new ClassGenerator();
+        $class->setNamespaceName('Vendor\\MyNamespace');
+        $method = ClientMethod::createFromExtSoapFunctionString(
+            'ReturnType function_name(param_type $param)',
+            'Vendor\\MyTypeNamespace'
+        );
+
+        $context = new ClientMethodContext($class, $method);
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace Vendor\MyNamespace;
+
+use Phpro\SoapClient\Type\RequestInterface;
+use Phpro\SoapClient\Type\ResultInterface;
+use Vendor\MyTypeNamespace;
+use Phpro\SoapClient\Exception\SoapException;
+
+class  extends \Phpro\SoapClient\Client
+{
+
+    /**
+     * @param RequestInterface|MyTypeNamespace\ParamType \$param
+     * @return ResultInterface|MyTypeNamespace\ReturnType
+     * @throws SoapException
+     */
+    public function functionName(\Vendor\MyTypeNamespace\ParamType \$param) : \Vendor\MyTypeNamespace\ReturnType
+    {
+        return \$this->call('function_name', \$param);
+    }
+
+
+}
+
+CODE;
+
         $this->assertEquals($expected, $code);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -135,7 +135,7 @@ class MyType
 {
 
     /**
-     * @param \\MyNamespace\\foobar \$prop1
+     * @param \\MyNamespace\\Foobar \$prop1
      * @return \$this
      */
     public function setProp1(\$prop1)
@@ -172,7 +172,7 @@ class MyType
 {
 
     /**
-     * @param \MyNamespace\\foobar \$prop1
+     * @param \MyNamespace\\Foobar \$prop1
      * @return \$this
      */
     public function setProp1(\$prop1) : \MyNamespace\MyType

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -154,6 +154,40 @@ CODE;
     }
 
     /**
+     * @test
+     */
+    function it_assembles_with_normalised_class_name()
+    {
+        $options = (new GetterAssemblerOptions())->withReturnType();
+        $assembler = new GetterAssembler($options);
+
+        $context = $this->createContext('prop4');
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+    /**
+     * @return \\ns1\\MyResponse
+     */
+    public function getProp4() : \\ns1\\MyResponse
+    {
+        return \$this->prop4;
+    }
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
      * @param string $propertyName
      * @return PropertyContext
      */
@@ -163,6 +197,7 @@ CODE;
             'prop1' => 'string',
             'prop2' => 'int',
             'prop3' => 'boolean',
+            'prop4' => 'My_Response',
         ];
 
         $class = new ClassGenerator('MyType', 'MyNamespace');


### PR DESCRIPTION
Fixes #192
Fixes #191

This PR contains:
- general type normalization written by @clamburger.
- improved client method naming suggested by @joshhornby.
- bugfix: use function name based on soap information instead of based on type.
- Rename valid soap method names that aren't valid in PHP.
