### PR TITLE
Fix issue 198 by setting exception code after parent constructor

### DIFF
--- a/spec/Phpro/SoapClient/Exception/SoapExceptionSpec.php
+++ b/spec/Phpro/SoapClient/Exception/SoapExceptionSpec.php
@@ -25,6 +25,6 @@ class SoapExceptionSpec extends ObjectBehavior
             protected $code = 'HY000';
         };
         $this->beConstructedThrough('fromThrowable', [$e]);
-        $this->getCode()->shouldBe(0);
+        $this->getCode()->shouldBe('HY000');
     }
 }

--- a/src/Phpro/SoapClient/Exception/SoapException.php
+++ b/src/Phpro/SoapClient/Exception/SoapException.php
@@ -9,6 +9,15 @@ namespace Phpro\SoapClient\Exception;
  */
 class SoapException extends RuntimeException
 {
+    public function __construct(string $message = "", $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, (int)$code, $previous);
+
+        if (!is_int($code)) {
+            $this->code = $code;
+        }
+    }
+
     /**
      * @param \Throwable $throwable
      *
@@ -16,6 +25,6 @@ class SoapException extends RuntimeException
      */
     public static function fromThrowable(\Throwable $throwable): self
     {
-        return new self($throwable->getMessage(), (int)$throwable->getCode(), $throwable);
+        return new self($throwable->getMessage(), $throwable->getCode(), $throwable);
     }
 }


### PR DESCRIPTION
This fix for issue #198 preserves the $code of the original exception