### PR TITLE
Duplicate types enhencements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You can customize the generated code based on the manual installation pages in t
   - [Choose a driver](docs/engine.md#driver)
     - [ExtSoapDriver](docs/drivers/ext-soap.md)
     - [Create your own driver](docs/drivers/new.md)
+        - [Manipulate the drivers metadata](docs/drivers/metadata.md)
   - [Specify your HTTP handler.](docs/engine.md#handler)
     - [HttPlugHandle](docs/handlers/httplug.md) (Supports [middlewares](docs/middlewares.md))
     - [ExtSoapClientHandle](docs/handlers/ext-soap/client.md)

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php-http/message-factory": "^1.0",
         "php-http/mock-client": "^1.3",
         "php-parallel-lint/php-parallel-lint": "^1.0",
-        "php-vcr/php-vcr": "dev-master#faa3341de89bd9b41a1609ace4e35d5b9786d3fe as 1.4.5",
+        "php-vcr/php-vcr": "1.4.5",
         "phpro/grumphp-shim": "~0.19.0",
         "phpspec/phpspec": "~6.1",
         "phpstan/phpstan": "^0.11.19",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "php-http/mock-client": "^1.3",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-vcr/php-vcr": "dev-master#faa3341de89bd9b41a1609ace4e35d5b9786d3fe as 1.4.5",
-        "phpro/grumphp": "~0.17.1",
+        "phpro/grumphp-shim": "~0.19.0",
         "phpspec/phpspec": "~6.1",
         "phpstan/phpstan": "^0.11.19",
         "phpunit/phpunit": "~8.5",
@@ -45,7 +45,7 @@
         "psr/http-message": "^1.0.1",
         "robrichards/wse-php": "^2.0.3",
         "robrichards/xmlseclibs": "^3.0",
-        "squizlabs/php_codesniffer": "~2.9",
+        "squizlabs/php_codesniffer": "~3.5",
         "symfony/validator": "~3.4 || ~4.0 || ~5.0"
     },
     "suggest": {
@@ -60,7 +60,7 @@
         "psr/http-message": "For gaining control over the HTTP layer",
         "psr/log-implementation": "For logging SOAP requests, responses and errors",
         "robrichards/wse-php": "If you want to use the WSA or WSSE middleware",
-    "symfony/validator": "If you easily want to validate SOAP requests / responses manually"
+        "symfony/validator": "If you easily want to validate SOAP requests / responses manually"
   },
   "repositories": [
     ],

--- a/docs/drivers/ext-soap.md
+++ b/docs/drivers/ext-soap.md
@@ -50,7 +50,7 @@ $typemap->add(new MyTypeConverter());
 ### Duplicate types
 
 Ext-soap does not add any namespace or unique identifier to the types it knows.
-You can read more about this in the [known ext-soap issues](../known-issues/ext-soap.md) section.
+You can read more about this in the [known ext-soap issues](../known-issues/ext-soap.md#duplicate-typenames) section.
 Therefore, we added some strategies to deal with duplicate types:
 
 **IntersectDuplicateTypesStrategy**
@@ -62,6 +62,7 @@ This duplicate types strategy will merge all duplicate types into one big type w
 **RemoveDuplicateTypesStrategy**
 
 This duplicate types strategy will remove all duplicate types it finds.
+
 
 
 You can overwrite the strategy on the `ExtSoapOptions` object:

--- a/docs/drivers/ext-soap.md
+++ b/docs/drivers/ext-soap.md
@@ -76,7 +76,7 @@ use Phpro\SoapClient\Soap\Engine\Metadata\MetadataOptions;
 
 $options = ExtSoapOptions::defaults($wsdl)
     ->withMetaOptions(function (MetadataOptions $options): MetadataOptions {
-        return $options->withMethodsManipulator(
+        return $options->withTypesManipulator(
             new RemoveDuplicateTypesStrategy()
         );
     });

--- a/docs/drivers/ext-soap.md
+++ b/docs/drivers/ext-soap.md
@@ -75,7 +75,7 @@ use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes\Re
 use Phpro\SoapClient\Soap\Engine\Metadata\MetadataOptions;
 
 $options = ExtSoapOptions::defaults($wsdl)
-    ->withMetaOptions(function (MetadataOptions $options): MetadataOptions {
+    ->withMetadataOptions(function (MetadataOptions $options): MetadataOptions {
         return $options->withTypesManipulator(
             new RemoveDuplicateTypesStrategy()
         );

--- a/docs/drivers/ext-soap.md
+++ b/docs/drivers/ext-soap.md
@@ -44,3 +44,39 @@ $options = ExtSoapOptions::defaults($wsdl, ['location' => 'http://somedifferents
 $typemap = $options->getTypeMap();
 $typemap->add(new MyTypeConverter());
 ```
+
+## Dealing with ext-soap issues
+
+### Duplicate types
+
+Ext-soap does not add any namespace or unique identifier to the types it knows.
+You can read more about this in the [known ext-soap issues](../known-issues/ext-soap.md) section.
+Therefore, we added some strategies to deal with duplicate types:
+
+**IntersectDuplicateTypesStrategy**
+
+Enabled by default when using `ExtSoapOptions::defaults()`.
+
+This duplicate types strategy will merge all duplicate types into one big type which contains all properties.
+
+**RemoveDuplicateTypesStrategy**
+
+This duplicate types strategy will remove all duplicate types it finds.
+
+
+You can overwrite the strategy on the `ExtSoapOptions` object:
+
+```php
+<?php
+
+use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes\RemoveDuplicateTypesStrategy;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataOptions;
+
+$options = ExtSoapOptions::defaults($wsdl)
+    ->withMetaOptions(function (MetadataOptions $options): MetadataOptions {
+        return $options->withMethodsManipulator(
+            new RemoveDuplicateTypesStrategy()
+        );
+    });
+```

--- a/docs/drivers/metadata.md
+++ b/docs/drivers/metadata.md
@@ -12,7 +12,7 @@ On top of that, we provide some generic tools that can be useful.
 
 ## LazyInMemoryMetadata
 
-This class will make sure that the metadata is only collected once and stores it in memory for a second access.
+This class will make sure that the metadata are only collected once and stores it in memory for a second access.
 
 Example output:
 

--- a/docs/drivers/metadata.md
+++ b/docs/drivers/metadata.md
@@ -3,7 +3,7 @@
 The metadata part of the driver knows what objects and functions are inside the soap service.
 This can be done by parsing the WSDL file.
 Every driver has its own way of collecting this information.
-On top of that, we provide some generic tools that can be usefull.
+On top of that, we provide some generic tools that can be useful.
 
 # Built-in metadata tools
 

--- a/docs/drivers/metadata.md
+++ b/docs/drivers/metadata.md
@@ -1,0 +1,55 @@
+# Driver metadata
+
+The metadata part of the driver knows what objects and functions are inside the soap service.
+This can be done by parsing the WSDL file.
+Every driver has its own way of collecting this information.
+On top of that, we provide some generic tools that can be usefull.
+
+# Built-in metadata tools
+
+- [LazyInMemoryMetadata](#lazyinmemorymetadata)
+- [ManipulatedMetadata](#manipulatedmetadata)
+
+## LazyInMemoryMetadata
+
+This class will make sure that the metadata is only collected once and stores it in memory for a second access.
+
+Example output:
+
+```php
+<?php
+
+use \Phpro\SoapClient\Soap\Engine\Metadata\LazyInMemoryMetadata;
+use \Phpro\SoapClient\Soap\Engine\Metadata\MetadataFactory;
+
+$lazy = MetadataFactory::lazy($actualMetadataInterface);
+```
+
+## ManipulatedMetadata
+
+This class makes it possible to manipulate metadata on the-fly.
+This can be handy for changing things before code is generated.
+Example use-cases are the duplicate type strategies in the ExtSoap driver.
+
+Example output:
+
+```php
+<?php
+
+use \Phpro\SoapClient\Soap\Engine\Metadata\ManipulatedMetadata;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorChain;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorChain;
+use \Phpro\SoapClient\Soap\Engine\Metadata\MetadataFactory;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataOptions;
+
+$lazyManipulated = MetadataFactory::manipulated(
+    $actualMetadataInterface,
+    (new MetadataOptions())
+        ->withMethodsManipulator(
+            new MethodsManipulatorChain()
+        )
+        ->withTypesManipulator(
+            new TypesManipulatorChain()
+        )
+);
+```

--- a/docs/drivers/new.md
+++ b/docs/drivers/new.md
@@ -106,6 +106,9 @@ class MyMetadataProvider implements MetadataProviderInterface
 }
 ```
 
+We provided some generic metadata tools that you can use to e.g. manipulate the metadata during code generation.
+You can find [more information about the metadata on this page](./metadata.md).
+
 Since detecting the metdata is a rather complex topic, you need to make sure it works the way we expect it to work.
 Therefor, you need to create a testcase for your implementation.
 We've provided the `PhproTest\SoapClient\Integration\Soap\Engine\AbstractMetadataProviderTest` to make sure all kinds of types are covered.

--- a/docs/known-issues/ext-soap.md
+++ b/docs/known-issues/ext-soap.md
@@ -13,10 +13,12 @@ This package will generate the code for the last detected type in the WSDL.
 
 Suggested workaround:
 
-- Manually create the missing classes.
-- Determine which is the most important type and use that one in the classmap.
-- You can use the type converters for the other type(s) with the same name.
-- You'll need to manually parse the XML and link it to an object.
+1. Use one of [the built-in duplicate types strategies](../drivers/ext-soap.md)
+2. Manually determine type converters for the various classes:
+    - Manually create the missing classes.
+    - Determine which is the most important type and use that one in the classmap.
+    - You can use the type converters for the other type(s) with the same name.
+    - You'll need to manually parse the XML and link it to an object.
 
 ```php
 $soapOptions = [

--- a/docs/known-issues/ext-soap.md
+++ b/docs/known-issues/ext-soap.md
@@ -2,6 +2,7 @@
 
 - [Duplicate typenames](#duplicate-typenames)
 - [Enumerations](#enumerations)
+- [Occurs](#occurs)
 
 Isn't your issue listed below? Feel free to provide additional issues in a functional test.
 
@@ -13,7 +14,7 @@ This package will generate the code for the last detected type in the WSDL.
 
 Suggested workaround:
 
-1. Use one of [the built-in duplicate types strategies](../drivers/ext-soap.md)
+1. Use one of [the built-in duplicate types strategies](../drivers/ext-soap.md#duplicate-types)
 2. Manually determine type converters for the various classes:
     - Manually create the missing classes.
     - Determine which is the most important type and use that one in the classmap.
@@ -96,3 +97,14 @@ $soapOptions = [
 More information:
 - [Functional test](../../test/PhproTest/SoapClient/Functional/ExtSoap/Encoding/EnumTest.php)
 - [Lack of validation in php-src](https://github.com/php/php-src/blob/php-7.2.10/ext/soap/php_encoding.c#L3172-L3200)
+
+
+## Occurs
+
+It is possible that the WSDL file contains `minOccurs` and `maxOccurs` on XSD elements.
+Ext-soap will not make this information available through the public API of the SOAP client.
+Therefore, we cannot predict during code generation if a type will definitely be an array or possibly be nullable.
+
+Currently, this issue can be avoided by not generating too strict types in the soap-client and optionally by using the [IteratorAssembler](../code-generation/assemblers.md#iteratorassembler).
+A better solution would be to parse the WSDL manually and add that information to the metadata.
+From that point on we can take this information into consideration during code generation.

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,4 @@
-parameters:
-    git_dir: .
-    bin_dir: ./vendor/bin
+grumphp:
     tasks:
         phpcs:
             standard: "PSR2"

--- a/spec/Phpro/SoapClient/Soap/Engine/Metadata/Collection/PropertyCollectionSpec.php
+++ b/spec/Phpro/SoapClient/Soap/Engine/Metadata/Collection/PropertyCollectionSpec.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace spec\Phpro\SoapClient\Soap\Engine\Metadata\Collection;
+
+use Phpro\SoapClient\Exception\MetadataException;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Property;
+use PhpSpec\ObjectBehavior;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\PropertyCollection;
+
+/**
+ * Class PropertyCollectionSpec
+ */
+class PropertyCollectionSpec extends ObjectBehavior
+{
+    function let(Property $property)
+    {
+        $this->beConstructedWith($property);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PropertyCollection::class);
+    }
+
+    function it_is_an_iterator_aggregate()
+    {
+        $this->shouldHaveType(\IteratorAggregate::class);
+    }
+
+    function it_is_countable()
+    {
+        $this->shouldHaveType(\Countable::class);
+    }
+
+    function it_has_a_count()
+    {
+        $this->count()->shouldBe(1);
+    }
+
+    function it_can_return_iterator(Property $property)
+    {
+        $iterator = $this->getIterator();
+        $iterator->shouldHaveType(\ArrayIterator::class);
+        $iterator->shouldIterateAs([$property]);
+    }
+
+    function it_can_map_over_properties()
+    {
+        $this->map(function() {
+            return 'hello';
+        })->shouldBe(['hello']);
+    }
+
+    function it_can_map_names(Property $property)
+    {
+        $property->getName()->willReturn('name');
+        $this->mapNames()->shouldBe(['name']);
+    }
+
+    function it_can_filter_uniques(Property $property1, Property $property2, Property $property3)
+    {
+        $property1->getName()->willReturn('prop');
+        $property2->getName()->willReturn('prop');
+        $property3->getName()->willReturn('prop2');
+
+        $this->beConstructedWith($property1, $property2, $property3);
+        $new = $this->unique();
+        $this->shouldNotBe($new);
+        $new->shouldIterateAs([$property2, $property3]);
+    }
+}

--- a/spec/Phpro/SoapClient/Soap/Engine/Metadata/Collection/TypeCollectionSpec.php
+++ b/spec/Phpro/SoapClient/Soap/Engine/Metadata/Collection/TypeCollectionSpec.php
@@ -69,4 +69,45 @@ class TypeCollectionSpec extends ObjectBehavior
         $type->getName()->willReturn($name = 'name');
         $this->shouldthrow(MetadataException::class)->duringFetchOneByName('invalid');
     }
+
+    public function it_can_filter_types(Type $type1, Type $type2): void
+    {
+        $this->beConstructedWith($type1, $type2);
+        $new = $this->filter(function (Type $type) use ($type1) {
+            return $type1->getWrappedObject() === $type;
+        });
+
+        $this->shouldNotBe($new);
+        $new->shouldBeAnInstanceOf(TypeCollection::class);
+        $new->shouldIterateAs([$type1]);
+    }
+
+    public function it_can_reduce(Type $type1, Type $type2): void
+    {
+        $this->beConstructedWith($type1, $type2);
+        $result = $this->reduce(
+            function (int $carry, Type $type) {
+                return $carry + 1;
+            },
+            0
+        );
+
+        $result->shouldBe(2);
+    }
+
+    public function it_can_fetch_multiple_by_normalized_name(Type $type1, Type $type2, Type $type3, Type $type4): void
+    {
+        $this->beConstructedWith($type1, $type2, $type3, $type4);
+
+        $type1->getName()->willReturn('file');
+        $type2->getName()->willReturn('File');
+        $type3->getName()->willReturn('-File');
+        $type4->getName()->willReturn('SomethingElse');
+
+        $result = $this->fetchAllByNormalizedName('File');
+
+        $this->shouldNotBe($result);
+        $result->shouldBeAnInstanceOf(TypeCollection::class);
+        $result->shouldIterateAs([$type1, $type2, $type3]);
+    }
 }

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/ExtSoapOptions.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/ExtSoapOptions.php
@@ -41,7 +41,7 @@ class ExtSoapOptions
         $this->wsdl = $wsdl;
         $this->options = $options;
         $this->wsdlProvider = new MixedWsdlProvider();
-        $this->metadataOptions = new MetadataOptions();
+        $this->metadataOptions = MetadataOptions::empty();
     }
 
     public static function defaults(string $wsdl, array $options = []): self

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/ExtSoapOptions.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/ExtSoapOptions.php
@@ -66,7 +66,7 @@ class ExtSoapOptions
                     $options
                 )
             )
-        )->withMetaOptions(static function (MetadataOptions $options): MetadataOptions {
+        )->withMetadataOptions(static function (MetadataOptions $options): MetadataOptions {
             // Ext-soap is not able to work with duplicate types (see FAQ)
             // Therefore, we decided to combine all duplicate types into 1 big intersected type instead.
             // Therefore it will always be usable, but might contain some empty properties.
@@ -133,7 +133,7 @@ class ExtSoapOptions
         return $this;
     }
 
-    public function withMetaOptions(callable $manipulator): self
+    public function withMetadataOptions(callable $manipulator): self
     {
         $this->metadataOptions = $manipulator($this->metadataOptions);
 

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetector.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Detector;
 
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
 use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
 
@@ -18,7 +19,11 @@ final class DuplicateTypeNamesDetector
     {
         return array_keys(
             array_filter(
-                array_count_values($types->mapNames()),
+                array_count_values($types->map(
+                    static function (Type $type) {
+                        return Normalizer::normalizeClassname($type->getName());
+                    }
+                )),
                 static function (int $count): bool {
                     return $count > 1;
                 }

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetector.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetector.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Detector;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+
+final class DuplicateTypeNamesDetector
+{
+    /**
+     * @param TypeCollection $types
+     *
+     * @return string[]
+     */
+    public function __invoke(TypeCollection $types): array
+    {
+        return array_keys(
+            array_filter(
+                array_count_values($types->mapNames()),
+                static function (int $count): bool {
+                    return $count > 1;
+                }
+            )
+        );
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetector.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetector.php
@@ -20,7 +20,7 @@ final class DuplicateTypeNamesDetector
         return array_keys(
             array_filter(
                 array_count_values($types->map(
-                    static function (Type $type) {
+                    static function (Type $type): string {
                         return Normalizer::normalizeClassname($type->getName());
                     }
                 )),

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes;
 
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Soap\Engine\Metadata\Collection\PropertyCollection;
 use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
 use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
@@ -15,7 +16,7 @@ final class IntersectDuplicateTypesStrategy implements TypesManipulatorInterface
     {
         return new TypeCollection(...array_values($allTypes->reduce(
             function (array $result, Type $type) use ($allTypes) {
-                $name = $type->getName();
+                $name = Normalizer::normalizeClassname($type->getName());
                 if (array_key_exists($name, $result)) {
                     return $result;
                 }

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\PropertyCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+
+final class IntersectDuplicateTypesStrategy implements TypesManipulatorInterface
+{
+    public function __invoke(TypeCollection $allTypes): TypeCollection
+    {
+        return new TypeCollection(...array_values($allTypes->reduce(
+            function (array $result, Type $type) use ($allTypes) {
+                $name = $type->getName();
+                if (array_key_exists($name, $result)) {
+                    return $result;
+                }
+
+                return array_merge(
+                    $result,
+                    [
+                        $name => $this->intersectTypes($allTypes->fetchAllByName($name))
+                    ]
+                );
+            },
+            []
+        )));
+    }
+
+    private function intersectTypes(TypeCollection $duplicateTypes): Type
+    {
+        return new Type(
+            current($duplicateTypes)->getXsdType(),
+            iterator_to_array(
+                (new PropertyCollection(...array_merge(
+                    $duplicateTypes->map(static function (Type $type): array {
+                        return $type->getProperties();
+                    })
+                )))->unique()
+            )
+        );
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
@@ -34,10 +34,10 @@ final class IntersectDuplicateTypesStrategy implements TypesManipulatorInterface
     private function intersectTypes(TypeCollection $duplicateTypes): Type
     {
         return new Type(
-            current($duplicateTypes)->getXsdType(),
+            current(iterator_to_array($duplicateTypes))->getXsdType(),
             iterator_to_array(
                 (new PropertyCollection(...array_merge(
-                    $duplicateTypes->map(static function (Type $type): array {
+                    ...$duplicateTypes->map(static function (Type $type): array {
                         return $type->getProperties();
                     })
                 )))->unique()

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
@@ -24,7 +24,7 @@ final class IntersectDuplicateTypesStrategy implements TypesManipulatorInterface
                 return array_merge(
                     $result,
                     [
-                        $name => $this->intersectTypes($allTypes->fetchAllByName($name))
+                        $name => $this->intersectTypes($allTypes->fetchAllByNormalizedName($name))
                     ]
                 );
             },

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
@@ -15,7 +15,7 @@ final class IntersectDuplicateTypesStrategy implements TypesManipulatorInterface
     public function __invoke(TypeCollection $allTypes): TypeCollection
     {
         return new TypeCollection(...array_values($allTypes->reduce(
-            function (array $result, Type $type) use ($allTypes) {
+            function (array $result, Type $type) use ($allTypes): array {
                 $name = Normalizer::normalizeClassname($type->getName());
                 if (array_key_exists($name, $result)) {
                     return $result;

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes;
 
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Detector\DuplicateTypeNamesDetector;
 use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
 use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
@@ -16,7 +17,7 @@ final class RemoveDuplicateTypesStrategy implements TypesManipulatorInterface
         $duplicateNames = (new DuplicateTypeNamesDetector())($types);
 
         return $types->filter(static function (Type $type) use ($duplicateNames): bool {
-            return !in_array($type->getName(), $duplicateNames, true);
+            return !in_array(Normalizer::normalizeClassname($type->getName()), $duplicateNames, true);
         });
     }
 }

--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes;
+
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Detector\DuplicateTypeNamesDetector;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+
+final class RemoveDuplicateTypesStrategy implements TypesManipulatorInterface
+{
+    public function __invoke(TypeCollection $types): TypeCollection
+    {
+        $duplicateNames = (new DuplicateTypeNamesDetector())($types);
+
+        return $types->filter(static function (Type $type) use ($duplicateNames): bool {
+            return !in_array($type->getName(), $duplicateNames, true);
+        });
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/PropertyCollection.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/PropertyCollection.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata\Collection;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Property;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+
+class PropertyCollection implements \IteratorAggregate, \Countable
+{
+    /**
+     * @var Property[]
+     */
+    private $properties;
+
+    public function __construct(Property ...$properties)
+    {
+        $this->properties = $properties;
+    }
+
+    /**
+     * @return \ArrayIterator|Property[]
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->properties);
+    }
+
+    public function count(): int
+    {
+        return count($this->properties);
+    }
+
+    public function map(callable  $callback): array
+    {
+        return array_map($callback, $this->properties);
+    }
+
+    public function mapNames(): array
+    {
+        return $this->map(static function (Property $property): string {
+            return $property->getName();
+        });
+    }
+
+    public function unique(): self
+    {
+        return new PropertyCollection(...array_values(
+            array_combine(
+                $this->mapNames(),
+                $this->properties
+            )
+        ));
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/PropertyCollection.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/PropertyCollection.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phpro\SoapClient\Soap\Engine\Metadata\Collection;
 
 use Phpro\SoapClient\Soap\Engine\Metadata\Model\Property;
-use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
 
 class PropertyCollection implements \IteratorAggregate, \Countable
 {

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/TypeCollection.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/TypeCollection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap\Engine\Metadata\Collection;
 
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\MetadataException;
 use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
 
@@ -77,10 +78,10 @@ class TypeCollection implements \IteratorAggregate, \Countable
         throw MetadataException::typeNotFound($name);
     }
 
-    public function fetchAllByName(string $name): TypeCollection
+    public function fetchAllByNormalizedName(string $name): TypeCollection
     {
         return $this->filter(static function (Type $type) use ($name): bool {
-            return $type->getName() === $name;
+            return Normalizer::normalizeClassname($type->getName()) === $name;
         });
     }
 }

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/TypeCollection.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/TypeCollection.php
@@ -49,13 +49,6 @@ class TypeCollection implements \IteratorAggregate, \Countable
         return array_map($callback, $this->types);
     }
 
-    public function mapNames(): array
-    {
-        return $this->map(static function (Type $type): string {
-            return $type->getName();
-        });
-    }
-
     public function filter(callable $filter): self
     {
         return new self(...array_filter(

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/TypeCollection.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Collection/TypeCollection.php
@@ -49,6 +49,30 @@ class TypeCollection implements \IteratorAggregate, \Countable
         return array_map($callback, $this->types);
     }
 
+    public function mapNames(): array
+    {
+        return $this->map(static function (Type $type): string {
+            return $type->getName();
+        });
+    }
+
+    public function filter(callable $filter): self
+    {
+        return new self(...array_filter(
+            $this->types,
+            $filter
+        ));
+    }
+
+    public function reduce(callable $reducer, $initial = null)
+    {
+        return array_reduce(
+            $this->types,
+            $reducer,
+            $initial
+        );
+    }
+
     public function fetchOneByName(string $name): Type
     {
         foreach ($this->types as $type) {
@@ -58,5 +82,12 @@ class TypeCollection implements \IteratorAggregate, \Countable
         }
 
         throw MetadataException::typeNotFound($name);
+    }
+
+    public function fetchAllByName(string $name): TypeCollection
+    {
+        return $this->filter(static function (Type $type) use ($name): bool {
+            return $type->getName() === $name;
+        });
     }
 }

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/ManipulatedMetadata.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/ManipulatedMetadata.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+
+class ManipulatedMetadata implements MetadataInterface
+{
+    /**
+     * @var MetadataInterface
+     */
+    private $metadata;
+
+    /**
+     * @var TypesManipulatorInterface
+     */
+    private $typesChangingStrategy;
+
+    /**
+     * @var MethodsManipulatorInterface
+     */
+    private $methodsChangingStrategyInterface;
+
+    public function __construct(
+        MetadataInterface $metadata,
+        MethodsManipulatorInterface $methodsChangingStrategyInterface,
+        TypesManipulatorInterface $typesChangingStrategy
+    ) {
+
+        $this->metadata = $metadata;
+        $this->methodsChangingStrategyInterface = $methodsChangingStrategyInterface;
+        $this->typesChangingStrategy = $typesChangingStrategy;
+    }
+
+    public function getTypes(): TypeCollection
+    {
+        return ($this->typesChangingStrategy)($this->metadata->getTypes());
+    }
+
+    public function getMethods(): MethodCollection
+    {
+        return ($this->methodsChangingStrategyInterface)($this->metadata->getMethods());
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Manipulators/MethodsManipulatorChain.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Manipulators/MethodsManipulatorChain.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata\Manipulators;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+
+final class MethodsManipulatorChain implements MethodsManipulatorInterface
+{
+    /**
+     * @var MethodsManipulatorInterface[]
+     */
+    private $manipulators;
+
+    public function __construct(MethodsManipulatorInterface ...$manipulators)
+    {
+        $this->manipulators = $manipulators;
+    }
+
+    public function __invoke(MethodCollection $allMethods): MethodCollection
+    {
+        return array_reduce(
+            $this->manipulators,
+            static function (MethodCollection $methods, MethodsManipulatorInterface $manipulator): MethodCollection {
+                return $manipulator($methods);
+            },
+            $allMethods
+        );
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Manipulators/MethodsManipulatorInterface.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Manipulators/MethodsManipulatorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata\Manipulators;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+
+interface MethodsManipulatorInterface
+{
+    /**
+     * By implementing this method, you can change a collection of types into a different collection of types.
+     * This makes it possible to alter, remove, combine, add, .. methods on the fly!
+     */
+    public function __invoke(MethodCollection $allMethods): MethodCollection;
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Manipulators/TypesManipulatorChain.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Manipulators/TypesManipulatorChain.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata\Manipulators;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+
+final class TypesManipulatorChain implements TypesManipulatorInterface
+{
+    /**
+     * @var TypesManipulatorInterface[]
+     */
+    private $manipulators;
+
+    public function __construct(TypesManipulatorInterface ...$manipulators)
+    {
+        $this->manipulators = $manipulators;
+    }
+
+    public function __invoke(TypeCollection $allTypes): TypeCollection
+    {
+        return array_reduce(
+            $this->manipulators,
+            static function (TypeCollection $types, TypesManipulatorInterface $manipulator): TypeCollection {
+                return $manipulator($types);
+            },
+            $allTypes
+        );
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Manipulators/TypesManipulatorInterface.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Manipulators/TypesManipulatorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata\Manipulators;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+
+interface TypesManipulatorInterface
+{
+    /**
+     * By implementing this method, you can change a collection of types into a different collection of types.
+     * This makes it possible to alter, remove, combine, add, .. types on the fly!
+     */
+    public function __invoke(TypeCollection $allTypes): TypeCollection;
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/MetadataFactory.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/MetadataFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata;
+
+class MetadataFactory
+{
+    public static function lazy(MetadataInterface $metadata): MetadataInterface
+    {
+        return new LazyInMemoryMetadata($metadata);
+    }
+
+    public static function manipulated(MetadataInterface $metadata, MetadataOptions $options): MetadataInterface
+    {
+        return self::lazy(
+            new ManipulatedMetadata(
+                $metadata,
+                $options->getMethodsManipulator(),
+                $options->getTypesManipulator()
+            )
+        );
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/MetadataOptions.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/MetadataOptions.php
@@ -21,10 +21,17 @@ final class MetadataOptions
      */
     private $typesManipulator;
 
-    public function __construct()
+    public function __construct(
+        MethodsManipulatorInterface $methodsManipulator,
+        TypesManipulatorInterface $typesManipulator
+    ) {
+        $this->methodsManipulator = $methodsManipulator;
+        $this->typesManipulator = $typesManipulator;
+    }
+
+    public static function empty(): self
     {
-        $this->methodsManipulator = new MethodsManipulatorChain();
-        $this->typesManipulator = new TypesManipulatorChain();
+        return new self(new MethodsManipulatorChain(), new TypesManipulatorChain());
     }
 
     public function withMethodsManipulator(MethodsManipulatorInterface $methodsManipulator): self

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/MetadataOptions.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/MetadataOptions.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorChain;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorChain;
+
+final class MetadataOptions
+{
+    /**
+     * @var MethodsManipulatorInterface
+     */
+    private $methodsManipulator;
+
+    /**
+     * @var TypesManipulatorInterface
+     */
+    private $typesManipulator;
+
+    public function __construct()
+    {
+        $this->methodsManipulator = new MethodsManipulatorChain();
+        $this->typesManipulator = new TypesManipulatorChain();
+    }
+
+    public function withMethodsManipulator(MethodsManipulatorInterface $methodsManipulator): self
+    {
+        $new = clone $this;
+        $new->methodsManipulator = $methodsManipulator;
+
+        return $new;
+    }
+
+    public function withTypesManipulator(TypesManipulatorInterface $typesManipulator): self
+    {
+        $new = clone $this;
+        $new->typesManipulator = $typesManipulator;
+
+        return $new;
+    }
+
+    public function getMethodsManipulator(): MethodsManipulatorInterface
+    {
+        return $this->methodsManipulator;
+    }
+
+    public function getTypesManipulator(): TypesManipulatorInterface
+    {
+        return $this->typesManipulator;
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Model/Type.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Model/Type.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap\Engine\Metadata\Model;
 
+/**
+ * @TODO V2.0 : Make properties instance of type PropertyCollection !
+ */
 class Type
 {
     /**

--- a/test/PhproTest/SoapClient/Integration/Soap/Driver/ExtSoap/ExtSoapOptionsTest.php
+++ b/test/PhproTest/SoapClient/Integration/Soap/Driver/ExtSoap/ExtSoapOptionsTest.php
@@ -255,7 +255,7 @@ class ExtSoapOptionsTest extends TestCase
         $options = new ExtSoapOptions($this->wsdl, []);
         $metadataOptions = $options->getMetadataOptions();
 
-        self::assertEquals(new MetadataOptions(), $metadataOptions);
+        self::assertEquals(MetadataOptions::empty(), $metadataOptions);
     }
 
     /** @test */
@@ -263,7 +263,7 @@ class ExtSoapOptionsTest extends TestCase
     {
         $options = ExtSoapOptions::defaults($this->wsdl);
         $metadataOptions = $options->getMetadataOptions();
-        $expectedMetadataOptions = (new MetadataOptions())->withTypesManipulator(
+        $expectedMetadataOptions = MetadataOptions::empty()->withTypesManipulator(
             new TypesManipulatorChain(new IntersectDuplicateTypesStrategy())
         );
 
@@ -275,7 +275,7 @@ class ExtSoapOptionsTest extends TestCase
     {
         $options = ExtSoapOptions::defaults($this->wsdl);
         $metadataOptions = $options->getMetadataOptions();
-        $expectedOptions = new MetadataOptions();
+        $expectedOptions = MetadataOptions::empty();
 
         $options->withMetaOptions(function ($options) use ($metadataOptions, $expectedOptions) {
             self::assertSame($metadataOptions, $options);

--- a/test/PhproTest/SoapClient/Integration/Soap/Driver/ExtSoap/ExtSoapOptionsTest.php
+++ b/test/PhproTest/SoapClient/Integration/Soap/Driver/ExtSoap/ExtSoapOptionsTest.php
@@ -9,6 +9,9 @@ use Phpro\SoapClient\Soap\ClassMap\ClassMap;
 use Phpro\SoapClient\Soap\ClassMap\ClassMapCollection;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptionsResolverFactory;
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes\IntersectDuplicateTypesStrategy;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorChain;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataOptions;
 use Phpro\SoapClient\Soap\TypeConverter;
 use Phpro\SoapClient\Wsdl\Provider\WsdlProviderInterface;
 use PHPUnit\Framework\TestCase;
@@ -244,5 +247,41 @@ class ExtSoapOptionsTest extends TestCase
         foreach ($options as $key => $option) {
             $this->assertSame($expectedOptions[$key], $option);
         }
+    }
+
+    /** @test */
+    public function it_contains_empty_metadata_options(): void
+    {
+        $options = new ExtSoapOptions($this->wsdl, []);
+        $metadataOptions = $options->getMetadataOptions();
+
+        self::assertEquals(new MetadataOptions(), $metadataOptions);
+    }
+
+    /** @test */
+    public function it_adds_prefered_default_metadata_options(): void
+    {
+        $options = ExtSoapOptions::defaults($this->wsdl);
+        $metadataOptions = $options->getMetadataOptions();
+        $expectedMetadataOptions = (new MetadataOptions())->withTypesManipulator(
+            new TypesManipulatorChain(new IntersectDuplicateTypesStrategy())
+        );
+
+        self::assertEquals($expectedMetadataOptions, $metadataOptions);
+    }
+
+    /** @test */
+    public function it_is_possible_to_change_metadata_options(): void
+    {
+        $options = ExtSoapOptions::defaults($this->wsdl);
+        $metadataOptions = $options->getMetadataOptions();
+        $expectedOptions = new MetadataOptions();
+
+        $options->withMetaOptions(function ($options) use ($metadataOptions, $expectedOptions) {
+            self::assertSame($metadataOptions, $options);
+            return $expectedOptions;
+        });
+
+        self::assertEquals($expectedOptions, $options->getMetadataOptions());
     }
 }

--- a/test/PhproTest/SoapClient/Integration/Soap/Driver/ExtSoap/ExtSoapOptionsTest.php
+++ b/test/PhproTest/SoapClient/Integration/Soap/Driver/ExtSoap/ExtSoapOptionsTest.php
@@ -277,7 +277,7 @@ class ExtSoapOptionsTest extends TestCase
         $metadataOptions = $options->getMetadataOptions();
         $expectedOptions = MetadataOptions::empty();
 
-        $options->withMetaOptions(function ($options) use ($metadataOptions, $expectedOptions) {
+        $options->withMetadataOptions(function ($options) use ($metadataOptions, $expectedOptions) {
             self::assertSame($metadataOptions, $options);
             return $expectedOptions;
         });

--- a/test/PhproTest/SoapClient/Unit/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetectorTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetectorTest.php
@@ -25,7 +25,7 @@ class DuplicateTypeNamesDetectorTest extends TestCase
             new Type(XsdType::create('with*specialchar'), []),
             new Type(XsdType::create('not-duplicate'), []),
             new Type(XsdType::create('CASEISDIFFERENT'), []),
-            new Type(XsdType::create('Case-is-different'), []),
+            new Type(XsdType::create('Case-is-different'), [])
         );
 
         $duplicates = $detector($types);

--- a/test/PhproTest/SoapClient/Unit/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetectorTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Driver/ExtSoap/Metadata/Detector/DuplicateTypeNamesDetectorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Driver\ExtSoap\Metadata\Detector;
+
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Detector\DuplicateTypeNamesDetector;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use PHPUnit\Framework\TestCase;
+
+class DuplicateTypeNamesDetectorTest extends TestCase
+{
+    /** @test */
+    public function it_can_detect_duplicate_type_names(): void
+    {
+        $detector = new DuplicateTypeNamesDetector();
+        $types = new TypeCollection(
+            new Type(XsdType::create('file'), []),
+            new Type(XsdType::create('file'), []),
+            new Type(XsdType::create('uppercased'), []),
+            new Type(XsdType::create('Uppercased'), []),
+            new Type(XsdType::create('with-specialchar'), []),
+            new Type(XsdType::create('with*specialchar'), []),
+            new Type(XsdType::create('not-duplicate'), []),
+            new Type(XsdType::create('CASEISDIFFERENT'), []),
+            new Type(XsdType::create('Case-is-different'), []),
+        );
+
+        $duplicates = $detector($types);
+
+        self::assertSame(
+            ['File', 'Uppercased', 'WithSpecialchar'],
+            $duplicates
+        );
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes;
+
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes\IntersectDuplicateTypesStrategy;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Property;
+use PHPUnit\Framework\TestCase;
+
+class IntersectDuplicateTypesStrategyTest extends TestCase
+{
+    public function it_is_a_types_manipulator(): void
+    {
+        $strategy = new IntersectDuplicateTypesStrategy();
+        self::assertInstanceOf(TypesManipulatorInterface::class, $strategy);
+    }
+
+    /** @test */
+    public function it_can_intersect_duplicate_types(): void
+    {
+        $strategy = new IntersectDuplicateTypesStrategy();
+        $types = new TypeCollection(
+            new Type(XsdType::create('file'), [
+                new Property('prop1', XsdType::create('string')),
+                new Property('prop3', XsdType::create('string')),
+            ]),
+            new Type(XsdType::create('file'), [
+                new Property('prop1', XsdType::create('string')),
+                new Property('prop2', XsdType::create('string')),
+            ]),
+            new Type(XsdType::create('uppercased'), []),
+            new Type(XsdType::create('Uppercased'), []),
+            new Type(XsdType::create('with-specialchar'), []),
+            new Type(XsdType::create('with*specialchar'), []),
+            new Type(XsdType::create('not-duplicate'), []),
+            new Type(XsdType::create('CASEISDIFFERENT'), []),
+            new Type(XsdType::create('Case-is-different'), [])
+        );
+
+        $manipulated = $strategy($types);
+
+        self::assertInstanceOf(TypeCollection::class, $manipulated);
+        self::assertEquals(
+            [
+                new Type(XsdType::create('file'), [
+                    new Property('prop1', XsdType::create('string')),
+                    new Property('prop3', XsdType::create('string')),
+                    new Property('prop2', XsdType::create('string')),
+                ]),
+                new Type(XsdType::create('uppercased'), []),
+                new Type(XsdType::create('with-specialchar'), []),
+                new Type(XsdType::create('not-duplicate'), []),
+                new Type(XsdType::create('CASEISDIFFERENT'), []),
+                new Type(XsdType::create('Case-is-different'), []),
+            ],
+            iterator_to_array($manipulated)
+        );
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Driver/ExtSoap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes;
+
+use Phpro\SoapClient\Soap\Driver\ExtSoap\Metadata\Manipulators\DuplicateTypes\RemoveDuplicateTypesStrategy;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Property;
+use PHPUnit\Framework\TestCase;
+
+class RemoveDuplicateTypesStrategyTest extends TestCase
+{
+    public function it_is_a_types_manipulator(): void
+    {
+        $strategy = new RemoveDuplicateTypesStrategy();
+        self::assertInstanceOf(TypesManipulatorInterface::class, $strategy);
+    }
+
+    /** @test */
+    public function it_can_intersect_duplicate_types(): void
+    {
+        $strategy = new RemoveDuplicateTypesStrategy();
+        $types = new TypeCollection(
+            new Type(XsdType::create('file'), []),
+            new Type(XsdType::create('file'), []),
+            new Type(XsdType::create('uppercased'), []),
+            new Type(XsdType::create('Uppercased'), []),
+            new Type(XsdType::create('with-specialchar'), []),
+            new Type(XsdType::create('with*specialchar'), []),
+            new Type(XsdType::create('not-duplicate'), []),
+            new Type(XsdType::create('CASEISDIFFERENT'), []),
+            new Type(XsdType::create('Case-is-different'), [])
+        );
+
+        $manipulated = $strategy($types);
+
+        self::assertInstanceOf(TypeCollection::class, $manipulated);
+        self::assertEquals(
+            [
+                new Type(XsdType::create('not-duplicate'), []),
+                new Type(XsdType::create('CASEISDIFFERENT'), []),
+                new Type(XsdType::create('Case-is-different'), []),
+            ],
+            iterator_to_array($manipulated)
+        );
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/ManipulatedMetadataTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/ManipulatedMetadataTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Engine\Metadata;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\ManipulatedMetadata;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorChain;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorChain;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Method;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use PHPUnit\Framework\TestCase;
+
+class ManipulatedMetadataTest extends TestCase
+{
+    /**
+     * @var MetadataInterface
+     */
+    private $metadata;
+
+    protected function setUp(): void
+    {
+        $this->metadata = new class implements MetadataInterface
+        {
+            public function getTypes(): TypeCollection
+            {
+                return new TypeCollection();
+            }
+
+            public function getMethods(): MethodCollection
+            {
+                return new MethodCollection();
+            }
+        };
+    }
+
+    /** @test */
+    public function it_is_a_metdata_object(): void
+    {
+        self::assertInstanceOf(MetadataInterface::class, new ManipulatedMetadata(
+            $this->metadata,
+            new MethodsManipulatorChain(),
+            new TypesManipulatorChain()
+        ));
+    }
+
+    /** @test */
+    public function it_proxies_everything_on_no_manipulators(): void
+    {
+        $manipulator = new ManipulatedMetadata(
+            $this->metadata,
+            new MethodsManipulatorChain(),
+            new TypesManipulatorChain()
+        );
+
+        self::assertEquals($this->metadata->getMethods(), $manipulator->getMethods());
+        self::assertEquals($this->metadata->getTypes(), $manipulator->getTypes());
+    }
+
+    /** @test */
+    public function it_can_manipulate_methods(): void
+    {
+        $manipulatedMeta = new ManipulatedMetadata(
+            $this->metadata,
+            new class implements MethodsManipulatorInterface {
+                public function __invoke(MethodCollection $allMethods): MethodCollection
+                {
+                    return new MethodCollection(new Method('method', [], XsdType::create('Response')));
+                }
+
+            },
+            new TypesManipulatorChain()
+        );
+
+        self::assertEquals(
+            new MethodCollection(new Method('method', [], XsdType::create('Response'))),
+            $manipulatedMeta->getMethods()
+        );
+    }
+
+    /** @test */
+    public function it_can_manipulate_types(): void
+    {
+        $manipulatedMeta = new ManipulatedMetadata(
+            $this->metadata,
+            new MethodsManipulatorChain(),
+            new class implements TypesManipulatorInterface {
+                public function __invoke(TypeCollection $allTypes): TypeCollection
+                {
+                    return new TypeCollection(new Type(XsdType::create('Type'), []));
+                }
+            }
+        );
+
+        self::assertEquals(
+            new TypeCollection(new Type(XsdType::create('Type'), [])),
+            $manipulatedMeta->getTypes()
+        );
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/Manipulators/MethodsManipulatorChainTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/Manipulators/MethodsManipulatorChainTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Engine\Metadata\Manipulators;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorChain;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Method;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use PHPUnit\Framework\TestCase;
+
+class MethodsManipulatorChainTest extends TestCase
+{
+    /** @test */
+    public function it_is_a_method_manipulator(): void
+    {
+        self::assertInstanceOf(MethodsManipulatorInterface::class, new MethodsManipulatorChain());
+    }
+
+    /** @test */
+    public function it_does_not_touch_methods_with_no_manipulator(): void
+    {
+        $methods = new MethodCollection();
+        $chain = new MethodsManipulatorChain();
+        $result = $chain($methods);
+
+        self::assertSame($methods, $result);
+    }
+
+    /** @test */
+    public function it_manipulates_methods_collection(): void
+    {
+        $methods = new MethodCollection();
+        $chain = new MethodsManipulatorChain(
+            new class implements MethodsManipulatorInterface {
+                public function __invoke(MethodCollection $allMethods): MethodCollection
+                {
+                    return new MethodCollection(...array_merge(
+                        iterator_to_array($allMethods),
+                        [new Method('method', [], XsdType::create('Response'))]
+                    ));
+                }
+            },
+            new class implements MethodsManipulatorInterface {
+                public function __invoke(MethodCollection $allMethods): MethodCollection
+                {
+                    return new MethodCollection(...array_merge(
+                        iterator_to_array($allMethods),
+                        [new Method('method2', [], XsdType::create('Response'))]
+                    ));
+                }
+            }
+        );
+        $result = $chain($methods);
+
+        self::assertNotSame($methods, $result);
+        self::assertInstanceOf(MethodCollection::class, $result);
+        self::assertCount(2, $result);
+        self::assertEquals(
+            [
+                new Method('method', [], XsdType::create('Response')),
+                new Method('method2', [], XsdType::create('Response')),
+            ],
+            iterator_to_array($result)
+        );
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/Manipulators/TypesManipulatorChainTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/Manipulators/TypesManipulatorChainTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Engine\Metadata\Manipulators;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorChain;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Type;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use PHPUnit\Framework\TestCase;
+
+class TypesManipulatorChainTest extends TestCase
+{
+    /** @test */
+    public function it_is_a_type_manipulator(): void
+    {
+        self::assertInstanceOf(TypesManipulatorInterface::class, new TypesManipulatorChain());
+    }
+
+    /** @test */
+    public function it_does_not_touch_types_with_no_manipulator(): void
+    {
+        $types = new TypeCollection();
+        $chain = new TypesManipulatorChain();
+        $result = $chain($types);
+
+        self::assertSame($types, $result);
+    }
+
+    /** @test */
+    public function it_manipulates_types_collection(): void
+    {
+        $types = new TypeCollection();
+        $chain = new TypesManipulatorChain(
+            new class implements TypesManipulatorInterface {
+                public function __invoke(TypeCollection $allTypes): TypeCollection
+                {
+                    return new TypeCollection(...array_merge(
+                        iterator_to_array($allTypes),
+                        [new Type(XsdType::create('Response'), [])]
+                    ));
+                }
+            },
+            new class implements TypesManipulatorInterface {
+                public function __invoke(TypeCollection $allTypes): TypeCollection
+                {
+                    return new TypeCollection(...array_merge(
+                        iterator_to_array($allTypes),
+                        [new Type(XsdType::create('Response2'), [])]
+                    ));
+                }
+            }
+        );
+        $result = $chain($types);
+
+        self::assertNotSame($types, $result);
+        self::assertInstanceOf(TypeCollection::class, $result);
+        self::assertCount(2, $result);
+        self::assertEquals(
+            [
+                new Type(XsdType::create('Response'), []),
+                new Type(XsdType::create('Response2'), []),
+            ],
+            iterator_to_array($result)
+        );
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/MetadataFactoryTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/MetadataFactoryTest.php
@@ -72,7 +72,7 @@ class MetadataFactoryTest extends TestCase
         MethodCollection $expectedMethods,
         TypeCollection $expectedTypes
     ) {
-        return (new MetadataOptions())
+        return MetadataOptions::empty()
             ->withTypesManipulator(new class ($expectedTypes) implements TypesManipulatorInterface {
                 /**
                  * @var TypeCollection

--- a/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/MetadataFactoryTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/MetadataFactoryTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Engine\Metadata;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\TypeCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataFactory;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataOptions;
+use PHPUnit\Framework\TestCase;
+
+class MetadataFactoryTest extends TestCase
+{
+    /** @test */
+    public function it_can_create_lazy_in_memory_metadata(): void
+    {
+        $meta = new class implements MetadataInterface {
+            public function getTypes(): TypeCollection
+            {
+                return new TypeCollection();
+            }
+
+            public function getMethods(): MethodCollection
+            {
+                return new MethodCollection();
+            }
+        };
+        $lazy = MetadataFactory::lazy($meta);
+
+        self::assertEquals($meta->getTypes(), $lazy->getTypes());
+        self::assertEquals($meta->getMethods(), $lazy->getMethods());
+        self::assertNotSame($meta->getTypes(), $lazy->getTypes());
+        self::assertNotSame($meta->getMethods(), $lazy->getMethods());
+        self::assertSame($lazy->getTypes(), $lazy->getTypes());
+        self::assertSame($lazy->getMethods(), $lazy->getMethods());
+    }
+
+    /** @test */
+    public function it_can_create_manipulated_metadata(): void
+    {
+        $meta = new class implements MetadataInterface {
+            public function getTypes(): TypeCollection
+            {
+                return new TypeCollection();
+            }
+
+            public function getMethods(): MethodCollection
+            {
+                return new MethodCollection();
+            }
+        };
+
+        $expectedMethods = new MethodCollection();
+        $expectedTypes = new TypeCollection();
+        $metaOptions = $this->createHardCodedManipulatorOptions($expectedMethods, $expectedTypes);
+
+        $manipulated = MetadataFactory::manipulated($meta, $metaOptions);
+
+        self::assertNotSame($meta->getTypes(), $manipulated->getTypes());
+        self::assertNotSame($meta->getMethods(), $manipulated->getMethods());
+        self::assertSame($expectedTypes, $manipulated->getTypes());
+        self::assertSame($expectedMethods, $manipulated->getMethods());
+        self::assertSame($manipulated->getTypes(), $manipulated->getTypes());
+        self::assertSame($manipulated->getMethods(), $manipulated->getMethods());
+    }
+
+    private function createHardCodedManipulatorOptions(
+        MethodCollection $expectedMethods,
+        TypeCollection $expectedTypes
+    ) {
+        return (new MetadataOptions())
+            ->withTypesManipulator(new class ($expectedTypes) implements TypesManipulatorInterface {
+                /**
+                 * @var TypeCollection
+                 */
+                private $types;
+
+                public function __construct(TypeCollection $types)
+                {
+                    $this->types = $types;
+                }
+
+                public function __invoke(TypeCollection $allTypes): TypeCollection
+                {
+                    return $this->types;
+                }
+            })
+            ->withMethodsManipulator(new class ($expectedMethods) implements MethodsManipulatorInterface {
+
+                /**
+                 * @var MethodCollection
+                 */
+                private $methods;
+
+                public function __construct(MethodCollection $methods)
+                {
+                    $this->methods = $methods;
+                }
+
+                public function __invoke(MethodCollection $allMethods): MethodCollection
+                {
+                    return $this->methods;
+                }
+            });
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/MetadataOptionsTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/MetadataOptionsTest.php
@@ -20,7 +20,7 @@ class MetadataOptionsTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->metaOptions = new MetadataOptions();
+        $this->metaOptions = MetadataOptions::empty();
     }
 
 
@@ -50,5 +50,15 @@ class MetadataOptionsTest extends TestCase
 
         self::assertNotSame($this->metaOptions, $new);
         self::assertSame($manipulator->reveal(), $new->getMethodsManipulator());
+    }
+
+    public function it_can_be_configured_from_constructor(): void
+    {
+        $methodsManipulator = $this->prophesize(MethodsManipulatorInterface::class);
+        $typesManipulator = $this->prophesize(TypesManipulatorInterface::class);
+        $metaOptions = new MetadataOptions($methodsManipulator->reveal(), $typesManipulator->reveal());
+
+        self::assertSame($typesManipulator->reveal(), $metaOptions->getTypesManipulator());
+        self::assertSame($methodsManipulator->reveal(), $metaOptions->getMethodsManipulator());
     }
 }

--- a/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/MetadataOptionsTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/MetadataOptionsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Engine\Metadata;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorChain;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\MethodsManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorChain;
+use Phpro\SoapClient\Soap\Engine\Metadata\Manipulators\TypesManipulatorInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataOptions;
+use PHPUnit\Framework\TestCase;
+
+class MetadataOptionsTest extends TestCase
+{
+    /**
+     * @var MetadataOptions
+     */
+    private $metaOptions;
+
+    protected function setUp(): void
+    {
+        $this->metaOptions = new MetadataOptions();
+    }
+
+
+    /** @test */
+    public function it_contains_empty_chains_on_startup(): void
+    {
+
+        self::assertEquals(new TypesManipulatorChain(), $this->metaOptions->getTypesManipulator());
+        self::assertEquals(new MethodsManipulatorChain(), $this->metaOptions->getMethodsManipulator());
+    }
+
+    /** @test */
+    public function it_is_possible_to_change_types_manipulator(): void
+    {
+        $manipulator = $this->prophesize(TypesManipulatorInterface::class);
+        $new = $this->metaOptions->withTypesManipulator($manipulator->reveal());
+
+        self::assertNotSame($this->metaOptions, $new);
+        self::assertSame($manipulator->reveal(), $new->getTypesManipulator());
+    }
+
+    /** @test */
+    public function it_is_possible_to_change_method_manipulator(): void
+    {
+        $manipulator = $this->prophesize(MethodsManipulatorInterface::class);
+        $new = $this->metaOptions->withMethodsManipulator($manipulator->reveal());
+
+        self::assertNotSame($this->metaOptions, $new);
+        self::assertSame($manipulator->reveal(), $new->getMethodsManipulator());
+    }
+}


### PR DESCRIPTION
Fixes #300

I made something that allows you to manipulate the metadata before types are generated.
To try it out, I also added 2 possible strategies for fixing duplicate types.


- IntersectDuplicateTypesStrategy (default) -> this merges all duplicate types into 1 big type
- RemoveDuplicateTypesStrategy

This seems to do the trick.
Currently it matches on exact case match. This might not work if you have similar types in different cases. For example a "file" and a "File" type. 

I was thinking about other strategies as well, but there is just no unique identifier like an XSD namespace. This means I could for example add an increment number, but then the code will break once items are moved inside the XSD (which is suboptimal). Another option was to make a hash of the properties, but that would also break if the type changes. Therefore, I think it is imposible to generate separate classes per type with ext-soap.

:question: **Unless anyone has any better idea?**


TODO:

- [x] Tests
- [x] Documentation
- [x] Improved duplicates detector (case insensitive, special chars, ...)

