### PR TITLE
remove decrecaptions for Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "ext-dom": "*",
     "ext-xml": "*",
     "psr/log": "^1.0",
-    "symfony/console": "~2.8|~3.0|~4.0",
-    "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-    "symfony/filesystem": "~2.8|~3.0|~4.0",
-    "symfony/options-resolver": "~2.8|~3.0|~4.0"
+    "symfony/console": "~2.8|~3.0|~4.0|~5.0",
+    "symfony/event-dispatcher": "~2.8|~3.0|~4.0|~5.0",
+    "symfony/filesystem": "~2.8|~3.0|~4.0|~5.0",
+    "symfony/options-resolver": "~2.8|~3.0|~4.0|~5.0"
   },
   "require-dev": {
     "ext-soap": "*",
@@ -34,7 +34,7 @@
     "php-http/message": "^1.6",
     "php-http/message-factory": "^1.0",
     "php-http/mock-client": "^1.0",
-    "php-vcr/php-vcr": "~1.3.2",
+    "php-vcr/php-vcr": "~1.4.4",
     "php-vcr/phpunit-testlistener-vcr": "3.0",
     "phpro/grumphp": "~0.15",
     "phpspec/phpspec": "~5.1",
@@ -46,7 +46,7 @@
     "robrichards/wse-php": "^2.0.2",
     "robrichards/xmlseclibs": "^3.0",
     "squizlabs/php_codesniffer": "~2.9",
-    "symfony/validator": "~2.8|~3.0|~4.0",
+    "symfony/validator": "~2.8|~3.0|~4.0|~5.0",
     "zendframework/zend-code": "^3.3.1"
   },
   "suggest": {

--- a/spec/Phpro/SoapClient/Event/FaultEventSpec.php
+++ b/spec/Phpro/SoapClient/Event/FaultEventSpec.php
@@ -3,16 +3,15 @@
 namespace spec\Phpro\SoapClient\Event;
 
 use Phpro\SoapClient\Client;
+use Phpro\SoapClient\Event\AbstractEvent;
 use Phpro\SoapClient\Event\FaultEvent;
 use Phpro\SoapClient\Event\RequestEvent;
 use Phpro\SoapClient\Exception\SoapException;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Symfony\Component\EventDispatcher\Event;
 
 class FaultEventSpec extends ObjectBehavior
 {
-    function let(Client $client,SoapException $soapException, RequestEvent $requestEvent)
+    function let(Client $client, SoapException $soapException, RequestEvent $requestEvent)
     {
         $this->beConstructedWith($client, $soapException, $requestEvent);
     }
@@ -24,7 +23,7 @@ class FaultEventSpec extends ObjectBehavior
 
     function it_is_an_event()
     {
-        $this->shouldHaveType(Event::class);
+        $this->shouldHaveType(AbstractEvent::class);
     }
 
     function it_should_know_the_request_event(RequestEvent $requestEvent)

--- a/spec/Phpro/SoapClient/Event/RequestEventSpec.php
+++ b/spec/Phpro/SoapClient/Event/RequestEventSpec.php
@@ -3,10 +3,9 @@
 namespace spec\Phpro\SoapClient\Event;
 
 use Phpro\SoapClient\Client;
+use Phpro\SoapClient\Event\AbstractEvent;
 use Phpro\SoapClient\Type\RequestInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Symfony\Component\EventDispatcher\Event;
 
 class RequestEventSpec extends ObjectBehavior
 {
@@ -22,7 +21,7 @@ class RequestEventSpec extends ObjectBehavior
 
     function it_is_an_event()
     {
-        $this->shouldHaveType(Event::class);
+        $this->shouldHaveType(AbstractEvent::class);
     }
 
     function it_should_know_the_request_method()

--- a/spec/Phpro/SoapClient/Event/ResponseEventSpec.php
+++ b/spec/Phpro/SoapClient/Event/ResponseEventSpec.php
@@ -3,12 +3,11 @@
 namespace spec\Phpro\SoapClient\Event;
 
 use Phpro\SoapClient\Client;
+use Phpro\SoapClient\Event\AbstractEvent;
 use Phpro\SoapClient\Event\RequestEvent;
 use Phpro\SoapClient\Event\ResponseEvent;
 use Phpro\SoapClient\Type\ResultInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Symfony\Component\EventDispatcher\Event;
 
 class ResponseEventSpec extends ObjectBehavior
 {
@@ -24,7 +23,7 @@ class ResponseEventSpec extends ObjectBehavior
 
     function it_is_an_event()
     {
-        $this->shouldHaveType(Event::class);
+        $this->shouldHaveType(AbstractEvent::class);
     }
 
     function it_should_know_the_request_event(RequestEvent $requestEvent)

--- a/src/Phpro/SoapClient/Client.php
+++ b/src/Phpro/SoapClient/Client.php
@@ -13,7 +13,6 @@ use Phpro\SoapClient\Type\ResultProviderInterface;
 use Phpro\SoapClient\Util\XmlFormatter;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyContractEventDispatcherInterface;
 
 /**
  * Class Client
@@ -66,8 +65,8 @@ class Client implements ClientInterface
      */
     private function dispatch(string $eventName, SymfonyEvent $event = null): void
     {
-        if (interface_exists(SymfonyContractEventDispatcherInterface::class)
-            && $this->dispatcher instanceof SymfonyContractEventDispatcherInterface) {
+        $interfacesImplemented = class_implements($this->dispatcher);
+        if (in_array('Symfony\Contracts\EventDispatcher\EventDispatcherInterface', $interfacesImplemented)) {
             $this->dispatcher->dispatch($event, $eventName);
         } else {
             $this->dispatcher->dispatch($eventName, $event);

--- a/src/Phpro/SoapClient/Client.php
+++ b/src/Phpro/SoapClient/Client.php
@@ -12,7 +12,6 @@ use Phpro\SoapClient\Type\ResultInterface;
 use Phpro\SoapClient\Type\ResultProviderInterface;
 use Phpro\SoapClient\Util\XmlFormatter;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
 
 /**
  * Class Client
@@ -60,14 +59,14 @@ class Client implements ClientInterface
     /**
      * For backward compatibility with Symfony 4
      *
-     * @param string            $eventName
-     * @param SymfonyEvent|null $event
+     * @param string $eventName
+     * @param Event\AbstractEvent  $event
      */
-    private function dispatch(string $eventName, SymfonyEvent $event = null): void
+    private function dispatch(string $eventName, Event\AbstractEvent $event = null): void
     {
         $interfacesImplemented = class_implements($this->dispatcher);
         if (in_array('Symfony\Contracts\EventDispatcher\EventDispatcherInterface', $interfacesImplemented)) {
-            $this->dispatcher->dispatch($event, $eventName);
+            $this->dispatcher->dispatch($event);
         } else {
             $this->dispatcher->dispatch($eventName, $event);
         }

--- a/src/Phpro/SoapClient/Client.php
+++ b/src/Phpro/SoapClient/Client.php
@@ -13,6 +13,7 @@ use Phpro\SoapClient\Type\ResultProviderInterface;
 use Phpro\SoapClient\Util\XmlFormatter;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as SymfonyContractEventDispatcherInterface;
 
 /**
  * Class Client
@@ -65,8 +66,8 @@ class Client implements ClientInterface
      */
     private function dispatch(string $eventName, SymfonyEvent $event = null): void
     {
-        if (interface_exists('\Symfony\Contracts\EventDispatcher\EventDispatcherInterface')
-            && $this->dispatcher instanceof \Symfony\Contracts\EventDispatcher\EventDispatcherInterface) {
+        if (interface_exists(SymfonyContractEventDispatcherInterface::class)
+            && $this->dispatcher instanceof SymfonyContractEventDispatcherInterface) {
             $this->dispatcher->dispatch($event, $eventName);
         } else {
             $this->dispatcher->dispatch($eventName, $event);

--- a/src/Phpro/SoapClient/Client.php
+++ b/src/Phpro/SoapClient/Client.php
@@ -65,7 +65,8 @@ class Client implements ClientInterface
      */
     private function dispatch(string $eventName, SymfonyEvent $event = null): void
     {
-        if (interface_exists('\Symfony\Contracts\EventDispatcher\EventDispatcherInterface') && $this->dispatcher instanceof \Symfony\Contracts\EventDispatcher\EventDispatcherInterface) {
+        if (interface_exists('\Symfony\Contracts\EventDispatcher\EventDispatcherInterface')
+            && $this->dispatcher instanceof \Symfony\Contracts\EventDispatcher\EventDispatcherInterface) {
             $this->dispatcher->dispatch($event, $eventName);
         } else {
             $this->dispatcher->dispatch($eventName, $event);

--- a/src/Phpro/SoapClient/Event/AbstractEvent.php
+++ b/src/Phpro/SoapClient/Event/AbstractEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phpro\SoapClient\Event;
+
+/**
+ * For backward compatibility with Symfony 4
+ */
+if (class_exists('Symfony\Contracts\EventDispatcher\Event')) {
+    abstract class AbstractEvent extends \Symfony\Contracts\EventDispatcher\Event
+    {
+    }
+} else {
+    abstract class AbstractEvent extends \Symfony\Component\EventDispatcher\Event
+    {
+    }
+}

--- a/src/Phpro/SoapClient/Event/FaultEvent.php
+++ b/src/Phpro/SoapClient/Event/FaultEvent.php
@@ -4,14 +4,13 @@ namespace Phpro\SoapClient\Event;
 
 use Phpro\SoapClient\Client;
 use Phpro\SoapClient\Exception\SoapException;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class FaultEvent
  *
  * @package Phpro\SoapClient\Event
  */
-class FaultEvent extends Event
+class FaultEvent extends AbstractEvent
 {
 
     /**

--- a/src/Phpro/SoapClient/Event/RequestEvent.php
+++ b/src/Phpro/SoapClient/Event/RequestEvent.php
@@ -4,14 +4,13 @@ namespace Phpro\SoapClient\Event;
 
 use Phpro\SoapClient\Client;
 use Phpro\SoapClient\Type\RequestInterface;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class RequestEvent
  *
  * @package Phpro\SoapClient\Event
  */
-class RequestEvent extends Event
+class RequestEvent extends AbstractEvent
 {
     /**
      * @var string

--- a/src/Phpro/SoapClient/Event/ResponseEvent.php
+++ b/src/Phpro/SoapClient/Event/ResponseEvent.php
@@ -3,14 +3,13 @@ namespace Phpro\SoapClient\Event;
 
 use Phpro\SoapClient\Client;
 use Phpro\SoapClient\Type\ResultInterface;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class ResponseEvent
  *
  * @package Phpro\SoapClient\Event
  */
-class ResponseEvent extends Event
+class ResponseEvent extends AbstractEvent
 {
     /**
      * @var RequestEvent
@@ -28,8 +27,8 @@ class ResponseEvent extends Event
     protected $client;
 
     /**
-     * @param Client $client
-     * @param RequestEvent $requestEvent
+     * @param Client          $client
+     * @param RequestEvent    $requestEvent
      * @param ResultInterface $response
      */
     public function __construct(Client $client, RequestEvent $requestEvent, ResultInterface $response)


### PR DESCRIPTION
Remove the deprecations for Symfony 4 applications, but still maintain backward compatibility with older versions.
Resolve https://github.com/phpro/soap-client/issues/249