### PR TITLE
Default to WSDL_CACHE_DISK caching strategy

### DIFF
--- a/src/Phpro/SoapClient/Soap/SoapClientFactory.php
+++ b/src/Phpro/SoapClient/Soap/SoapClientFactory.php
@@ -47,7 +47,7 @@ class SoapClientFactory
             'trace' => true,
             'exceptions' => true,
             'keep_alive' => true,
-            'cache_wsdl' => WSDL_CACHE_BOTH,
+            'cache_wsdl' => WSDL_CACHE_DISK,
             'features' => SOAP_SINGLE_ELEMENT_ARRAYS,
             'classmap' => $this->classMap->toSoapClassMap(),
             'typemap' => $this->typeConverters->toSoapTypeMap(),


### PR DESCRIPTION
The soap caching strategy WSDL_CACHE_MEMORY (WSDL_CACHE_BOTH) caused random segmentation faults while using this library, after debugging the issue we found that WSDL_CACHE_DISK is much more reliable and makes the crashes go away.

So Disk-Caching should be the default in here.