### PR TITLE
Add return 0 for compability with symfomy parent console command

### DIFF
--- a/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
@@ -92,6 +92,8 @@ class GenerateClassmapCommand extends Command
         $this->handleClassmap($generator, $typeMap, $path);
 
         $io->success('Generated classmap at ' . $path);
+        
+        return 0;
     }
 
 

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
@@ -96,6 +96,8 @@ class GenerateClientCommand extends Command
         );
 
         $io->success('Generated client at ' . $destination);
+        
+        return 0;
     }
 
     /**

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
@@ -72,6 +72,8 @@ class GenerateClientFactoryCommand extends Command
         $this->filesystem->putFileContents($dest, $generator->generate(new FileGenerator(), $context));
 
         $io->success('Generated client factory at ' . $dest);
+
+        return 0;
     }
 
     /**

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -101,6 +101,8 @@ CONFIRMATION;
         $generator = new ConfigGenerator();
         $this->filesystem->putFileContents($destination, $generator->generate(new FileGenerator(), $context));
         $io->success('Config has been written to ' . $destination);
+
+        return 0;
     }
 
     private function addNonEmptySetter(ConfigContext $context, string $key, string $value)

--- a/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
@@ -93,6 +93,8 @@ class GenerateTypesCommand extends Command
         }
 
         $io->success('All SOAP types generated');
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Add return status code for fix exception 
`PHP Fatal error:  Uncaught TypeError: Return value of "Phpro\SoapClient\Console\Command\GenerateTypesCommand::execute()" must be of the type int, NULL returned. in /Users/user/soap-client/vendor/symfony/console/Command/Command.php:258`
See changes https://github.com/symfony/console/commit/87f6898fe35f68cf22473e3f43145c70a8795ea4