### PR TITLE
`Phpro\SoapClient\Client::debugLastSoapRequest()` returns empty `response.body`

### DIFF
--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/AbusedClient.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/AbusedClient.php
@@ -44,7 +44,8 @@ class AbusedClient extends \SoapClient
         int $version,
         int $oneWay = 0
     ): string {
-        return (string) parent::__doRequest($request, $location, $action, $version, $oneWay);
+        $this->__last_response = (string) parent::__doRequest($request, $location, $action, $version, $oneWay);
+        return $this->__getLastResponse();
     }
 
     public function collectRequest(): SoapRequest


### PR DESCRIPTION

`Phpro\SoapClient\Soap\Driver\ExtSoap\AbusedClient::doActualRequest()` doesn't set `$this->__last_response` so `Phpro\SoapClient\Client::debugLastSoapRequest()` returns empty `response.body`

https://github.com/phpro/soap-client/issues/246