### PR TITLE
Feature/duplicate typenames

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContextSpec.php
@@ -26,7 +26,7 @@ class ClientFactoryContextSpec extends ObjectBehavior
             'Myclassmap',
             'App\\Classmap'
         );
-        $this->beConstructedWith($clientContext, $classMapContext);
+        $this->beConstructedWith($clientContext, $classMapContext, 'App\\SoapTypes');
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/TypeMapSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/TypeMapSpec.php
@@ -18,9 +18,13 @@ class TypeMapSpec extends ObjectBehavior
     function let()
     {
         $this->beConstructedWith('MyNamespace', [
-            'type1' => [
-                'prop1' => 'string',
-            ],
+            [
+                'typeName' => 'type1',
+                'properties' => [
+                    'prop1' => 'string',
+                ],
+                'duplicate' => false
+            ]
         ]);
     }
 

--- a/spec/Phpro/SoapClient/Soap/ClassMap/ClassMapCollectionSpec.php
+++ b/spec/Phpro/SoapClient/Soap/ClassMap/ClassMapCollectionSpec.php
@@ -34,6 +34,9 @@ class ClassMapCollectionSpec extends ObjectBehavior
 
     function it_should_add_a_classmap(ClassMap $classMap2)
     {
+        $classMap2->getWsdlType()->willReturn('WsdlType2');
+        $classMap2->getPhpClassName()->willReturn('PhpClass2');
+
         $this->has($classMap2)->shouldBe(false);
         $this->add($classMap2);
         $this->has($classMap2)->shouldBe(true);

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClassMapAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClassMapAssembler.php
@@ -44,8 +44,6 @@ class ClassMapAssembler implements AssemblerInterface
         $file->setClass($class);
         $file->setNamespace($context->getNamespace());
         $typeMap = $context->getTypeMap();
-        $typeNamespace = $typeMap->getNamespace();
-        $file->setUse($typeNamespace, preg_match('/\\\\Type$/', $typeNamespace) ? null : 'Type');
 
         try {
             $file->setUse(ClassMapCollection::class);
@@ -83,7 +81,7 @@ class ClassMapAssembler implements AssemblerInterface
                 '%snew ClassMap(\'%s\', %s::class),',
                 $indentation,
                 $type->getXsdName(),
-                'Type\\'.$type->getName()
+                '\\'.$type->getNamespace().'\\'.$type->getName()
             );
         }
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
@@ -11,6 +11,7 @@ use Phpro\SoapClient\Exception\SoapException;
 use Phpro\SoapClient\Type\MultiArgumentRequest;
 use Phpro\SoapClient\Type\RequestInterface;
 use Phpro\SoapClient\Type\ResultInterface;
+use Zend\Code\Generator\AbstractGenerator;
 use Zend\Code\Generator\ClassGenerator;
 use Zend\Code\Generator\DocBlockGenerator;
 use Zend\Code\Generator\MethodGenerator;
@@ -97,14 +98,14 @@ class ClientMethodAssembler implements AssemblerInterface
     {
         $class = $context->getClass();
         $method = $context->getMethod();
-        $description = ['MultiArgumentRequest with following params:'.PHP_EOL];
+        $description = ['MultiArgumentRequest with following params:'.AbstractGenerator::LINE_FEED];
         foreach ($context->getMethod()->getParameters() as $parameter) {
             $description[] = $parameter->getType().' $'.$parameter->getName();
         }
 
         return DocBlockGenerator::fromArray(
             [
-                'longdescription' => implode(PHP_EOL, $description),
+                'longdescription' => implode(AbstractGenerator::LINE_FEED, $description),
                 'tags' => [
                     ['name' => 'param', 'description' => MultiArgumentRequest::class],
                     [

--- a/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
@@ -5,6 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator;
 use Phpro\SoapClient\ClientBuilder;
 use Phpro\SoapClient\ClientFactory;
 use Phpro\SoapClient\CodeGenerator\Context\ClientFactoryContext;
+use Phpro\SoapClient\CodeGenerator\Model\DuplicateType;
 use Zend\Code\Generator\ClassGenerator;
 use Zend\Code\Generator\FileGenerator;
 use Zend\Code\Generator\MethodGenerator;
@@ -18,7 +19,7 @@ class ClientFactoryGenerator implements GeneratorInterface
 {
     const BODY = <<<BODY
 \$clientFactory = new PhproClientFactory(%1\$s::class);
-\$clientBuilder = new ClientBuilder(\$clientFactory, \$wsdl, []);
+\$clientBuilder = new ClientBuilder(\$clientFactory, \$wsdl, %3\$s);
 \$clientBuilder->withClassMaps(%2\$s::getCollection());
 
 return \$clientBuilder->build();
@@ -39,12 +40,26 @@ BODY;
         $class->addUse($context->getClassmapFqcn());
         $class->addUse(ClientFactory::class, 'PhproClientFactory');
         $class->addUse(ClientBuilder::class);
+
+        $options = [];
+        $soapTypeMapCode = $this->generateSoapTypeMapCode($context->getTypeNamespace(), $context->getDuplicateTypes());
+        if ($soapTypeMapCode) {
+            $options = [
+                'typemap' => $soapTypeMapCode
+            ];
+        }
+
         $class->addMethodFromGenerator(
             MethodGenerator::fromArray(
                 [
                     'name' => 'factory',
                     'static' => true,
-                    'body' => sprintf(self::BODY, $context->getClientName(), $context->getClassmapName()),
+                    'body' => sprintf(
+                        self::BODY,
+                        $context->getClientName(),
+                        $context->getClassmapName(),
+                        var_export($options, true)
+                    ),
                     'returntype' => $context->getClientFqcn(),
                     'parameters' => [
                         [
@@ -59,5 +74,29 @@ BODY;
         $file->setClass($class);
 
         return $file->generate();
+    }
+
+    /**
+     * @param $typesNamespace
+     * @param DuplicateType[]|array $duplicateTypes
+     * @return array
+     */
+    private function generateSoapTypeMapCode($typesNamespace, array $duplicateTypes)
+    {
+        $typeMaps = [];
+        foreach ($duplicateTypes as $duplicateType) {
+            $typeMap = [
+                'type_name' => $duplicateType->getTypeName(),
+                'type_ns' => $duplicateType->getXsdNamespace(),
+                'from_xml' =>
+                    $typesNamespace.'\\'
+                    .$duplicateType->getNamespaceSuffix().'\\'
+                    .$duplicateType->getTypeName().'::fromXml'
+            ];
+
+            $typeMaps[] = $typeMap;
+        }
+
+        return $typeMaps;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
@@ -4,6 +4,7 @@ namespace Phpro\SoapClient\CodeGenerator\Config;
 
 use Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Assembler\ClientMethodAssembler;
+use Phpro\SoapClient\CodeGenerator\Model\DuplicateType;
 use Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSet;
@@ -85,6 +86,12 @@ class Config implements ConfigInterface
      * @var string
      */
     protected $classMapDestination;
+
+
+    /**
+     * @var DuplicateType[]
+     */
+    protected $duplicateTypes;
 
     /**
      * Config constructor.
@@ -400,6 +407,24 @@ class Config implements ConfigInterface
     public function setClassMapDestination(string $classMapDestination): self
     {
         $this->classMapDestination = $classMapDestination;
+
+        return $this;
+    }
+
+    /**
+     * @return DuplicateType[]
+     */
+    public function getDuplicateTypes(): array
+    {
+        return $this->duplicateTypes;
+    }
+
+    /**
+     * @param DuplicateType[] $duplicateTypes
+     */
+    public function setDuplicateTypes(array $duplicateTypes)
+    {
+        $this->duplicateTypes = $duplicateTypes;
 
         return $this;
     }

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -53,7 +53,7 @@ RULESET;
      */
     private function generateSetter(string $name, string $value, FileGenerator $file): string
     {
-        return sprintf("%s->%s('%s')".PHP_EOL, $file->getIndentation(), $name, $value);
+        return sprintf("%s->%s('%s')".FileGenerator::LINE_FEED, $file->getIndentation(), $name, $value);
     }
 
     /**
@@ -63,7 +63,9 @@ RULESET;
      */
     private function parseIndentedRuleSet(FileGenerator $file, string $ruleset): string
     {
-        return $file->getIndentation().preg_replace('/\n/', sprintf("\n%s", $file->getIndentation()), $ruleset).PHP_EOL;
+        return $file->getIndentation()
+            .preg_replace('/\n/', sprintf("\n%s", $file->getIndentation()), $ruleset)
+            .FileGenerator::LINE_FEED;
     }
 
     /**
@@ -89,7 +91,7 @@ RULESET;
             $body .= sprintf($rules, $context->getRequestRegex(), $context->getResponseRegex());
         }
 
-        $file->setBody($body.';'.PHP_EOL);
+        $file->setBody($body.';'.FileGenerator::LINE_FEED);
 
         return $file->generate();
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContext.php
@@ -2,6 +2,8 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\Model\DuplicateType;
+
 class ClientFactoryContext implements ContextInterface
 {
     /**
@@ -14,12 +16,26 @@ class ClientFactoryContext implements ContextInterface
      */
     private $clientContext;
 
+    /**
+     * @var string
+     */
+    private $typeNamespace;
+
+    /**
+     * @var DuplicateType[]|array
+     */
+    private $duplicateTypes;
+
     public function __construct(
         ClientContext $clientContext,
-        ClassMapContext $classMapContext
+        ClassMapContext $classMapContext,
+        string $typeNamespace,
+        array $duplicateTypes = []
     ) {
         $this->classMapContext = $classMapContext;
         $this->clientContext = $clientContext;
+        $this->typeNamespace = $typeNamespace;
+        $this->duplicateTypes = $duplicateTypes;
     }
 
     public function getClientName(): string
@@ -50,5 +66,21 @@ class ClientFactoryContext implements ContextInterface
     public function getClassmapFqcn(): string
     {
         return $this->classMapContext->getFqcn();
+    }
+
+    /**
+     * @return array|DuplicateType[]
+     */
+    public function getDuplicateTypes()
+    {
+        return $this->duplicateTypes;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTypeNamespace(): string
+    {
+        return $this->typeNamespace;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/DuplicateType.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/DuplicateType.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Model;
+
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+
+class DuplicateType
+{
+    /**
+     * @var string
+     */
+    private $typeName;
+
+    /**
+     * @var string
+     */
+    private $xsdNamespace;
+
+    /**
+     * @var array
+     */
+    private $properties;
+
+    public function __construct(string $typeName, string $xsdNamespace, array $properties)
+    {
+        $this->typeName = $typeName;
+        $this->xsdNamespace = $xsdNamespace;
+        $this->properties = $properties;
+    }
+
+    /**
+     * Return true if type match criteria.
+     *
+     * @param Type $type
+     * @return bool
+     */
+    public function matchType(Type $type)
+    {
+        if ($type->getName() !== $this->typeName) {
+            return false;
+        }
+
+        if (count($type->getProperties()) !== count($this->properties)) {
+            return false;
+        }
+
+        $propertyNames = [];
+        /** @var Property $property */
+        foreach ($type->getProperties() as $property) {
+            $propertyNames[] = $property->getName();
+        }
+
+        // Type must contains all defined properties to match
+        foreach ($this->properties as $property) {
+            if (!in_array($property, $propertyNames)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string Normalized namespace suffix
+     */
+    public function getNamespaceSuffix()
+    {
+        $namespaceParts = explode('/', $this->xsdNamespace);
+
+        return Normalizer::normalizeClassname(end($namespaceParts));
+    }
+
+    /**
+     * @return string
+     */
+    public function getTypeName(): string
+    {
+        return $this->typeName;
+    }
+
+    /**
+     * @param string $typeName
+     */
+    public function setTypeName(string $typeName)
+    {
+        $this->typeName = $typeName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getXsdNamespace(): string
+    {
+        return $this->xsdNamespace;
+    }
+
+    /**
+     * @param string $xsdNamespace
+     */
+    public function setXsdNamespace(string $xsdNamespace)
+    {
+        $this->xsdNamespace = $xsdNamespace;
+    }
+
+    /**
+     * @return array
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @param array $properties
+     */
+    public function setProperties(array $properties)
+    {
+        $this->properties = $properties;
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
@@ -33,22 +33,34 @@ class Type
      */
     private $properties = [];
 
+    /**
+     * @var DuplicateType
+     */
+    private $duplicateType;
 
     /**
-     * TypeModel constructor.
+     * Type constructor.
      *
-     * @param string     $namespace
-     * @param string     $xsdName
-     * @param Property[] $properties
+     * @param string $namespace
+     * @param string $xsdName
+     * @param array $properties
+     * @param DuplicateType|null $duplicateType
      */
-    public function __construct(string $namespace, string $xsdName, array $properties)
+    public function __construct(string $namespace, string $xsdName, array $properties, $duplicateType = null)
     {
         $this->namespace = Normalizer::normalizeNamespace($namespace);
         $this->xsdName = $xsdName;
         $this->name = Normalizer::normalizeClassname($xsdName);
+        $this->duplicateType = $duplicateType;
 
+        // Properties will always have default namespace(user must change it manually)
         foreach ($properties as $property => $type) {
             $this->properties[] = new Property($property, $type, $this->namespace);
+        }
+
+        // Append namespace suffix for duplicates
+        if ($duplicateType !== null) {
+            $this->namespace .= '\\'.$duplicateType->getNamespaceSuffix();
         }
     }
 
@@ -84,7 +96,7 @@ class Type
     public function getFileInfo(string $destination): SplFileInfo
     {
         $name = Normalizer::normalizeClassname($this->getName());
-        $path = rtrim($destination, '/\\').DIRECTORY_SEPARATOR.$name.'.php';
+        $path = rtrim($destination, '/\\').'/'.$name.'.php';
 
         return new SplFileInfo($path);
     }
@@ -116,5 +128,21 @@ class Type
     public function getProperties(): array
     {
         return $this->properties;
+    }
+
+    /**
+     * @return DuplicateType
+     */
+    public function getDuplicateType()
+    {
+        return $this->duplicateType;
+    }
+
+    /**
+     * @param DuplicateType $duplicateType
+     */
+    public function setDuplicateType(DuplicateType $duplicateType)
+    {
+        $this->duplicateType = $duplicateType;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/TypeMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/TypeMap.php
@@ -23,18 +23,69 @@ class TypeMap
      */
     private $namespace;
 
+
     /**
      * TypeMap constructor.
      *
      * @param string $namespace
-     * @param array $types
+     * @param array $soapTypes
+     * @param DuplicateType[] $duplicateTypes
      */
-    public function __construct(string $namespace, array $types)
+    public function __construct(string $namespace, array $soapTypes, array $duplicateTypes = [])
     {
         $this->namespace = Normalizer::normalizeNamespace($namespace);
 
-        foreach ($types as $type => $properties) {
-            $this->types[] = new Type($namespace, $type, $properties);
+        $unprocessedSoapTypes = $soapTypes;
+        foreach ($duplicateTypes as $duplicateType) {
+            $alreadyMatched = false;
+            foreach ($unprocessedSoapTypes as $key => $soapType) {
+                if (!$soapType['duplicate']) {
+                    continue;
+                }
+
+                $type = new Type($namespace, $soapType['typeName'], $soapType['properties']);
+                if ($duplicateType->matchType($type)) {
+                    /**
+                     * If duplicate is already matched but in another namespace
+                     * we can ignore it and use only class from that another namespace
+                     */
+                    if ($alreadyMatched) {
+                        unset($unprocessedSoapTypes[$key]);
+                        continue;
+                    }
+
+                    $this->types[] = new Type(
+                        $namespace,
+                        $soapType['typeName'],
+                        $soapType['properties'],
+                        $duplicateType
+                    );
+
+                    unset($unprocessedSoapTypes[$key]);
+                    $alreadyMatched = true;
+                }
+            }
+        }
+
+        foreach ($unprocessedSoapTypes as $key => $soapType) {
+            if ($soapType['duplicate']) {
+                continue;
+            }
+
+            $this->types[] = new Type($namespace, $soapType['typeName'], $soapType['properties']);
+            unset($unprocessedSoapTypes[$key]);
+        }
+
+        if ($unprocessedSoapTypes) {
+            $unprocessedSoapTypeNames = [];
+            foreach ($unprocessedSoapTypes as $duplicateType) {
+                $unprocessedSoapTypeNames[] = $duplicateType['typeName'];
+            }
+
+            throw new \Exception(
+                'WSDL contains duplicate types('.implode(', ', $unprocessedSoapTypeNames).') 
+                but duplicateType isn`t explicitly defined in configration.'
+            );
         }
     }
 
@@ -44,9 +95,9 @@ class TypeMap
      *
      * @return TypeMap
      */
-    public static function fromSoapClient(string $namespace, SoapClient $client): self
+    public static function fromSoapClient(string $namespace, SoapClient $client, array $duplicateTypes = []): self
     {
-        return new self($namespace, $client->getSoapTypes());
+        return new self($namespace, $client->getSoapTypes(), $duplicateTypes);
     }
 
     /**

--- a/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
@@ -80,7 +80,8 @@ class GenerateClassmapCommand extends Command
 
         $config = $this->getConfigHelper()->load($input);
         $soapClient = new SoapClient($config->getWsdl(), $config->getSoapOptions());
-        $typeMap = TypeMap::fromSoapClient($config->getTypeNamespace(), $soapClient);
+        $duplicateTypes = $config->getDuplicateTypes();
+        $typeMap = TypeMap::fromSoapClient($config->getTypeNamespace(), $soapClient, $duplicateTypes);
 
         $generator = new ClassMapGenerator(
             $config->getRuleSet(),

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
@@ -66,7 +66,13 @@ class GenerateClientFactoryCommand extends Command
             $config->getClassMapNamespace()
         );
         $clientContext = new ClientContext($config->getClientName(), $config->getClientNamespace());
-        $context = new ClientFactoryContext($clientContext, $classmapContext);
+        $duplicateTypes = $config->getDuplicateTypes();
+        $context = new ClientFactoryContext(
+            $clientContext,
+            $classmapContext,
+            $config->getTypeNamespace(),
+            $duplicateTypes
+        );
         $generator = new ClientFactoryGenerator();
         $dest = $config->getClientDestination().DIRECTORY_SEPARATOR.$config->getClientName().'Factory.php';
         $this->filesystem->putFileContents($dest, $generator->generate(new FileGenerator(), $context));

--- a/src/Phpro/SoapClient/Soap/ClassMap/ClassMapCollection.php
+++ b/src/Phpro/SoapClient/Soap/ClassMap/ClassMapCollection.php
@@ -60,7 +60,13 @@ class ClassMapCollection
      */
     public function has(ClassMapInterface $classMap): bool
     {
-        return array_key_exists($classMap->getWsdlType(), $this->classMaps);
+        foreach ($this->classMaps as $existingClassMap) {
+            if ($existingClassMap->getPhpClassName() === $classMap->getPhpClassName()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/test/PhproTest/SoapClient/Functional/Encoding/DuplicateTypenamesTest.php
+++ b/test/PhproTest/SoapClient/Functional/Encoding/DuplicateTypenamesTest.php
@@ -29,14 +29,20 @@ class DuplicateTypenamesTest extends AbstractSoapTestCase
     }
 
     /** @test */
-    function it_does_only_register_the_last_type()
+    function it_does_register_all_types()
     {
         $types = $this->client->getSoapTypes();
-        $this->assertCount(1, $types);
+        $this->assertCount(2, $types);
 
-        $type = $types['Store'];
+        $duplicateTypes = [];
+        foreach ($types as $type) {
+            if ($type['typeName'] === 'Store') {
+                $duplicateTypes[] = $type;
+            }
+        }
 
-        $this->assertEquals($type['Attribute2'], 'string');
+        $this->assertEquals($duplicateTypes[0]['properties']['Attribute1'], 'string');
+        $this->assertEquals($duplicateTypes[1]['properties']['Attribute2'], 'string');
     }
 
     /**

--- a/test/PhproTest/SoapClient/Functional/Encoding/SimpleContentTest.php
+++ b/test/PhproTest/SoapClient/Functional/Encoding/SimpleContentTest.php
@@ -32,10 +32,15 @@ class SimpleContentTest extends AbstractSoapTestCase
     function it_can_parse_simple_content_types()
     {
         $types = $this->client->getSoapTypes();
-        $type = $types['SimpleContent'];
+        $type = null;
+        foreach ($types as $type) {
+            if ($type['typeName'] === 'SimpleContent') {
+                break;
+            }
+        }
 
-        $this->assertEquals($type['country'], 'string');
-        $this->assertEquals($type['_'], 'integer');
+        $this->assertEquals($type['properties']['country'], 'string');
+        $this->assertEquals($type['properties']['_'], 'integer');
     }
 
     /**

--- a/test/PhproTest/SoapClient/Integration/Soap/SoapClientTest.php
+++ b/test/PhproTest/SoapClient/Integration/Soap/SoapClientTest.php
@@ -39,8 +39,15 @@ class SoapClientTest extends TestCase
     {
         $types = $this->client->getSoapTypes();
 
-        $this->assertTrue(array_key_exists('GetCityForecastByZIP', $types));
-        $this->assertEquals('string', $types['GetCityForecastByZIP']['ZIP']);
+        $type = null;
+        foreach ($types as $type) {
+            if ($type['typeName'] === 'GetCityForecastByZIP') {
+                break;
+            }
+        }
+
+        $this->assertNotNull($type);
+        $this->assertEquals('string', $type['properties']['ZIP']);
     }
 
     /**

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
@@ -50,7 +50,6 @@ class ClassMapAssemblerTest extends TestCase
 
 namespace ClassMapNamespace;
 
-use MyNamespace as Type;
 use Phpro\SoapClient\Soap\ClassMap\ClassMapCollection;
 use Phpro\SoapClient\Soap\ClassMap\ClassMap;
 
@@ -60,7 +59,7 @@ class ClassMap
     public static function getCollection() : \Phpro\SoapClient\Soap\ClassMap\ClassMapCollection
     {
         return new ClassMapCollection([
-            new ClassMap('MyType', Type\MyType::class),
+            new ClassMap('MyType', \MyNamespace\MyType::class),
         ]);
     }
 
@@ -79,8 +78,12 @@ CODE;
     {
         $file = new FileGenerator();
         $typeMap = new TypeMap('MyNamespace', [
-            'MyType' => [
-                'myProperty' => 'string',
+            [
+                'typeName' => 'MyType',
+                'properties' => [
+                    'myProperty' => 'string',
+                ],
+                'duplicate' => false
             ]
         ]);
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
@@ -28,7 +28,8 @@ class MyclientFactory
     public static function factory(string \$wsdl) : \App\Client\Myclient
     {
         \$clientFactory = new PhproClientFactory(Myclient::class);
-        \$clientBuilder = new ClientBuilder(\$clientFactory, \$wsdl, []);
+        \$clientBuilder = new ClientBuilder(\$clientFactory, \$wsdl, array (
+        ));
         \$clientBuilder->withClassMaps(Myclassmap::getCollection());
 
         return \$clientBuilder->build();
@@ -46,7 +47,7 @@ BODY;
             'Myclassmap',
             'App\\Classmap'
         );
-        $context = new ClientFactoryContext($clientContext, $classMapContext);
+        $context = new ClientFactoryContext($clientContext, $classMapContext, '', []);
         $generator = new ClientFactoryGenerator();
         self::assertEquals($expected, $generator->generate(new FileGenerator(), $context));
     }


### PR DESCRIPTION
In this pull request I try to solve problem with duplicate tymenames.
https://github.com/phpro/soap-client/blob/master/docs/known-issues/ext-soap.md#duplicate-typenames

Little documentation for this feature:
https://github.com/trexima/soap-client/blob/feature/duplicate-typenames/docs/known-issues/ext-soap.md#duplicate-typenames

Since WSDL can properly contains more types with same names, this client is absolutely unusable for us.
So I try to find solution for this. At most while this library is dependent on ext-soap.

I add option _setDuplicateTypes_ where you can explicitly define duplicate typenames with proper XSD namespace. Different types are determined by attribute names(which you must write manually from WSDL). It is not absolutely automatic and you must tweak your classes after generation but it saves you much time.

I know it is a little bit hacky solution but it works without dumping ext-soap extension. We need it for complex WSDL. I hope it helps someone else.

This pull request contains some minor bug fixes(read more in commit messages).

Feel free to comment my work.