### PR TITLE
Feature: Add ReturnType for Setters

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssemblerOptionsSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssemblerOptionsSpec.php
@@ -32,4 +32,10 @@ class ImmutableSetterAssemblerOptionsSpec extends ObjectBehavior
         $options = $this::create()->withTypeHints();
         $options->useTypeHints()->shouldBe(true);
     }
+
+    function it_shout_set_return_types()
+    {
+        $options = $this::create()->withReturnTypes();
+        $options->useReturnTypes()->shouldBe(true);
+    }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
@@ -66,6 +66,9 @@ class ImmutableSetterAssembler implements AssemblerInterface
             if ($this->options->useTypeHints()) {
                 $parameterOptions['type'] = $property->getType();
             }
+            $returnType = $this->options->useReturnTypes()
+                ? $class->getNamespaceName() . '\\' . $class->getName()
+                : null;
             $class->addMethodFromGenerator(
                 MethodGenerator::fromArray(
                     [
@@ -73,7 +76,7 @@ class ImmutableSetterAssembler implements AssemblerInterface
                         'parameters' => [$parameterOptions],
                         'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
                         'body' => implode($class::LINE_FEED, $lines),
-                        'returntype' => $this->options->useReturnTypes() ? $class->getNamespaceName() . '\\' . $class->getName() : null,
+                        'returntype' => $returnType,
                         'docblock' => DocBlockGeneratorFactory::fromArray([
                             'tags' => [
                                 [

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
@@ -73,6 +73,7 @@ class ImmutableSetterAssembler implements AssemblerInterface
                         'parameters' => [$parameterOptions],
                         'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
                         'body' => implode($class::LINE_FEED, $lines),
+                        'returntype' => $this->options->useReturnTypes() ? $class->getNamespaceName() . '\\' . $class->getName() : null,
                         'docblock' => DocBlockGeneratorFactory::fromArray([
                             'tags' => [
                                 [

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssemblerOptions.php
@@ -14,6 +14,11 @@ class ImmutableSetterAssemblerOptions
     private $typeHints = false;
 
     /**
+     * @var bool
+     */
+    private $returnTypes = false;
+
+    /**
      * @return ImmutableSetterAssemblerOptions
      */
     public function withTypeHints(): ImmutableSetterAssemblerOptions
@@ -25,11 +30,30 @@ class ImmutableSetterAssemblerOptions
     }
 
     /**
+     * @return ImmutableSetterAssemblerOptions
+     */
+    public function withReturnTypes(): ImmutableSetterAssemblerOptions
+    {
+        $new = clone $this;
+        $new->returnTypes = true;
+
+        return $new;
+    }
+
+    /**
      * @return bool
      */
     public function useTypeHints(): bool
     {
         return $this->typeHints;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useReturnTypes(): bool
+    {
+        return $this->returnTypes;
     }
 
     /**

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
@@ -160,6 +160,45 @@ CODE;
     }
 
     /**
+     * @test
+     */
+    public function it_assembles_with_return_type(): void
+    {
+        $assembler = new ImmutableSetterAssembler(
+            (new ImmutableSetterAssemblerOptions())
+                ->withReturnTypes()
+        );
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+    /**
+     * @param string \$prop1
+     * @return MyType
+     */
+    public function withProp1(\$prop1) : \MyNamespace\MyType
+    {
+        \$new = clone \$this;
+        \$new->prop1 = \$prop1;
+
+        return \$new;
+    }
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
      * @return PropertyContext
      */
     private function createContextWithLongType()


### PR DESCRIPTION
Hi. Since all setters are fluent by default. I have just added a valid returntype to it.
I need to add the FQN because `zend-code` will always add a trailing `\` in front. Otherwise I would have taken `self` as a simple approach.