### PR TITLE
added DisablePoliciesMiddleware to remove WS policies

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -17,6 +17,7 @@ Next, you can use one of the built-in middlewares:
 - [WsseMiddleware](#wssemiddleware)
 - [RemoveEmptyNodesMiddleware](#removeemptynodesmiddleware)
 - [Wsdl/DisableExtensionsMiddleware](#wsdldisableextensionsmiddleware)
+- [Wsdl/DisablePoliciesMiddleware](#wsdldisablepoliciesmiddleware)
 
 Can't find the middleware you were looking for?
 [It is always possible to create your own one!](#creating-your-own-middleware)
@@ -131,6 +132,21 @@ property to false on the fly so that you don't have to change the WSDL on the se
 ```php
 $wsdlProvier = HttPlugWsdlProvider::create($client);
 $wsdlProvider->addMiddleware(new DisableExtensionsMiddleware());
+```
+
+
+### Wsdl/DisablePoliciesMiddleware
+
+The default SOAP client does not support the [Web Services Policy Framework](http://schemas.xmlsoap.org/ws/2004/09/policy/) attributes since there is no such support in PHP.
+You will retrieve this exception: "[SoapFault] SOAP-ERROR: Parsing WSDL: Unknown required WSDL extension 'http://schemas.xmlsoap.org/ws/2004/09/policy'" 
+when the WSDL does contains WS policies.
+ 
+This middleware can be used to remove all UsingPolicy and Policy tags on the fly so that you don't have to change the WSDL on the server.
+
+**Usage**
+```php
+$wsdlProvier = HttPlugWsdlProvider::create($client);
+$wsdlProvider->addMiddleware(new DisablePoliciesMiddleware());
 ```
 
 

--- a/src/Phpro/SoapClient/Middleware/Wsdl/DisablePoliciesMiddleware.php
+++ b/src/Phpro/SoapClient/Middleware/Wsdl/DisablePoliciesMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phpro\SoapClient\Middleware\Wsdl;
+
+use Phpro\SoapClient\Middleware\Middleware;
+use Phpro\SoapClient\Xml\WsdlXml;
+use Psr\Http\Message\ResponseInterface;
+
+class DisablePoliciesMiddleware extends Middleware
+{
+    public function getName(): string
+    {
+        return 'wsdl_disable_policies';
+    }
+
+    public function afterResponse(ResponseInterface $response): ResponseInterface
+    {
+        $xml = WsdlXml::fromStream($response->getBody());
+        $xml->registerNamespace('wsd', 'http://schemas.xmlsoap.org/ws/2004/09/policy');
+
+        /** @var \DOMElement $node */
+        // remove all "UsingPolicy" tags
+        foreach ($xml->xpath('//wsd:UsingPolicy') as $node) {
+            $node->parentNode->removeChild($node);
+        }
+        // remove all "Policy" tags
+        foreach ($xml->xpath('//wsd:Policy') as $node) {
+            $node->parentNode->removeChild($node);
+        }
+
+        return $response->withBody($xml->toStream());
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Middleware/Wsdl/DisablePoliciesMiddlewareTest.php
+++ b/test/PhproTest/SoapClient/Unit/Middleware/Wsdl/DisablePoliciesMiddlewareTest.php
@@ -74,8 +74,9 @@ class DisablePoliciesMiddlewareTest extends TestCase
 
         $response = $this->client->sendRequest(new Request('POST', '/'));
         $xml = WsdlXml::fromStream($response->getBody());
+        $xml->registerNamespace('wsd', 'http://schemas.xmlsoap.org/ws/2004/09/policy');
 
-        $this->assertEquals(0, $xml->xpath('//wsdl:UsingPolicy')->length, 'Still got imports of WSDL policies (<UsingPolicy>).');
-        $this->assertEquals(0, $xml->xpath('//wsdl:Polocy')->length, 'Still got references to WSDL policies (<Policy>).');
+        $this->assertEquals(0, $xml->xpath('//wsd:Policy')->length, 'Still got policies in WSDL file.');
+        $this->assertEquals(0, $xml->xpath('//wsd:UsingPolicy')->length, 'Still got using statements for policies in WSDL file.');
     }
 }

--- a/test/PhproTest/SoapClient/Unit/Middleware/Wsdl/DisablePoliciesMiddlewareTest.php
+++ b/test/PhproTest/SoapClient/Unit/Middleware/Wsdl/DisablePoliciesMiddlewareTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\Middleware\Wsdl;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Http\Client\Common\PluginClient;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Http\Mock\Client;
+use Phpro\SoapClient\Middleware\MiddlewareInterface;
+use Phpro\SoapClient\Middleware\Wsdl\DisablePoliciesMiddleware;
+use Phpro\SoapClient\Xml\WsdlXml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class BasicAuthMiddleware
+ *
+ * @package PhproTest\SoapClient\Unit\Middleware
+ */
+class DisablePoliciesMiddlewareTest extends TestCase
+{
+
+    /**
+     * @var PluginClient
+     */
+    private $client;
+
+    /**
+     * @var Client
+     */
+    private $mockClient;
+
+    /**
+     * @var DisablePoliciesMiddleware
+     */
+    private $middleware;
+
+    /***
+     * Initialize all basic objects
+     */
+    protected function setUp(): void
+    {
+        $this->middleware = new DisablePoliciesMiddleware();
+        $this->mockClient = new Client(new GuzzleMessageFactory());
+        $this->client = new PluginClient($this->mockClient, [$this->middleware]);
+    }
+
+    /**
+     * @test
+     */
+    function it_is_a_middleware()
+    {
+        $this->assertInstanceOf(MiddlewareInterface::class, $this->middleware);
+    }
+
+    /**
+     * @test
+     */
+    function it_has_a_name()
+    {
+        $this->assertEquals('wsdl_disable_policies', $this->middleware->getName());
+    }
+
+    /**
+     * @test
+     */
+    function it_removes_wsdl_policies()
+    {
+        $this->mockClient->addResponse(new Response(
+            200,
+            [],
+            file_get_contents(FIXTURE_DIR . '/wsdl/wsdl-policies.wsdl'))
+        );
+
+        $response = $this->client->sendRequest(new Request('POST', '/'));
+        $xml = WsdlXml::fromStream($response->getBody());
+
+        $this->assertEquals(0, $xml->xpath('//wsdl:UsingPolicy')->length, 'Still got imports of WSDL policies (<UsingPolicy>).');
+        $this->assertEquals(0, $xml->xpath('//wsdl:Polocy')->length, 'Still got references to WSDL policies (<Policy>).');
+    }
+}

--- a/test/fixtures/wsdl/wsdl-policies.wsdl
+++ b/test/fixtures/wsdl/wsdl-policies.wsdl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
+                  xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" 
+                  xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" >
+    <wsp:UsingPolicy wsdl:required="true" />
+    <wsp:Policy wsu:Id="PolicySampleService" />
+    <wsdl:portType name="SampleService">
+        <wsdl:operation name="SampleService">
+            <wsp:Policy>
+                <wsp:PolicyReference URI="#PolicySampleService" />
+            </wsp:Policy>
+        </wsdl:operation>
+    </wsdl:portType>
+</wsdl:definitions>


### PR DESCRIPTION
---
name: ⚙ New Middleware to Disable WS Policies
---

### Improvement

|    Q                |   A
|-------------- | ------
| New Feature   | yes
| RFC                | no
| BC Break        | no
| Docs updated | yes
| Tested            | yes

#### Summary

I was struggeling with an SAP NetWeaver Application Server that uses the Web Services Policy Framework (http://schemas.xmlsoap.org/ws/2004/09/policy/). Unfortunatly, PHP's internal soap client  cannot handle these policies and crashes with an error message.

The middleware I have implemented removes all `<wsp:UsingPolicy />` and `<wsp:Policy  />` tags from the WSDL, hence, renders the WSDL from my SAP server usable. Test cases including a sample WSDL and documentation are provided.