### PR TITLE
Detect request & response types automatically

### DIFF
--- a/docs/code-generation/rules.md
+++ b/docs/code-generation/rules.md
@@ -12,6 +12,8 @@ The goal of a rule is to run a code assembler.
 
 - [AssemblerRule](#assemblerrule)
 - [ClientMethodMatchesRule](#clientmethodmatchesrule)
+- [IsRequestRule](#isrequestrule)
+- [IsResultRule](#isresultrule)
 - [MultiRule](#multirule)
 - [PropertynameMatchesRule](#propertynamematchesrule)
 - [TypeMapRule](#TypeMapRule)
@@ -35,7 +37,6 @@ In the example above, a getter will be created for every property in the SOAP ty
 
 ```php
 use My\Project\CodeGenerator\Assembler as CustomAssembler;
-use Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Rules;
 
 new Rules\ClientMethodMatchesRule(
@@ -50,6 +51,50 @@ The regular expression will be matched against the method name added to the gene
 If the regular expression matches and the subRule is accepted, the defined assembler will run.
  
 In the example above, a custom `RemoveClientMethodAssembler` is is used to remove the `demoSetup` method from the Client completely.
+
+## IsRequestRule
+
+```php
+use Phpro\SoapClient\CodeGenerator\Assembler;
+use Phpro\SoapClient\CodeGenerator\Rules;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+
+assert($metadata instanceof MetadataInterface);
+
+new Rules\IsRequestRule(
+    $metadata,
+    new Rules\AssembleRule(new Assembler\RequestAssembler())
+)
+```
+
+The `IsRequestRule` can be used in the "types" generation command and contains the engine's metadata and a subRule.
+The rule will try to guess all request types based on the provided SOAP metadata.
+If the type matches a request type and the subRule is accepted, the defined assembler will run.
+
+This rule can be used to e.g. add the required `RequestInterface` to request objects.
+
+
+## IsResultRule
+
+```php
+use Phpro\SoapClient\CodeGenerator\Assembler;
+use Phpro\SoapClient\CodeGenerator\Rules;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+
+assert($metadata instanceof MetadataInterface);
+
+new Rules\IsResultRule(
+    $metadata,
+    new Rules\AssembleRule(new Assembler\ResultAssembler())
+)
+```
+
+The `IsResultRule` can be used in the "types" generation command and contains the engine's metadata and a subRule.
+The rule will try to guess all response types based on the provided SOAP metadata.
+If the type matches a response type and the subRule is accepted, the defined assembler will run.
+
+This rule can be used to e.g. add the required `ResultInterface` to request objects.
+
 
 ## MultiRule
 

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRuleSpec.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
+use Phpro\SoapClient\CodeGenerator\Rules\IsRequestRule;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Method;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Parameter;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * Class IsRequestRuleSpec
+ *
+ * @package spec\Phpro\SoapClient\CodeGenerator\Rules
+ * @mixin IsRequestRule
+ */
+class IsRequestRuleSpec extends ObjectBehavior
+{
+    function let(MetadataInterface $metadata, RuleInterface $subRule)
+    {
+        $metadata->getMethods()->willReturn(new MethodCollection(
+            new Method('method1', [new Parameter('prop1', XsdType::create('Request-Type'))], XsdType::create('string'))
+        ));
+        $this->beConstructedWith($metadata, $subRule);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(IsRequestRule::class);
+    }
+
+    function it_is_a_rule()
+    {
+        $this->shouldImplement(RuleInterface::class);
+    }
+
+    function it_can_not_apply_to_regular_context(ContextInterface $context)
+    {
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', []));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(true);
+    }
+
+    function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', []));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', []));
+        $subRule->appliesToContext($context)->willReturn(false);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_appies_subrule_when_applied(RuleInterface $subRule, ContextInterface $context)
+    {
+        $subRule->apply($context)->shouldBeCalled();
+        $this->apply($context);
+    }
+}

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsResultRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsResultRuleSpec.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use Phpro\SoapClient\CodeGenerator\Rules\IsResultRule;
+use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Method;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Parameter;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * Class IsResponseRuleSpec
+ *
+ * @package spec\Phpro\SoapClient\CodeGenerator\Rules
+ * @mixin IsResponseRule
+ */
+class IsResultRuleSpec extends ObjectBehavior
+{
+    function let(MetadataInterface $metadata, RuleInterface $subRule)
+    {
+        $metadata->getMethods()->willReturn(new MethodCollection(
+            new Method('method1', [new Parameter('prop1', XsdType::create('string'))], XsdType::create('Result-Type'))
+        ));
+        $this->beConstructedWith($metadata, $subRule);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(IsResultRule::class);
+    }
+
+    function it_is_a_rule()
+    {
+        $this->shouldImplement(RuleInterface::class);
+    }
+
+    function it_can_not_apply_to_regular_context(ContextInterface $context)
+    {
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', []));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(true);
+    }
+
+    function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', []));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', []));
+        $subRule->appliesToContext($context)->willReturn(false);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_appies_subrule_when_applied(RuleInterface $subRule, ContextInterface $context)
+    {
+        $subRule->apply($context)->shouldBeCalled();
+        $this->apply($context);
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -31,26 +31,26 @@ RULESET;
 
     const RULESET_REQUEST_RESPONSE = <<<RULESET
 ->addRule(
-    new Rules\TypenameMatchesRule(
+    new Rules\IsRequestRule(
+        \$engine->getMetadata(),
         new Rules\MultiRule([
             new Rules\AssembleRule(new Assembler\RequestAssembler()),
             new Rules\AssembleRule(new Assembler\ConstructorAssembler(new Assembler\ConstructorAssemblerOptions())),
-        ]),
-        '%s'
+        ])
     )
 )
 ->addRule(
-    new Rules\TypenameMatchesRule(
+    new Rules\IsResultRule(
+        \$engine->getMetadata(),
         new Rules\MultiRule([
             new Rules\AssembleRule(new Assembler\ResultAssembler()),
-        ]),
-        '%s'
+        ])
     )
 )
 RULESET;
 
     const ENGINE_BOILERPLATE = <<<EOENGINE
-->setEngine(ExtSoapEngineFactory::fromOptions(
+->setEngine(\$engine = ExtSoapEngineFactory::fromOptions(
         ExtSoapOptions::defaults('%s', [])
             ->disableWsdlCache()
     ))
@@ -104,11 +104,7 @@ EOENGINE;
         }
 
         $body .= $this->parseIndentedRuleSet($file, self::RULESET_DEFAULT);
-
-        if ($context->getRequestRegex() !== '' && $context->getResponseRegex() !== '') {
-            $rules = $this->parseIndentedRuleSet($file, self::RULESET_REQUEST_RESPONSE);
-            $body .= sprintf($rules, $context->getRequestRegex(), $context->getResponseRegex());
-        }
+        $body .= $this->parseIndentedRuleSet($file, self::RULESET_REQUEST_RESPONSE);
 
         $file->setBody($body.';'.PHP_EOL);
 

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
@@ -11,16 +11,6 @@ class ConfigContext implements ContextInterface
      */
     private $wsdl;
 
-    /**
-     * @var string
-     */
-    private $requestRegex = '';
-
-    /**
-     * @var string
-     */
-    private $responseRegex = '';
-
     public function addSetter(string $name, string $value): self
     {
         $this->setters[$name] = $value;
@@ -51,44 +41,6 @@ class ConfigContext implements ContextInterface
     public function setWsdl(string $wsdl): self
     {
         $this->wsdl = $wsdl;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getRequestRegex(): string
-    {
-        return $this->requestRegex;
-    }
-
-    /**
-     * @param string $requestRegex
-     * @return ConfigContext
-     */
-    public function setRequestRegex(string $requestRegex): self
-    {
-        $this->requestRegex = $requestRegex;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getResponseRegex(): string
-    {
-        return $this->responseRegex;
-    }
-
-    /**
-     * @param string $responseRegex
-     * @return ConfigContext
-     */
-    public function setResponseRegex(string $responseRegex): self
-    {
-        $this->responseRegex = $responseRegex;
 
         return $this;
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRule.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Phpro\SoapClient\Soap\Engine\Metadata\Detector\RequestTypesDetector;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+
+class IsRequestRule implements RuleInterface
+{
+    /**
+     * @var MetadataInterface
+     */
+    private $metadata;
+
+    /**
+     * @var RuleInterface
+     */
+    private $subRule;
+
+    /**
+     * @var array|null
+     */
+    private $requestTypes;
+
+    public function __construct(MetadataInterface $metadata, RuleInterface $subRule)
+    {
+        $this->metadata = $metadata;
+        $this->subRule = $subRule;
+    }
+
+    public function appliesToContext(ContextInterface $context): bool
+    {
+        if (!$context instanceof TypeContext) {
+            return false;
+        }
+
+        $type = $context->getType();
+        if (!in_array($type->getName(), $this->listRequestTypes(), true)) {
+            return false;
+        }
+
+        return $this->subRule->appliesToContext($context);
+    }
+
+    public function apply(ContextInterface $context)
+    {
+        $this->subRule->apply($context);
+    }
+
+    private function listRequestTypes(): array
+    {
+        if (null === $this->requestTypes) {
+            $this->requestTypes = array_map(
+                static function (string $type) {
+                    return Normalizer::normalizeClassname($type);
+                },
+                (new RequestTypesDetector())($this->metadata->getMethods())
+            );
+        }
+
+        return $this->requestTypes;
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/IsResultRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/IsResultRule.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Phpro\SoapClient\Soap\Engine\Metadata\Detector\ResponseTypesDetector;
+use Phpro\SoapClient\Soap\Engine\Metadata\MetadataInterface;
+
+class IsResultRule implements RuleInterface
+{
+    /**
+     * @var MetadataInterface
+     */
+    private $metadata;
+
+    /**
+     * @var RuleInterface
+     */
+    private $subRule;
+
+    /**
+     * @var array|null
+     */
+    private $responseTypes;
+
+    public function __construct(MetadataInterface $metadata, RuleInterface $subRule)
+    {
+        $this->metadata = $metadata;
+        $this->subRule = $subRule;
+    }
+
+    public function appliesToContext(ContextInterface $context): bool
+    {
+        if (!$context instanceof TypeContext) {
+            return false;
+        }
+
+        $type = $context->getType();
+        if (!in_array($type->getName(), $this->listResponseTypes(), true)) {
+            return false;
+        }
+
+        return $this->subRule->appliesToContext($context);
+    }
+
+    public function apply(ContextInterface $context)
+    {
+        $this->subRule->apply($context);
+    }
+
+    private function listResponseTypes(): array
+    {
+        if (null === $this->responseTypes) {
+            $this->responseTypes = array_map(
+                static function (string $type) {
+                    return Normalizer::normalizeClassname($type);
+                },
+                (new ResponseTypesDetector())($this->metadata->getMethods())
+            );
+        }
+
+        return $this->responseTypes;
+    }
+}

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -17,12 +17,6 @@ class GenerateConfigCommand extends Command
 {
     const COMMAND_NAME = 'generate:config';
 
-    const RULE_CONFIRMATION = <<<CONFIRMATION
-This tool can set some basic code generation rules. This requires some knowledge of the SOAP service.
-Take a look at the message section in the WSDL. Are you able to match request and response elements based on keywords?
-These keywords are used in a case insensitive regex match with '/' delimiters, escape accordingly!
-CONFIRMATION;
-
     /**
      * @var Filesystem
      */
@@ -88,14 +82,6 @@ CONFIRMATION;
         $this->addNonEmptySetter($context, 'setClassMapDestination', $baseDir);
         $this->addNonEmptySetter($context, 'setClassMapName', $name.'Classmap');
         $this->addNonEmptySetter($context, 'setClassMapNamespace', $namespace);
-
-        // Ruleset
-        if ($io->confirm(self::RULE_CONFIRMATION, false)) {
-            $requestKeyword = $io->ask('Keyword for matching request objects', '');
-            $context->setRequestRegex("/$requestKeyword/i");
-            $responseKeyword = $io->ask('Keyword for matching response objects', '');
-            $context->setResponseRegex("/$responseKeyword/i");
-        }
 
         // Create the config
         $generator = new ConfigGenerator();

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Detector/RequestTypesDetector.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Detector/RequestTypesDetector.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata\Detector;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Method;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Parameter;
+
+final class RequestTypesDetector
+{
+    public function __invoke(MethodCollection $methods): array
+    {
+        return array_unique(array_reduce(
+            iterator_to_array($methods),
+            static function (array $list, Method $method): array {
+                if (count($method->getParameters()) === 1) {
+                    /** @var Parameter $param */
+                    $param = current($method->getParameters());
+                    $list[] = $param->getType()->getName();
+                }
+
+                return $list;
+            },
+            []
+        ));
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Engine/Metadata/Detector/ResponseTypesDetector.php
+++ b/src/Phpro/SoapClient/Soap/Engine/Metadata/Detector/ResponseTypesDetector.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Engine\Metadata\Detector;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Method;
+
+final class ResponseTypesDetector
+{
+    public function __invoke(MethodCollection $methods): array
+    {
+        return array_unique(array_map(
+            static function (Method $method): string {
+                return $method->getReturnType()->getName();
+            },
+            iterator_to_array($methods)
+        ));
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -21,7 +21,7 @@ use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
 use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapEngineFactory;
 
 return Config::create()
-    ->setEngine(ExtSoapEngineFactory::fromOptions(
+    ->setEngine(\$engine = ExtSoapEngineFactory::fromOptions(
         ExtSoapOptions::defaults('wsdl.xml', [])
             ->disableWsdlCache()
     ))
@@ -36,70 +36,22 @@ return Config::create()
     ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
     ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler()))
     ->addRule(
-        new Rules\TypenameMatchesRule(
+        new Rules\IsRequestRule(
+            \$engine->getMetadata(),
             new Rules\MultiRule([
                 new Rules\AssembleRule(new Assembler\RequestAssembler()),
                 new Rules\AssembleRule(new Assembler\ConstructorAssembler(new Assembler\ConstructorAssemblerOptions())),
-            ]),
-            '/Request$/i'
+            ])
         )
     )
     ->addRule(
-        new Rules\TypenameMatchesRule(
+        new Rules\IsResultRule(
+            \$engine->getMetadata(),
             new Rules\MultiRule([
                 new Rules\AssembleRule(new Assembler\ResultAssembler()),
-            ]),
-            '/Response$/i'
+            ])
         )
     )
-;
-
-CONTENT;
-        $context = new ConfigContext();
-        $context
-            ->setWsdl('wsdl.xml')
-            ->addSetter('setTypeDestination', 'src/type')
-            ->addSetter('setTypeNamespace', 'App\\\\Type')
-            ->addSetter('setClientDestination', 'src/client')
-            ->addSetter('setClientName', 'Client')
-            ->addSetter('setClientNamespace', 'App\\\\Client')
-            ->addSetter('setClassmapDestination', 'src/classmap')
-            ->addSetter('setClassmapName', 'Classmap')
-            ->addSetter('setClassmapNamespace', 'App\\\\Classmap')
-            ->setRequestRegex('/Request$/i')
-            ->setResponseRegex('/Response$/i');
-
-        $generator = new ConfigGenerator();
-        $generated = $generator->generate(new FileGenerator(), $context);
-        self::assertEquals($expected, $generated);
-    }
-
-    public function testGenerateWithoutRegex()
-    {
-        $expected = <<<CONTENT
-<?php
-
-use Phpro\SoapClient\CodeGenerator\Assembler;
-use Phpro\SoapClient\CodeGenerator\Rules;
-use Phpro\SoapClient\CodeGenerator\Config\Config;
-use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
-use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapEngineFactory;
-
-return Config::create()
-    ->setEngine(ExtSoapEngineFactory::fromOptions(
-        ExtSoapOptions::defaults('wsdl.xml', [])
-            ->disableWsdlCache()
-    ))
-    ->setTypeDestination('src/type')
-    ->setTypeNamespace('App\\\\Type')
-    ->setClientDestination('src/client')
-    ->setClientName('Client')
-    ->setClientNamespace('App\\\\Client')
-    ->setClassmapDestination('src/classmap')
-    ->setClassmapName('Classmap')
-    ->setClassmapNamespace('App\\\\Classmap')
-    ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
-    ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler()))
 ;
 
 CONTENT;
@@ -119,5 +71,4 @@ CONTENT;
         $generated = $generator->generate(new FileGenerator(), $context);
         self::assertEquals($expected, $generated);
     }
-
 }

--- a/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/Detector/RequestTypesDetectorTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/Detector/RequestTypesDetectorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Engine\Metadata\Detector;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Detector\RequestTypesDetector;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Method;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Parameter;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use PHPUnit\Framework\TestCase;
+
+class RequestTypesDetectorTest extends TestCase
+{
+    /** @test */
+    public function it_can_detect_request_types(): void
+    {
+        $methods = new MethodCollection(
+            new Method('method1', [], XsdType::create('string')),
+            new Method('method2', [
+                new Parameter('param1', XsdType::create('RequestType1'))
+            ], XsdType::create('string')),
+            new Method('method3', [
+                new Parameter('param1', XsdType::create('RequestType2')),
+                new Parameter('param2', XsdType::create('RequestType3'))
+            ], XsdType::create('string')),
+            new Method('method4', [
+                new Parameter('param1', XsdType::create('RequestType4'))
+            ], XsdType::create('string')),
+            new Method('method5', [
+                new Parameter('param1', XsdType::create('string'))
+            ], XsdType::create('string'))
+        );
+
+        $detected = (new RequestTypesDetector())($methods);
+        self::assertSame(
+            ['RequestType1', 'RequestType4', 'string'],
+            $detected
+        );
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/Detector/ResponseTypesDetectorTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Engine/Metadata/Detector/ResponseTypesDetectorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Engine\Metadata\Detector;
+
+use Phpro\SoapClient\Soap\Engine\Metadata\Collection\MethodCollection;
+use Phpro\SoapClient\Soap\Engine\Metadata\Detector\RequestTypesDetector;
+use Phpro\SoapClient\Soap\Engine\Metadata\Detector\ResponseTypesDetector;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Method;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\Parameter;
+use Phpro\SoapClient\Soap\Engine\Metadata\Model\XsdType;
+use PHPUnit\Framework\TestCase;
+
+class ResponseTypesDetectorTest extends TestCase
+{
+    /** @test */
+    public function it_can_detect_request_types(): void
+    {
+        $methods = new MethodCollection(
+            new Method('method1', [], XsdType::create('Response1')),
+            new Method('method3', [
+                new Parameter('param1', XsdType::create('RequestType2')),
+                new Parameter('param2', XsdType::create('RequestType3'))
+            ], XsdType::create('Response2')),
+            new Method('method1', [], XsdType::create('string'))
+        );
+
+        $detected = (new ResponseTypesDetector())($methods);
+        self::assertSame(
+            ['Response1', 'Response2', 'string'],
+            $detected
+        );
+    }
+}


### PR DESCRIPTION
This PR contains 2 new rules:

* IsRequestRule
* IsResultRule

Which can be used to automatically detect `RequestInterface` and `ResultInterface`.
The generated config now looks like this:


```php
<?php

use Phpro\SoapClient\CodeGenerator\Assembler;
use Phpro\SoapClient\CodeGenerator\Rules;
use Phpro\SoapClient\CodeGenerator\Config\Config;
use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapEngineFactory;

return Config::create()
    ->setEngine($engine = ExtSoapEngineFactory::fromOptions(
        ExtSoapOptions::defaults('wsdl.xml', [])
            ->disableWsdlCache()
    ))
    ->setTypeDestination('src/type')
    ->setTypeNamespace('App\\Type')
    ->setClientDestination('src/client')
    ->setClientName('Client')
    ->setClientNamespace('App\\Client')
    ->setClassmapDestination('src/classmap')
    ->setClassmapName('Classmap')
    ->setClassmapNamespace('App\\Classmap')
    ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
    ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler()))
    ->addRule(
        new Rules\IsRequestRule(
            $engine->getMetadata(),
            new Rules\MultiRule([
                new Rules\AssembleRule(new Assembler\RequestAssembler()),
                new Rules\AssembleRule(new Assembler\ConstructorAssembler(new Assembler\ConstructorAssemblerOptions())),
            ])
        )
    )
    ->addRule(
        new Rules\IsResultRule(
            $engine->getMetadata(),
            new Rules\MultiRule([
                new Rules\AssembleRule(new Assembler\ResultAssembler()),
            ])
        )
    )
;
```

Which is a massive improvement compared to the "type regex in CLI" solution we had first.
