### PR TITLE
PHPStan level 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "phpstan/phpstan": "^0.11.8",
     "phpunit/phpunit": "~6.0",
     "psr/http-factory": "^1.0",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^1.0.1",
     "robrichards/wse-php": "^2.0.2",
     "robrichards/xmlseclibs": "^3.0",
     "squizlabs/php_codesniffer": "~2.9",

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,4 +1,7 @@
 parameters:
+    testsuites:
+        phpstan:
+            tasks: [phpstan]
     git_dir: .
     bin_dir: ./vendor/bin
     tasks:
@@ -14,7 +17,9 @@ parameters:
         phpunit: ~
         phplint: ~
         phpstan:
+            level: 4
             configuration: "phpstan.neon"
             ignore_patterns:
                 - "spec/"
                 - "vendor/"
+                - "test"

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,7 +1,4 @@
 parameters:
-    testsuites:
-        phpstan:
-            tasks: [phpstan]
     git_dir: .
     bin_dir: ./vendor/bin
     tasks:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,6 @@ parameters:
     ignoreErrors:
         # Soapclient reflection is quite broken
         - '#Call to an undefined static method SoapClient::__construct().#'
-        # This is something we hope to fix in later PHP versions
+        # This is something we hope to fix in PHP 7.4
+        # https://wiki.php.net/rfc/covariant-returns-and-contravariant-parameters
         - '#Call to an undefined method Phpro\\.*(Context|RuleSet)Interface.*$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
 parameters:
-  ignoreErrors:
-    - '#Call to an undefined static method SoapClient::__construct().#'
+    ignoreErrors:
+        - '#Call to an undefined static method SoapClient::__construct().#'
+        - '#Call to an undefined method Phpro\\.*Interface.*$#'
+        - '#Invalid type Http\\Client\\Exception to throw.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     ignoreErrors:
+        # Soapclient reflection is quite broken
         - '#Call to an undefined static method SoapClient::__construct().#'
-        - '#Call to an undefined method Phpro\\.*Interface.*$#'
-        - '#Invalid type Http\\Client\\Exception to throw.#'
+        # This is something we hope to fix in later PHP versions
+        - '#Call to an undefined method Phpro\\.*(Context|RuleSet)Interface.*$#'

--- a/spec/Phpro/SoapClient/Event/Subscriber/ValidatorSubscriberSpec.php
+++ b/spec/Phpro/SoapClient/Event/Subscriber/ValidatorSubscriberSpec.php
@@ -4,6 +4,7 @@ namespace spec\Phpro\SoapClient\Event\Subscriber;
 
 use Phpro\SoapClient\Client;
 use Phpro\SoapClient\Event\RequestEvent;
+use Phpro\SoapClient\Event\Subscriber\ValidatorSubscriber;
 use Phpro\SoapClient\Exception\RequestException;
 use Phpro\SoapClient\Type\RequestInterface;
 use PhpSpec\ObjectBehavior;
@@ -11,7 +12,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Phpro\SoapClient\Event\Subscriber\ValidatorSubscriber;
 
 class ValidatorSubscriberSpec extends ObjectBehavior
 {
@@ -34,11 +34,16 @@ class ValidatorSubscriberSpec extends ObjectBehavior
         ValidatorInterface $validator,
         Client $client,
         RequestInterface $request,
-        ConstraintViolation $violation
+        ConstraintViolation $violation1,
+        ConstraintViolation $violation2
     ) {
         $event = new RequestEvent($client->getWrappedObject(), 'method', $request->getWrappedObject());
-        $violation->__toString()->willReturn('error');
-        $validator->validate($request)->willReturn(new ConstraintViolationList([$violation->getWrappedObject()]));
+        $violation1->getMessage()->willReturn('error 1');
+        $violation2->getMessage()->willReturn('error 2');
+        $validator->validate($request)->willReturn(new ConstraintViolationList([
+            $violation1->getWrappedObject(),
+            $violation2->getWrappedObject(),
+        ]));
         $this->shouldThrow(RequestException::class)->duringOnClientRequest($event);
     }
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/InterfaceAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/InterfaceAssembler.php
@@ -15,16 +15,16 @@ use Phpro\SoapClient\Exception\AssemblerException;
 class InterfaceAssembler implements AssemblerInterface
 {
     /**
-     * @var
+     * @var string
      */
     private $interfaceName;
 
     /**
      * InterfaceAssembler constructor.
      *
-     * @param $interfaceName
+     * @param string $interfaceName
      */
-    public function __construct($interfaceName)
+    public function __construct(string $interfaceName)
     {
         $this->interfaceName = $interfaceName;
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ResultProviderAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ResultProviderAssembler.php
@@ -28,9 +28,9 @@ class ResultProviderAssembler implements AssemblerInterface
     /**
      * ResultProviderAssembler constructor.
      *
-     * @param null $wrapperClass
+     * @param string $wrapperClass
      */
-    public function __construct($wrapperClass = null)
+    public function __construct(string $wrapperClass = null)
     {
         $this->wrapperClass = ($wrapperClass !== null) ? ltrim($wrapperClass, '\\') : null;
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/UseAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/UseAssembler.php
@@ -20,6 +20,7 @@ class UseAssembler implements AssemblerInterface
      * @var string
      */
     private $useName;
+
     /**
      * @var string
      */
@@ -27,10 +28,10 @@ class UseAssembler implements AssemblerInterface
 
     /**
      * UseAssembler constructor.
-     * @param $useName
-     * @param $useAlias
+     * @param string $useName
+     * @param string $useAlias
      */
-    public function __construct(string $useName, $useAlias = null)
+    public function __construct(string $useName, string $useAlias = null)
     {
         $this->useName = $useName;
         $this->useAlias = $useAlias;

--- a/src/Phpro/SoapClient/CodeGenerator/ClientGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClientGenerator.php
@@ -41,7 +41,7 @@ class ClientGenerator implements GeneratorInterface
      */
     public function generate(FileGenerator $file, $client): string
     {
-        $class = $file->getClass() ?: new ClassGenerator();
+        $class = $file->getClass() ?? new ClassGenerator();
         $class->setNamespaceName($client->getNamespace());
         $class->setName($client->getName());
         $methods = $client->getMethodMap();

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Parameter.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Parameter.php
@@ -29,7 +29,7 @@ class Parameter
         $this->type = Normalizer::normalizeClassnameInFQN($type);
     }
 
-    public static function fromMetadata(string $parameterNamespace, MetadataParameter $parameter)
+    public static function fromMetadata(string $parameterNamespace, MetadataParameter $parameter): Parameter
     {
         $type = $parameter->getType()->getBaseTypeOrFallbackToName();
 

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRule.php
@@ -54,6 +54,7 @@ class TypeMapRule implements RuleInterface
         }
 
         // It's possible to define a null rule, which means that no code will be generated.
+        /** @var RuleInterface|null $rule */
         $rule = $this->typeMap[$type->getName()];
         if ($rule  === null) {
             return false;

--- a/src/Phpro/SoapClient/CodeGenerator/TypeGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeGenerator.php
@@ -39,7 +39,7 @@ class TypeGenerator implements GeneratorInterface
      */
     public function generate(FileGenerator $file, $type): string
     {
-        $class = $file->getClass() ?: new ClassGenerator();
+        $class = $file->getClass() ?? new ClassGenerator();
         $class->setNamespaceName($type->getNamespace());
         $class->setName($type->getName());
 

--- a/src/Phpro/SoapClient/CodeGenerator/Util/TypeChecker.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/TypeChecker.php
@@ -19,7 +19,7 @@ class TypeChecker
     private static $internalPhpTypes = ['void', 'int', 'float', 'string', 'bool', 'array', 'callable', 'iterable'];
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return bool
      */

--- a/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
@@ -98,13 +98,17 @@ class GenerateClassmapCommand extends Command
     /**
      * Generates one type class
      *
-     * @param FileGenerator     $file
+     * @param FileGenerator $file
      * @param ClassMapGenerator $generator
-     * @param TypeMap           $typeMap
-     * @param                   $path
+     * @param TypeMap $typeMap
+     * @param string $path
      */
-    protected function generateClassmap(FileGenerator $file, ClassMapGenerator $generator, TypeMap $typeMap, $path)
-    {
+    protected function generateClassmap(
+        FileGenerator $file,
+        ClassMapGenerator $generator,
+        TypeMap $typeMap,
+        string $path
+    ) {
         $code = $generator->generate($file, $typeMap);
         $this->filesystem->putFileContents($path, $code);
     }
@@ -117,10 +121,11 @@ class GenerateClassmapCommand extends Command
      *
      * @param ClassMapGenerator $generator
      * @param TypeMap           $typeMap
-     * @param                   $path
+     * @param string            $path
+     *
      * @return bool
      */
-    protected function handleClassmap(ClassMapGenerator $generator, TypeMap $typeMap, $path): bool
+    protected function handleClassmap(ClassMapGenerator $generator, TypeMap $typeMap, string $path): bool
     {
         // Handle existing class:
         if ($this->filesystem->fileExists($path)) {

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
@@ -3,6 +3,7 @@
 namespace Phpro\SoapClient\Console\Command;
 
 use Phpro\SoapClient\CodeGenerator\ClientGenerator;
+use Phpro\SoapClient\CodeGenerator\GeneratorInterface;
 use Phpro\SoapClient\CodeGenerator\Model\Client;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethodMap;
 use Phpro\SoapClient\CodeGenerator\TypeGenerator;
@@ -101,11 +102,11 @@ class GenerateClientCommand extends Command
      * Generates one type class
      *
      * @param FileGenerator $file
-     * @param ClientGenerator|TypeGenerator $generator
+     * @param GeneratorInterface $generator
      * @param Client $client
      * @param string $path
      */
-    protected function generateClient(FileGenerator $file, ClientGenerator $generator, Client $client, $path)
+    protected function generateClient(FileGenerator $file, GeneratorInterface $generator, Client $client, string $path)
     {
         $code = $generator->generate($file, $client);
         $this->filesystem->putFileContents($path, $code);
@@ -117,12 +118,12 @@ class GenerateClientCommand extends Command
      * If patching the old class does not work: ask for an overwrite
      * Create a class from an empty file
      *
-     * @param ClientGenerator|TypeGenerator $generator
+     * @param ClientGenerator $generator
      * @param Client $client
      * @param string $path
      * @return bool
      */
-    protected function handleClient(ClientGenerator $generator, Client $client, $path)
+    protected function handleClient(ClientGenerator $generator, Client $client, string $path): bool
     {
         // Handle existing class:
         if ($this->filesystem->fileExists($path)) {
@@ -154,14 +155,14 @@ class GenerateClientCommand extends Command
     /**
      * An existing file was found. Try to patch or ask if it can be overwritten.
      *
-     * @param TypeGenerator $generator
+     * @param GeneratorInterface $generator
      * @param Client $client
      * @param string $path
      * @return bool
      */
-    protected function handleExistingFile(TypeGenerator $generator, Client $client, $path)
+    protected function handleExistingFile(GeneratorInterface $generator, Client $client, $path): bool
     {
-        $this->output->write(sprintf('Type %s exists. Trying to patch ...', $client->getName()));
+        $this->output->write(sprintf('Class %s exists. Trying to patch ...', $client->getName()));
         $patched = $this->patchExistingFile($generator, $client, $path);
 
         if ($patched) {
@@ -178,13 +179,13 @@ class GenerateClientCommand extends Command
     /**
      * This method tries to patch an existing type class.
      *
-     * @param TypeGenerator $generator
+     * @param GeneratorInterface $generator
      * @param Client $client
      * @param string $path
      * @return bool
      * @internal param Type $type
      */
-    protected function patchExistingFile(TypeGenerator $generator, Client $client, $path)
+    protected function patchExistingFile(GeneratorInterface $generator, Client $client, $path): bool
     {
         try {
             $this->filesystem->createBackup($path);
@@ -203,7 +204,7 @@ class GenerateClientCommand extends Command
     /**
      * @return bool
      */
-    protected function askForOverwrite()
+    protected function askForOverwrite(): bool
     {
         $overwriteByDefault = $this->input->getOption('overwrite');
         $question = new ConfirmationQuestion('Do you want to overwrite it?', $overwriteByDefault);

--- a/src/Phpro/SoapClient/Console/Helper/ConfigHelper.php
+++ b/src/Phpro/SoapClient/Console/Helper/ConfigHelper.php
@@ -33,7 +33,7 @@ class ConfigHelper extends Helper
     /**
      * Attempts to load the configuration file, returns it on success
      * @param InputInterface $input
-     * @return Config
+     * @return ConfigInterface
      */
     public function load(InputInterface $input): ConfigInterface
     {

--- a/src/Phpro/SoapClient/Event/Subscriber/ValidatorSubscriber.php
+++ b/src/Phpro/SoapClient/Event/Subscriber/ValidatorSubscriber.php
@@ -6,6 +6,8 @@ use Phpro\SoapClient\Event\RequestEvent;
 use Phpro\SoapClient\Events;
 use Phpro\SoapClient\Exception\RequestException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class ValidatorSubscriber implements EventSubscriberInterface
@@ -26,6 +28,16 @@ class ValidatorSubscriber implements EventSubscriberInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::REQUEST => 'onClientRequest',
+        ];
+    }
+
+    /**
      * @param RequestEvent $event
      *
      * @throws \Phpro\SoapClient\Exception\RequestException
@@ -35,17 +47,18 @@ class ValidatorSubscriber implements EventSubscriberInterface
         $errors = $this->validator->validate($event->getRequest());
 
         if (count($errors)) {
-            throw new RequestException((string) $errors);
+            throw new RequestException(self::toString($errors));
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function getSubscribedEvents(): array
+    private static function toString(ConstraintViolationListInterface $errors): string
     {
-        return [
-            Events::REQUEST  => 'onClientRequest',
-        ];
+        $strErrors = [];
+        /** @var ConstraintViolationInterface $error */
+        foreach ($errors as $error) {
+            $strErrors[] = $error->getMessage();
+        }
+
+        return implode(PHP_EOL, $strErrors);
     }
 }

--- a/src/Phpro/SoapClient/Exception/MiddlewareException.php
+++ b/src/Phpro/SoapClient/Exception/MiddlewareException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Phpro\SoapClient\Exception;
+
+use Http\Client\Exception;
+use Throwable;
+
+class MiddlewareException extends RuntimeException
+{
+    public static function fromHttPlugException(Exception $exception): self
+    {
+        if ($exception instanceof Throwable) {
+            return new self($exception->getMessage(), $exception->getCode(), $exception);
+        }
+
+        return new self('Something went wrong: '.get_class($exception));
+    }
+}

--- a/src/Phpro/SoapClient/Middleware/Middleware.php
+++ b/src/Phpro/SoapClient/Middleware/Middleware.php
@@ -6,6 +6,7 @@ use Http\Client\Exception;
 use Http\Promise\Promise;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Throwable;
 
 /**
  * Class Middleware
@@ -44,6 +45,10 @@ class Middleware implements MiddlewareInterface
 
     public function onError(Exception $exception)
     {
+        if (!$exception instanceof Throwable) {
+            return;
+        }
+
         throw $exception;
     }
 }

--- a/src/Phpro/SoapClient/Middleware/Middleware.php
+++ b/src/Phpro/SoapClient/Middleware/Middleware.php
@@ -4,9 +4,9 @@ namespace Phpro\SoapClient\Middleware;
 
 use Http\Client\Exception;
 use Http\Promise\Promise;
+use Phpro\SoapClient\Exception\MiddlewareException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Throwable;
 
 /**
  * Class Middleware
@@ -45,10 +45,6 @@ class Middleware implements MiddlewareInterface
 
     public function onError(Exception $exception)
     {
-        if (!$exception instanceof Throwable) {
-            return;
-        }
-
-        throw $exception;
+        throw MiddlewareException::fromHttPlugException($exception);
     }
 }

--- a/src/Phpro/SoapClient/Middleware/RemoveEmptyNodesMiddleware.php
+++ b/src/Phpro/SoapClient/Middleware/RemoveEmptyNodesMiddleware.php
@@ -4,6 +4,7 @@ namespace Phpro\SoapClient\Middleware;
 
 use Http\Promise\Promise;
 use Phpro\SoapClient\Xml\SoapXml;
+use Phpro\SoapClient\Xml\Xml;
 use Psr\Http\Message\RequestInterface;
 
 class RemoveEmptyNodesMiddleware extends Middleware
@@ -18,7 +19,7 @@ class RemoveEmptyNodesMiddleware extends Middleware
         $xml = SoapXml::fromStream($request->getBody());
 
         // remove all empty nodes
-        while (($notNodes = $xml->xpath('//*[not(node())]')) && ($notNodes->length)) {
+        while ($notNodes = $this->getNotNodes($xml)) {
             foreach ($notNodes as $node) {
                 $node->parentNode->removeChild($node);
             }
@@ -27,5 +28,15 @@ class RemoveEmptyNodesMiddleware extends Middleware
         $request = $request->withBody($xml->toStream());
 
         return $handler($request);
+    }
+
+    private function getNotNodes(Xml $xml): ?\DOMNodeList
+    {
+        $notNodes = $xml->xpath('//*[not(node())]');
+        if (!$notNodes->length) {
+            return null;
+        }
+
+        return $notNodes;
     }
 }

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/AbusedClient.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/AbusedClient.php
@@ -10,12 +10,12 @@ use Phpro\SoapClient\Soap\HttpBinding\SoapResponse;
 class AbusedClient extends \SoapClient
 {
     /**
-     * @var SoapRequest
+     * @var SoapRequest|null
      */
     protected $storedRequest;
 
     /**
-     * @var SoapResponse
+     * @var SoapResponse|null
      */
     protected $storedResponse;
 

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Model/Parameter.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Model/Parameter.php
@@ -12,7 +12,7 @@ class Parameter
     private $name;
 
     /**
-     * @var string
+     * @var XsdType
      */
     private $type;
 

--- a/src/Phpro/SoapClient/Soap/HttpBinding/Converter/Psr7Converter.php
+++ b/src/Phpro/SoapClient/Soap/HttpBinding/Converter/Psr7Converter.php
@@ -21,12 +21,12 @@ use Psr\Http\Message\StreamFactoryInterface;
 class Psr7Converter
 {
     /**
-     * @var RequestFactoryInterface
+     * @var MessageFactory
      */
     private $messageFactory;
 
     /**
-     * @var StreamFactoryInterface
+     * @var StreamFactory
      */
     private $streamFactory;
 

--- a/src/Phpro/SoapClient/Xml/SoapXml.php
+++ b/src/Phpro/SoapClient/Xml/SoapXml.php
@@ -44,8 +44,11 @@ class SoapXml extends Xml
         if (!$body = $this->getBody()) {
             return null;
         }
+        if ($body->firstChild === null) {
+            return null;
+        }
 
-        return $body->firstChild ? $body->firstChild->namespaceURI : null;
+        return $body->firstChild->namespaceURI;
     }
 
     /**
@@ -92,9 +95,9 @@ class SoapXml extends Xml
     }
 
     /**
-     * @return DOMElement|null
+     * @return \DOMNode|null
      */
-    public function getBody(): ?DOMElement
+    public function getBody(): ?\DOMNode
     {
         $list = $this->xpath('//soap:Envelope/soap:Body');
 

--- a/src/Phpro/SoapClient/Xml/Xml.php
+++ b/src/Phpro/SoapClient/Xml/Xml.php
@@ -4,6 +4,7 @@ namespace Phpro\SoapClient\Xml;
 
 use DOMDocument;
 use DOMElement;
+use DOMNode;
 use DOMXPath;
 use Http\Discovery\StreamFactoryDiscovery;
 use Psr\Http\Message\StreamInterface;
@@ -75,7 +76,7 @@ class Xml
      *
      * @return \DOMNodeList
      */
-    public function xpath(string $expression, \DOMNode $contextNode = null): \DOMNodeList
+    public function xpath(string $expression, DOMNode $contextNode = null): \DOMNodeList
     {
         return $this->xpath->query($expression, $contextNode);
     }


### PR DESCRIPTION
Going up some levels in PHPStan.

New ignores explained:
```
'#Call to an undefined method Phpro\\.*Interface.*$#'
```
The issue we discussed in the chat about the interfaces, hopefully we can fix this in php 7.5

```
'#Invalid type Http\\Client\\Exception to throw.#' 
```
It's an interface that is not throwable, I'll allow it.

More levels next time I get to work on this.