### PR TITLE
Add PHPStan for additional bug detection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,12 +39,14 @@
     "phpro/grumphp": "~0.15",
     "phpspec/phpspec": "~5.1",
     "phpspec/prophecy": "~1.8",
+    "phpstan/phpstan": "^0.11.8",
     "phpunit/phpunit": "~6.0",
+    "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
     "robrichards/wse-php": "^2.0.2",
     "robrichards/xmlseclibs": "^3.0",
-    "symfony/validator": "~2.8|~3.0|~4.0",
     "squizlabs/php_codesniffer": "~2.9",
+    "symfony/validator": "~2.8|~3.0|~4.0",
     "zendframework/zend-code": "^3.3.1"
   },
   "suggest": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -13,3 +13,8 @@ parameters:
         phpspec: ~
         phpunit: ~
         phplint: ~
+        phpstan:
+            configuration: "phpstan.neon"
+            ignore_patterns:
+                - "spec/"
+                - "vendor/"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+  ignoreErrors:
+    - '#Call to an undefined static method SoapClient::__construct().#'

--- a/src/Phpro/SoapClient/Soap/HttpBinding/Converter/Psr7Converter.php
+++ b/src/Phpro/SoapClient/Soap/HttpBinding/Converter/Psr7Converter.php
@@ -4,13 +4,14 @@ namespace Phpro\SoapClient\Soap\HttpBinding\Converter;
 
 use Http\Message\MessageFactory;
 use Http\Message\StreamFactory;
-use Interop\Http\Factory\RequestFactoryInterface;
-use Interop\Http\Factory\StreamFactoryInterface;
+use Phpro\SoapClient\Exception\RequestException;
 use Phpro\SoapClient\Soap\HttpBinding\Builder\Psr7RequestBuilder;
 use Phpro\SoapClient\Soap\HttpBinding\SoapRequest;
 use Phpro\SoapClient\Soap\HttpBinding\SoapResponse;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * Class Psr7Converter
@@ -38,7 +39,7 @@ class Psr7Converter
     /**
      * @param SoapRequest $request
      *
-     * @throws \Phpro\SoapClient\Exception\RequestException
+     * @throws RequestException
      * @return RequestInterface
      */
     public function convertSoapRequest(SoapRequest $request): RequestInterface


### PR DESCRIPTION
PHPStan found the issue mentioned, and a missing interface as well, Interop is deprecated and moved to a psr lib.
Suppressed one false positive due to SoapClient reflection weirdness in the phpstan.neon config file.