### PR TITLE
Migration from zend-code to laminas-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Since life is too short to read documentation,
 All you need to do is:
 
 ```sh
-composer require --dev zendframework/zend-code:^3.1.0
+composer require --dev laminas/laminas-code:^3.1.0
 ./vendor/bin/soap-client wizard
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,77 +1,81 @@
 {
-  "name": "phpro/soap-client",
-  "description": "A general purpose SoapClient library",
-  "keywords": ["soap"],
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Toon Verwerft",
-      "email": "toon.verwerft@phpro.be"
+    "name": "phpro/soap-client",
+    "description": "A general purpose SoapClient library",
+    "keywords": [
+        "soap"
+    ],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Toon Verwerft",
+            "email": "toon.verwerft@phpro.be"
+        }
+    ],
+    "require": {
+        "php": "^7.2",
+        "ext-dom": "*",
+        "ext-xml": "*",
+        "psr/event-dispatcher": "^1.0",
+        "psr/log": "^1.0",
+        "symfony/console": "~3.4|~4.0|~5.0",
+        "symfony/event-dispatcher": "~3.4|~4.0|~5.0",
+        "symfony/filesystem": "~3.4|~4.0|~5.0",
+        "symfony/options-resolver": "~3.4|~4.0|~5.0"
+    },
+    "require-dev": {
+        "ext-soap": "*",
+        "guzzlehttp/guzzle": "^6.4.1",
+        "guzzlehttp/promises": "^1.3.1",
+        "guzzlehttp/psr7": "^1.6.1",
+        "jakub-onderka/php-parallel-lint": "^1.0",
+        "php-http/client-common": "^1.10",
+        "php-http/discovery": "^1.7",
+        "php-http/guzzle6-adapter": "^1.1.1",
+        "php-http/httplug": "^1.1",
+        "php-http/message": "^1.8",
+        "php-http/message-factory": "^1.0",
+        "php-http/mock-client": "^1.3",
+        "php-vcr/php-vcr": "~1.4.4",
+        "phpro/grumphp": "~0.17.1",
+        "phpspec/phpspec": "~6.1",
+        "phpstan/phpstan": "^0.11.19",
+        "phpunit/phpunit": "~8.5",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0.1",
+        "robrichards/wse-php": "^2.0.3",
+        "robrichards/xmlseclibs": "^3.0",
+        "squizlabs/php_codesniffer": "~2.9",
+        "symfony/validator": "~3.4|~4.0|~5.0",
+        "laminas/laminas-code": "^3.4.0"
+    },
+    "suggest": {
+        "ext-soap": "If you want to use PHP's ext-soap driver.",
+        "php-http/client-implementation": "For gaining control over the HTTP layer",
+        "phpro/annotated-cache": "For caching SOAP responses",
+        "psr/log-implementation": "For logging SOAP requests, responses and errors",
+        "psr/http-message": "For gaining control over the HTTP layer",
+        "php-http/httplug": "For gaining control over the HTTP layer",
+        "php-http/message-factory": "For gaining control over the HTTP layer",
+        "php-http/discovery": "For gaining control over the HTTP layer",
+        "php-http/message": "For gaining control over the HTTP layer",
+        "php-http/client-common": "For gaining control over the HTTP layer",
+        "robrichards/wse-php": "If you want to use the WSA or WSSE middleware",
+        "symfony/validator": "If you easily want to validate SOAP requests / responses manually"
+    },
+    "autoload": {
+        "psr-0": {
+            "Phpro\\SoapClient\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "PhproTest\\SoapClient\\": "test/"
+        }
+    },
+    "bin": [
+        "bin/soap-client"
+    ],
+    "config": {
+        "sort-packages": true
     }
-  ],
-  "require": {
-    "php": "^7.2",
-    "ext-dom": "*",
-    "ext-xml": "*",
-    "psr/event-dispatcher": "^1.0",
-    "psr/log": "^1.0",
-    "symfony/console": "~3.4|~4.0|~5.0",
-    "symfony/event-dispatcher": "~3.4|~4.0|~5.0",
-    "symfony/filesystem": "~3.4|~4.0|~5.0",
-    "symfony/options-resolver": "~3.4|~4.0|~5.0"
-  },
-  "require-dev": {
-    "ext-soap": "*",
-    "guzzlehttp/guzzle": "^6.4.1",
-    "guzzlehttp/promises": "^1.3.1",
-    "guzzlehttp/psr7": "^1.6.1",
-    "jakub-onderka/php-parallel-lint": "^1.0",
-    "php-http/client-common": "^1.10",
-    "php-http/discovery": "^1.7",
-    "php-http/guzzle6-adapter": "^1.1.1",
-    "php-http/httplug": "^1.1",
-    "php-http/message": "^1.8",
-    "php-http/message-factory": "^1.0",
-    "php-http/mock-client": "^1.3",
-    "php-vcr/php-vcr": "~1.4.4",
-    "phpro/grumphp": "~0.17.1",
-    "phpspec/phpspec": "~6.1",
-    "phpstan/phpstan": "^0.11.19",
-    "phpunit/phpunit": "~8.5",
-    "psr/http-factory": "^1.0",
-    "psr/http-message": "^1.0.1",
-    "robrichards/wse-php": "^2.0.3",
-    "robrichards/xmlseclibs": "^3.0",
-    "squizlabs/php_codesniffer": "~2.9",
-    "symfony/validator": "~3.4|~4.0|~5.0",
-    "zendframework/zend-code": "^3.4.0"
-  },
-  "suggest": {
-    "ext-soap": "If you want to use PHP's ext-soap driver.",
-    "php-http/client-implementation": "For gaining control over the HTTP layer",
-    "phpro/annotated-cache": "For caching SOAP responses",
-    "psr/log-implementation": "For logging SOAP requests, responses and errors",
-    "psr/http-message": "For gaining control over the HTTP layer",
-    "php-http/httplug": "For gaining control over the HTTP layer",
-    "php-http/message-factory": "For gaining control over the HTTP layer",
-    "php-http/discovery": "For gaining control over the HTTP layer",
-    "php-http/message": "For gaining control over the HTTP layer",
-    "php-http/client-common": "For gaining control over the HTTP layer",
-    "robrichards/wse-php": "If you want to use the WSA or WSSE middleware",
-    "symfony/validator": "If you easily want to validate SOAP requests / responses manually"
-  },
-  "autoload": {
-    "psr-0": {
-      "Phpro\\SoapClient\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-0": {
-      "PhproTest\\SoapClient\\": "test/"
-    }
-  },
-  "bin": ["bin/soap-client"],
-  "config": {
-    "sort-packages": true
-  }
 }

--- a/docs/cli/generate-classmap.md
+++ b/docs/cli/generate-classmap.md
@@ -2,7 +2,7 @@
 
 Before you can generate code, you'll need to add some additional dev dependencies to your project:
 ```sh
-composer require --dev zendframework/zend-code:^3.1.0
+composer require --dev laminas/laminas-code:^3.1.0
 ```
 
 When the value-objects are generated, we need to tell SOAP about how the PHP classes are mapped to the XSD types.

--- a/docs/cli/generate-client.md
+++ b/docs/cli/generate-client.md
@@ -2,7 +2,7 @@
 
 Before you can generate code, you'll need to add some additional dev dependencies to your project:
 ```sh
-composer require --dev zendframework/zend-code:^3.1.0
+composer require --dev laminas/laminas-code:^3.1.0
 ```
 
 A client with type and return type hints can be generated.

--- a/docs/cli/generate-types.md
+++ b/docs/cli/generate-types.md
@@ -2,7 +2,7 @@
 
 Before you can generate code, you'll need to add some additional dev dependencies to your project:
 ```sh
-composer require --dev zendframework/zend-code:^3.1.0
+composer require --dev laminas/laminas-code:^3.1.0
 ```
 
 Basic value-objects can be generated automatically.

--- a/docs/code-generation/assemblers.md
+++ b/docs/code-generation/assemblers.md
@@ -1,6 +1,6 @@
 # Code assemblers
 
-Code assemblers are a thin layer above [zend-code](https://github.com/zendframework/zend-code).
+Code assemblers are a thin layer above [laminas-code](https://github.com/laminas/laminas-code).
 There are a lot of built-in assemblers but it is also possible to create your own assembler 
 to generate the code you want to add to the generated SOAP types.
  
@@ -440,7 +440,7 @@ Example output:
 
 Creating your own Assembler is pretty easy. 
 The only thing you'll need to do is implementing the `AssemblerInterface`.
-You can use the [zend-code](https://github.com/zendframework/zend-code) `ClassGenerator` and `FileGenerator` to manipulate your code.
+You can use the [laminas-code](https://github.com/laminas/laminas-code) `ClassGenerator` and `FileGenerator` to manipulate your code.
 
 ```php
 /**

--- a/spec/Phpro/SoapClient/CodeGenerator/ClassMapGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/ClassMapGeneratorSpec.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSetInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class ClassMapGeneratorSpec

--- a/spec/Phpro/SoapClient/CodeGenerator/ClientFactoryGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/ClientFactoryGeneratorSpec.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\GeneratorInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Phpro\SoapClient\CodeGenerator\ClientFactoryGenerator;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class ClientFactoryGeneratorSpec

--- a/spec/Phpro/SoapClient/CodeGenerator/ClientGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/ClientGeneratorSpec.php
@@ -13,8 +13,8 @@ use Phpro\SoapClient\CodeGenerator\Model\Parameter;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSetInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class ClientGeneratorSpec

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClassMapContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClassMapContextSpec.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class ClassMapContextSpec

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContextSpec.php
@@ -10,7 +10,7 @@ use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Phpro\SoapClient\CodeGenerator\Context\ClientFactoryContext;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class ClientFactoryContextSpec

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/MethodContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/MethodContextSpec.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
 use PhpSpec\ObjectBehavior;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class ClientMethodContextSpec

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/PropertyContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/PropertyContextSpec.php
@@ -8,7 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class PropertyContextSpec

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/TypeContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/TypeContextSpec.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class TypeContextSpec

--- a/spec/Phpro/SoapClient/CodeGenerator/TypeGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/TypeGeneratorSpec.php
@@ -12,8 +12,8 @@ use Phpro\SoapClient\CodeGenerator\Rules\RuleSetInterface;
 use Phpro\SoapClient\CodeGenerator\TypeGenerator;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class TypeGeneratorSpec

--- a/spec/Phpro/SoapClient/CodeGenerator/Util/ValidatorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Util/ValidatorSpec.php
@@ -18,16 +18,16 @@ class ValidatorSpec extends ObjectBehavior
         $this->shouldHaveType(Validator::class);
     }
 
-    function it_can_tell_what_commands_need_zend_code()
+    function it_can_tell_what_commands_need_laminas_code()
     {
-        $this->commandRequiresZendCode('wizard')->shouldBe(true);
-        $this->commandRequiresZendCode('generate')->shouldBe(true);
-        $this->commandRequiresZendCode('generate:something')->shouldBe(true);
-        $this->commandRequiresZendCode('list')->shouldBe(false);
+        $this->commandRequiresLaminasCode('wizard')->shouldBe(true);
+        $this->commandRequiresLaminasCode('generate')->shouldBe(true);
+        $this->commandRequiresLaminasCode('generate:something')->shouldBe(true);
+        $this->commandRequiresLaminasCode('list')->shouldBe(false);
     }
 
-    function it_can_tell_if_zend_code_is_installed()
+    function it_can_tell_if_laminas_code_is_installed()
     {
-        $this->zendCodeIsInstalled()->shouldBe(true);
+        $this->laminasCodeIsInstalled()->shouldBe(true);
     }
 }

--- a/spec/Phpro/SoapClient/Console/Event/Subscriber/LaminasCodeValidationSubscriberSpec.php
+++ b/spec/Phpro/SoapClient/Console/Event/Subscriber/LaminasCodeValidationSubscriberSpec.php
@@ -2,20 +2,20 @@
 
 namespace spec\Phpro\SoapClient\Console\Event\Subscriber;
 
-use Phpro\SoapClient\Console\Event\Subscriber\ZendCodeValidationSubscriber;
+use Phpro\SoapClient\Console\Event\Subscriber\LaminasCodeValidationSubscriber;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Class ZendCodeValidationSubscriberSpec
+ * Class LaminasCodeValidationSubscriberSpec
  * @package spec\Phpro\SoapClient\Event
  */
-class ZendCodeValidationSubscriberSpec extends ObjectBehavior
+class LaminasCodeValidationSubscriberSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType(ZendCodeValidationSubscriber::class);
+        $this->shouldHaveType(LaminasCodeValidationSubscriber::class);
     }
 
     function it_be_an_eventsubsciberinterface()

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClassMapAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClassMapAssembler.php
@@ -8,8 +8,8 @@ use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Phpro\SoapClient\Soap\ClassMap\ClassMap;
 use Phpro\SoapClient\Soap\ClassMap\ClassMapCollection;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class ClassMapAssembler

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
@@ -6,7 +6,7 @@ use Phpro\SoapClient\Client;
 use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Phpro\SoapClient\Exception\SoapException;
 use Phpro\SoapClient\Type\MultiArgumentRequest;

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
@@ -12,10 +12,10 @@ use Phpro\SoapClient\Exception\SoapException;
 use Phpro\SoapClient\Type\MultiArgumentRequest;
 use Phpro\SoapClient\Type\RequestInterface;
 use Phpro\SoapClient\Type\ResultInterface;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\DocBlockGenerator;
-use Zend\Code\Generator\MethodGenerator;
-use Zend\Code\Generator\ParameterGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\DocBlockGenerator;
+use Laminas\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\ParameterGenerator;
 
 class ClientMethodAssembler implements AssemblerInterface
 {

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class ConstructorAssembler
@@ -62,7 +62,7 @@ class ConstructorAssembler implements AssemblerInterface
      * @param Type $type
      *
      * @return MethodGenerator
-     * @throws \Zend\Code\Generator\Exception\InvalidArgumentException
+     * @throws \Laminas\Code\Generator\Exception\InvalidArgumentException
      */
     private function assembleConstructor(Type $type): MethodGenerator
     {

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
@@ -5,7 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendAssembler.php
@@ -5,7 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class ExtendAssembler

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssembler.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\CodeGenerator\Util\TypeChecker;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssembler.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\CodeGenerator\Util\TypeChecker;
 use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class SetterAssembler

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
@@ -8,7 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class GetterAssembler

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
@@ -6,7 +6,7 @@ use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class ImmutableSetterAssembler

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
@@ -5,7 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/IteratorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/IteratorAssembler.php
@@ -5,7 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\MethodGenerator;

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/IteratorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/IteratorAssembler.php
@@ -7,8 +7,8 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class IteratorAssembler
@@ -56,7 +56,7 @@ class IteratorAssembler implements AssemblerInterface
      * @param ClassGenerator $class
      * @param Property       $firstProperty
      *
-     * @throws \Zend\Code\Generator\Exception\InvalidArgumentException
+     * @throws \Laminas\Code\Generator\Exception\InvalidArgumentException
      */
     private function implementGetIterator(ClassGenerator $class, Property $firstProperty)
     {

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/JsonSerializableAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/JsonSerializableAssembler.php
@@ -6,7 +6,7 @@ use JsonSerializable;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\MethodGenerator;

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/JsonSerializableAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/JsonSerializableAssembler.php
@@ -8,8 +8,8 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class JsonSerializableAssembler
@@ -49,7 +49,7 @@ class JsonSerializableAssembler implements AssemblerInterface
      * @param Type $type
      * @param ClassGenerator $class
      *
-     * @throws \Zend\Code\Generator\Exception\InvalidArgumentException
+     * @throws \Laminas\Code\Generator\Exception\InvalidArgumentException
      */
     private function implementJsonSerialize(Type $type, ClassGenerator $class)
     {

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/PropertyAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/PropertyAssembler.php
@@ -6,7 +6,7 @@ use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\PropertyGenerator;
+use Laminas\Code\Generator\PropertyGenerator;
 
 /**
  * Class PropertyAssembler

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/PropertyAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/PropertyAssembler.php
@@ -4,7 +4,7 @@ namespace Phpro\SoapClient\CodeGenerator\Assembler;
 
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\PropertyGenerator;
 
@@ -47,7 +47,7 @@ class PropertyAssembler implements AssemblerInterface
         $class = $context->getClass();
         $property = $context->getProperty();
         try {
-            // It's not possible to overwrite a property in zend-code yet!
+            // It's not possible to overwrite a property in laminas-code yet!
             if ($class->hasProperty($property->getName())) {
                 return;
             }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ResultProviderAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ResultProviderAssembler.php
@@ -10,8 +10,8 @@ use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Phpro\SoapClient\Type\ResultInterface;
 use Phpro\SoapClient\Type\ResultProviderInterface;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class ResultProviderAssembler
@@ -73,7 +73,7 @@ class ResultProviderAssembler implements AssemblerInterface
      * @param ClassGenerator   $class
      * @param Property         $property
      *
-     * @throws \Zend\Code\Generator\Exception\InvalidArgumentException
+     * @throws \Laminas\Code\Generator\Exception\InvalidArgumentException
      */
     private function implementGetResult(ContextInterface $context, ClassGenerator $class, Property $property)
     {

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ResultProviderAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ResultProviderAssembler.php
@@ -6,7 +6,7 @@ use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Phpro\SoapClient\Type\ResultInterface;
 use Phpro\SoapClient\Type\ResultProviderInterface;

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class SetterAssembler

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
@@ -5,7 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
-use Phpro\SoapClient\CodeGenerator\ZendCodeFactory\DocBlockGeneratorFactory;
+use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/UseAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/UseAssembler.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\AssemblerException;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class UseAssembler

--- a/src/Phpro/SoapClient/CodeGenerator/ClassMapGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClassMapGenerator.php
@@ -5,7 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSetInterface;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class ClassMapGenerator

--- a/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
@@ -6,9 +6,9 @@ use Phpro\SoapClient\CodeGenerator\Context\ClientFactoryContext;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapEngineFactory;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\FileGenerator;
-use Zend\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\MethodGenerator;
 
 /**
  * Class ClientBuilderGenerator

--- a/src/Phpro/SoapClient/CodeGenerator/ClientGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClientGenerator.php
@@ -8,8 +8,8 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Client;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSetInterface;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class ClientGenerator

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapEngineFactory;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\Handler\ExtSoapClientHandle;
 use Phpro\SoapClient\Soap\Engine\Engine;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class ConfigGenerator

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClassMapContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClassMapContext.php
@@ -3,7 +3,7 @@
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class ClassMapContext

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClientContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClientContext.php
@@ -3,7 +3,7 @@
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
 use Phpro\SoapClient\CodeGenerator\Model\Type;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class ClientContext

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContext.php
@@ -3,7 +3,7 @@
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 class ClientMethodContext implements ContextInterface
 {

--- a/src/Phpro/SoapClient/CodeGenerator/Context/PropertyContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/PropertyContext.php
@@ -4,7 +4,7 @@ namespace Phpro\SoapClient\CodeGenerator\Context;
 
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class PropertyContext

--- a/src/Phpro/SoapClient/CodeGenerator/Context/TypeContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/TypeContext.php
@@ -3,7 +3,7 @@
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
 use Phpro\SoapClient\CodeGenerator\Model\Type;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class TypeContext

--- a/src/Phpro/SoapClient/CodeGenerator/GeneratorInterface.php
+++ b/src/Phpro/SoapClient/CodeGenerator/GeneratorInterface.php
@@ -2,7 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator;
 
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Interface GeneratorInterface

--- a/src/Phpro/SoapClient/CodeGenerator/LaminasCodeFactory/DocBlockGeneratorFactory.php
+++ b/src/Phpro/SoapClient/CodeGenerator/LaminasCodeFactory/DocBlockGeneratorFactory.php
@@ -1,13 +1,9 @@
 <?php declare(strict_types=1);
 
-namespace Phpro\SoapClient\CodeGenerator\ZendCodeFactory;
+namespace Phpro\SoapClient\CodeGenerator\LaminasCodeFactory;
 
 use Laminas\Code\Generator\DocBlockGenerator;
 
-/**
- * @deprecated Please use LaminasCodeFactory\DocBlockGeneratorFactory instead
- * @see \Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory
- */
 final class DocBlockGeneratorFactory
 {
     public static function fromArray(array $data): DocBlockGenerator

--- a/src/Phpro/SoapClient/CodeGenerator/TypeGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeGenerator.php
@@ -6,8 +6,8 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSetInterface;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class TypeGenerator

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Validator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Validator.php
@@ -7,17 +7,35 @@ use Laminas\Code\Generator\ClassGenerator;
 
 class Validator
 {
-    public static function zendCodeIsInstalled(): bool
+    public static function laminasCodeIsInstalled(): bool
     {
         return class_exists(ClassGenerator::class);
     }
 
-    public static function commandRequiresZendCode(string $name): bool
+    /**
+     * @deprecated use laminasCodeIsInstalled() instead
+     * @see self::laminasCodeIsInstalled()
+     */
+    public static function zendCodeIsInstalled(): bool
+    {
+        return self::laminasCodeIsInstalled();
+    }
+
+    public static function commandRequiresLaminasCode(string $name): bool
     {
         if ($name === WizardCommand::COMMAND_NAME) {
             return true;
         }
 
         return strpos($name, 'generate') === 0;
+    }
+
+    /**
+     * @deprecated use commandRequiresLaminasCode() instead
+     * @see self::commandRequiresLaminasCode()
+     */
+    public static function commandRequiresZendCode(string $name): bool
+    {
+        return self::commandRequiresLaminasCode($name);
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Validator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Validator.php
@@ -3,7 +3,7 @@
 namespace Phpro\SoapClient\CodeGenerator\Util;
 
 use Phpro\SoapClient\Console\Command\WizardCommand;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 class Validator
 {

--- a/src/Phpro/SoapClient/CodeGenerator/ZendCodeFactory/DocBlockGeneratorFactory.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ZendCodeFactory/DocBlockGeneratorFactory.php
@@ -2,7 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\ZendCodeFactory;
 
-use Zend\Code\Generator\DocBlockGenerator;
+use Laminas\Code\Generator\DocBlockGenerator;
 
 final class DocBlockGeneratorFactory
 {

--- a/src/Phpro/SoapClient/Console/Application.php
+++ b/src/Phpro/SoapClient/Console/Application.php
@@ -4,7 +4,7 @@
 namespace Phpro\SoapClient\Console;
 
 use Phpro\SoapClient\Console\Command;
-use Phpro\SoapClient\Console\Event\Subscriber\ZendCodeValidationSubscriber;
+use Phpro\SoapClient\Console\Event\Subscriber\LaminasCodeValidationSubscriber;
 use Phpro\SoapClient\Console\Helper\ConfigHelper;
 use Phpro\SoapClient\Util\Filesystem;
 use Symfony\Component\Console\Application as SymfonyApplication;
@@ -59,7 +59,7 @@ class Application extends SymfonyApplication
     private function createEventDispatcher(): EventDispatcherInterface
     {
         $dispatcher = new EventDispatcher();
-        $dispatcher->addSubscriber(new ZendCodeValidationSubscriber());
+        $dispatcher->addSubscriber(new LaminasCodeValidationSubscriber());
 
         return $dispatcher;
     }

--- a/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class GenerateTypesCommand

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class GenerateClientCommand

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 class GenerateClientFactoryCommand extends Command
 {

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 class GenerateConfigCommand extends Command
 {

--- a/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 /**
  * Class GenerateTypesCommand

--- a/src/Phpro/SoapClient/Console/Event/Subscriber/LaminasCodeValidationSubscriber.php
+++ b/src/Phpro/SoapClient/Console/Event/Subscriber/LaminasCodeValidationSubscriber.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Phpro\SoapClient\Console\Event\Subscriber;
+
+use Phpro\SoapClient\CodeGenerator\Util\Validator;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Check if laminas code is installed when generating code
+ * Show a helpful error message for when it is not
+ *
+ * Class LaminasCodeValidationListener
+ * @package Phpro\SoapClient\Event\Subscriber
+ */
+class LaminasCodeValidationSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ConsoleEvents::COMMAND => 'onCommand',
+        ];
+    }
+
+    public function onCommand(ConsoleCommandEvent $event)
+    {
+        if (!Validator::commandRequiresLaminasCode($event->getCommand()->getName())) {
+            return;
+        }
+        if (Validator::laminasCodeIsInstalled()) {
+            return;
+        }
+        $io = new SymfonyStyle($event->getInput(), $event->getOutput());
+        $io->error(
+            [
+                'laminas-code not installed, require it with this command:',
+                'composer require --dev laminas/laminas-code:^3.1.0',
+            ]
+        );
+        $event->disableCommand();
+    }
+}

--- a/src/Phpro/SoapClient/Console/Event/Subscriber/ZendCodeValidationSubscriber.php
+++ b/src/Phpro/SoapClient/Console/Event/Subscriber/ZendCodeValidationSubscriber.php
@@ -2,46 +2,11 @@
 
 namespace Phpro\SoapClient\Console\Event\Subscriber;
 
-use Phpro\SoapClient\CodeGenerator\Util\Validator;
-use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-
 /**
- * Check if zend code is installed when generating code
- * Show a helpful error message for when it is not
- *
- * Class ZendCodeValidationListener
  * @package Phpro\SoapClient\Event\Subscriber
+ * @deprecated use LaminasCodeValidationSubscriber instead
+ * @see LaminasCodeValidationSubscriber
  */
-class ZendCodeValidationSubscriber implements EventSubscriberInterface
+class ZendCodeValidationSubscriber extends LaminasCodeValidationSubscriber
 {
-    /**
-     * @inheritdoc
-     */
-    public static function getSubscribedEvents(): array
-    {
-        return [
-            ConsoleEvents::COMMAND => 'onCommand',
-        ];
-    }
-
-    public function onCommand(ConsoleCommandEvent $event)
-    {
-        if (!Validator::commandRequiresZendCode($event->getCommand()->getName())) {
-            return;
-        }
-        if (Validator::zendCodeIsInstalled()) {
-            return;
-        }
-        $io = new SymfonyStyle($event->getInput(), $event->getOutput());
-        $io->error(
-            [
-                'zend-code not installed, require it with this command:',
-                'composer require --dev laminas/laminas-code:^3.1.0',
-            ]
-        );
-        $event->disableCommand();
-    }
 }

--- a/src/Phpro/SoapClient/Console/Event/Subscriber/ZendCodeValidationSubscriber.php
+++ b/src/Phpro/SoapClient/Console/Event/Subscriber/ZendCodeValidationSubscriber.php
@@ -39,7 +39,7 @@ class ZendCodeValidationSubscriber implements EventSubscriberInterface
         $io->error(
             [
                 'zend-code not installed, require it with this command:',
-                'composer require --dev zendframework/zend-code:^3.1.0',
+                'composer require --dev laminas/laminas-code:^3.1.0',
             ]
         );
         $event->disableCommand();

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
@@ -8,7 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
 use Phpro\SoapClient\CodeGenerator\Model\Parameter;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class GetterAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class ConstructorAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
@@ -8,7 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class ExtendAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FinalClassAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FinalClassAssemblerTest.php
@@ -8,7 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class FinalClassAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -22,12 +22,12 @@ class FluentSetterAssemblerTest extends TestCase
      * @param string $version
      * @return bool
      */
-    function zendOlderOrEqual($version)
+    function laminasOlderOrEqual($version)
     {
-        $zendCodeVersion = \PackageVersions\Versions::getVersion('laminas/laminas-code');
-        $zendCodeVersion = substr($zendCodeVersion, 0, strpos($zendCodeVersion, '@'));
+        $laminasCodeVersion = \PackageVersions\Versions::getVersion('laminas/laminas-code');
+        $laminasCodeVersion = substr($laminasCodeVersion, 0, strpos($laminasCodeVersion, '@'));
 
-        return version_compare($zendCodeVersion, $version, '>=');
+        return version_compare($laminasCodeVersion, $version, '>=');
     }
 
     /**
@@ -156,8 +156,8 @@ CODE;
      */
     public function it_generates_return_types()
     {
-        if (!$this->zendOlderOrEqual('3.3.0')) {
-            $this->markTestSkipped('zend-code not new enough');
+        if (!$this->laminasOlderOrEqual('3.3.0')) {
+            $this->markTestSkipped('laminas-code not new enough');
         }
         $assembler = new FluentSetterAssembler((new FluentSetterAssemblerOptions())->withReturnType());
         $context = $this->createContextWithAnUnknownType();

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class SetterAssemblerTest
@@ -24,7 +24,7 @@ class FluentSetterAssemblerTest extends TestCase
      */
     function zendOlderOrEqual($version)
     {
-        $zendCodeVersion = \PackageVersions\Versions::getVersion('zendframework/zend-code');
+        $zendCodeVersion = \PackageVersions\Versions::getVersion('laminas/laminas-code');
         $zendCodeVersion = substr($zendCodeVersion, 0, strpos($zendCodeVersion, '@'));
 
         return version_compare($zendCodeVersion, $version, '>=');

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class GetterAssemblerTest
@@ -24,7 +24,7 @@ class GetterAssemblerTest extends TestCase
      */
     function zendOlderOrEqual($version)
     {
-        $zendCodeVersion = \PackageVersions\Versions::getVersion('zendframework/zend-code');
+        $zendCodeVersion = \PackageVersions\Versions::getVersion('laminas/laminas-code');
         $zendCodeVersion = substr($zendCodeVersion, 0, strpos($zendCodeVersion, '@'));
 
         return version_compare($zendCodeVersion, $version, '>=');
@@ -87,7 +87,7 @@ CODE;
     public function it_assembles_with_return_type()
     {
         if (!$this->zendOlderOrEqual('3.3.0')) {
-            $this->markTestSkipped('zendframework/zend-code 3.3.0 required');
+            $this->markTestSkipped('laminas/laminas-code 3.3.0 required');
         }
         $options = (new GetterAssemblerOptions())
             ->withReturnType();

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -22,12 +22,12 @@ class GetterAssemblerTest extends TestCase
      * @param string $version
      * @return bool
      */
-    function zendOlderOrEqual($version)
+    function laminasOlderOrEqual($version)
     {
-        $zendCodeVersion = \PackageVersions\Versions::getVersion('laminas/laminas-code');
-        $zendCodeVersion = substr($zendCodeVersion, 0, strpos($zendCodeVersion, '@'));
+        $laminasCodeVersion = \PackageVersions\Versions::getVersion('laminas/laminas-code');
+        $laminasCodeVersion = substr($laminasCodeVersion, 0, strpos($laminasCodeVersion, '@'));
 
-        return version_compare($zendCodeVersion, $version, '>=');
+        return version_compare($laminasCodeVersion, $version, '>=');
     }
 
     /**
@@ -86,7 +86,7 @@ CODE;
      */
     public function it_assembles_with_return_type()
     {
-        if (!$this->zendOlderOrEqual('3.3.0')) {
+        if (!$this->laminasOlderOrEqual('3.3.0')) {
             $this->markTestSkipped('laminas/laminas-code 3.3.0 required');
         }
         $options = (new GetterAssemblerOptions())

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class ImmutableSetterAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class InterfaceAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
@@ -8,7 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class IteratorAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
@@ -8,7 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class JsonSerializableAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
@@ -8,8 +8,8 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
-use Zend\Code\Generator\PropertyGenerator;
+use Laminas\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\PropertyGenerator;
 
 /**
  * Class PropertyAssemblerTest
@@ -20,7 +20,7 @@ class PropertyAssemblerTest extends TestCase
 {
     function zendCodeCompare($version, $operator)
     {
-        $zendCodeVersion = \PackageVersions\Versions::getVersion('zendframework/zend-code');
+        $zendCodeVersion = \PackageVersions\Versions::getVersion('laminas/laminas-code');
         $zendCodeVersion = substr($zendCodeVersion, 0, strpos($zendCodeVersion, '@'));
 
         return version_compare($zendCodeVersion, $version, $operator);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
@@ -18,12 +18,12 @@ use Laminas\Code\Generator\PropertyGenerator;
  */
 class PropertyAssemblerTest extends TestCase
 {
-    function zendCodeCompare($version, $operator)
+    function laminasCodeCompare($version, $operator)
     {
-        $zendCodeVersion = \PackageVersions\Versions::getVersion('laminas/laminas-code');
-        $zendCodeVersion = substr($zendCodeVersion, 0, strpos($zendCodeVersion, '@'));
+        $laminasCodeVersion = \PackageVersions\Versions::getVersion('laminas/laminas-code');
+        $laminasCodeVersion = substr($laminasCodeVersion, 0, strpos($laminasCodeVersion, '@'));
 
-        return version_compare($zendCodeVersion, $version, $operator);
+        return version_compare($laminasCodeVersion, $version, $operator);
     }
 
     /**
@@ -40,7 +40,7 @@ class PropertyAssemblerTest extends TestCase
      */
     function it_assembles_property_without_default_value()
     {
-        if ($this->zendCodeCompare('3.3.0', '<')) {
+        if ($this->laminasCodeCompare('3.3.0', '<')) {
             $this->markTestSkipped('Running it_assembles_property_with_default_value instead');
         }
 
@@ -72,7 +72,7 @@ CODE;
      */
     function it_assembles_property_with_default_value()
     {
-        if ($this->zendCodeCompare('3.3.0', '>=')) {
+        if ($this->laminasCodeCompare('3.3.0', '>=')) {
             $this->markTestSkipped('Running it_assembles_property_without_default_value instead');
         }
 
@@ -104,7 +104,7 @@ CODE;
      */
     function it_assembles_with_visibility_without_default_value()
     {
-        if ($this->zendCodeCompare('3.3.0', '<')) {
+        if ($this->laminasCodeCompare('3.3.0', '<')) {
             $this->markTestSkipped('Running it_assembles_with_visibility_with_default_value instead');
         }
 
@@ -136,7 +136,7 @@ CODE;
      */
     function it_assembles_with_visibility_with_default_value()
     {
-        if ($this->zendCodeCompare('3.3.0', '>=')) {
+        if ($this->laminasCodeCompare('3.3.0', '>=')) {
             $this->markTestSkipped('Running it_assembles_with_visibility_without_default_value instead');
         }
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/RequestAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/RequestAssemblerTest.php
@@ -8,7 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class RequestAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultAssemblerTest.php
@@ -8,7 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class ResultAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\Type\MixedResult;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class ResultProviderAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class SetterAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/TraitAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/TraitAssemblerTest.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\TraitAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class TraitAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
@@ -9,7 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\ClassGenerator;
+use Laminas\Code\Generator\ClassGenerator;
 
 /**
  * Class UseAssemblerTest

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
@@ -7,7 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientFactoryContext;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 class ClientFactoryGeneratorTest extends TestCase
 {

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -5,7 +5,7 @@ namespace PhproTest\SoapClient\Unit\CodeGenerator;
 use Phpro\SoapClient\CodeGenerator\ConfigGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
 use PHPUnit\Framework\TestCase;
-use Zend\Code\Generator\FileGenerator;
+use Laminas\Code\Generator\FileGenerator;
 
 class ConfigGeneratorTest extends TestCase
 {


### PR DESCRIPTION
---
name: ⚙ Migration to laminas-code
---

### Improvement

|    Q                |   A
|-------------- | ------
| New Feature   | no
| RFC                | no
| BC Break        | no
| Docs updated | yes
| Tested            | yes

#### Summary

As you probably already know, the Zend Framework has moved to the [Laminas Project](https://getlaminas.org/). In consequence, all zendframework/zend-* packages now reside in laminas/laminas-* and the Zend\ namespace in PHP has changed to Laminas\.

I have ported phpro from zend-code to laminas-code. Currently, the zend-code and laminas-code packages are (besides the namespace) identical, but zend-code will be not further developed and is officially abandoned. Since switching right now is quite easy, phpro should switch as soon as possible.

To ensure backward compatibility, I have added proxy functions and classes to all members of phpro which have been renamed. Those are marked as deprecated and can be dropped in the next major release.