### PR TITLE
Replace deprecated package jakub-onderka/php-parallel-lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
         "ext-xml": "*",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.0",
-        "symfony/console": "~3.4|~4.0|~5.0",
-        "symfony/event-dispatcher": "~3.4|~4.0|~5.0",
-        "symfony/filesystem": "~3.4|~4.0|~5.0",
-        "symfony/options-resolver": "~3.4|~4.0|~5.0"
+        "symfony/console": "~3.4 || ~4.0 || ~5.0",
+        "symfony/event-dispatcher": "~3.4 || ~4.0 || ~5.0",
+        "symfony/filesystem": "~3.4 || ~4.0 || ~5.0",
+        "symfony/options-resolver": "~3.4 || ~4.0 || ~5.0"
     },
     "require-dev": {
         "ext-soap": "*",
         "guzzlehttp/guzzle": "^6.4.1",
         "guzzlehttp/promises": "^1.3.1",
         "guzzlehttp/psr7": "^1.6.1",
-        "jakub-onderka/php-parallel-lint": "^1.0",
+        "laminas/laminas-code": "^3.4.0",
         "php-http/client-common": "^1.10",
         "php-http/discovery": "^1.7",
         "php-http/guzzle6-adapter": "^1.1.1",
@@ -35,6 +35,7 @@
         "php-http/message": "^1.8",
         "php-http/message-factory": "^1.0",
         "php-http/mock-client": "^1.3",
+        "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-vcr/php-vcr": "~1.4.4",
         "phpro/grumphp": "~0.17.1",
         "phpspec/phpspec": "~6.1",
@@ -45,22 +46,24 @@
         "robrichards/wse-php": "^2.0.3",
         "robrichards/xmlseclibs": "^3.0",
         "squizlabs/php_codesniffer": "~2.9",
-        "symfony/validator": "~3.4|~4.0|~5.0",
-        "laminas/laminas-code": "^3.4.0"
+        "symfony/validator": "~3.4 || ~4.0 || ~5.0"
     },
     "suggest": {
         "ext-soap": "If you want to use PHP's ext-soap driver.",
-        "php-http/client-implementation": "For gaining control over the HTTP layer",
-        "phpro/annotated-cache": "For caching SOAP responses",
-        "psr/log-implementation": "For logging SOAP requests, responses and errors",
-        "psr/http-message": "For gaining control over the HTTP layer",
-        "php-http/httplug": "For gaining control over the HTTP layer",
-        "php-http/message-factory": "For gaining control over the HTTP layer",
-        "php-http/discovery": "For gaining control over the HTTP layer",
-        "php-http/message": "For gaining control over the HTTP layer",
         "php-http/client-common": "For gaining control over the HTTP layer",
+        "php-http/client-implementation": "For gaining control over the HTTP layer",
+        "php-http/discovery": "For gaining control over the HTTP layer",
+        "php-http/httplug": "For gaining control over the HTTP layer",
+        "php-http/message": "For gaining control over the HTTP layer",
+        "php-http/message-factory": "For gaining control over the HTTP layer",
+        "phpro/annotated-cache": "For caching SOAP responses",
+        "psr/http-message": "For gaining control over the HTTP layer",
+        "psr/log-implementation": "For logging SOAP requests, responses and errors",
         "robrichards/wse-php": "If you want to use the WSA or WSSE middleware",
         "symfony/validator": "If you easily want to validate SOAP requests / responses manually"
+    },
+    "config": {
+        "sort-packages": true
     },
     "autoload": {
         "psr-0": {
@@ -74,8 +77,5 @@
     },
     "bin": [
         "bin/soap-client"
-    ],
-    "config": {
-        "sort-packages": true
-    }
+    ]
 }


### PR DESCRIPTION
This PR:

* [x] Replace deprecated package [`jakub-onderka/php-parallel-lint`](https://packagist.org/packages/jakub-onderka/php-parallel-lint) and replace with [`parallel-lint/php-parallel-lint`](https://packagist.org/packages/php-parallel-lint/php-parallel-lint).
* [x] Normalize `composer.json` using [ergebnis/composer-normalise](https://packagist.org/packages/ergebnis/composer-normalize)