### PR TITLE
Register last soap request and response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "php-http/message-factory": "^1.0",
     "php-http/mock-client": "^1.3",
     "php-vcr/php-vcr": "~1.4.4",
-    "phpro/grumphp": "~0.17",
+    "phpro/grumphp": "~0.17.1",
     "phpspec/phpspec": "~6.1",
     "phpstan/phpstan": "^0.11.19",
     "phpunit/phpunit": "~8.5",

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/AbusedClient.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/AbusedClient.php
@@ -19,6 +19,24 @@ class AbusedClient extends \SoapClient
      */
     protected $storedResponse;
 
+    // @codingStandardsIgnoreStart
+    /**
+     * Internal SoapClient property for storing last request.
+     *
+     * @var string
+     */
+    protected $__last_request = '';
+    // @codingStandardsIgnoreEnd
+
+    // @codingStandardsIgnoreStart
+    /**
+     * Internal SoapClient property for storing last response.
+     *
+     * @var string
+     */
+    protected $__last_response = '';
+    // @codingStandardsIgnoreEnd
+
     public function __construct($wsdl, array $options = [])
     {
         $options = ExtSoapOptionsResolverFactory::createForWsdl($wsdl)->resolve($options);
@@ -44,8 +62,10 @@ class AbusedClient extends \SoapClient
         int $version,
         int $oneWay = 0
     ): string {
+        $this->__last_request = $request;
         $this->__last_response = (string) parent::__doRequest($request, $location, $action, $version, $oneWay);
-        return $this->__getLastResponse();
+
+        return $this->__last_response;
     }
 
     public function collectRequest(): SoapRequest


### PR DESCRIPTION
Fixes #246, Fixes #247 
Internal test-suite already checks last request / response