### PR TITLE
Add CachedWsdlProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "guzzlehttp/promises": "^1.3.1",
         "guzzlehttp/psr7": "^1.6.1",
         "laminas/laminas-code": "^3.4.0",
+        "nyholm/psr7": "^1.3",
         "php-http/client-common": "^2.1",
         "php-http/discovery": "^1.7",
         "php-http/guzzle6-adapter": "^2.0.1",

--- a/docs/wsdl-providers.md
+++ b/docs/wsdl-providers.md
@@ -25,7 +25,7 @@ $options = ExtSoapOptions::defaults('my.wsdl')
 
 Here is a list of built-in providers:
 
-- [CachedWsdlProvider](#cached wsdl provider)
+- [CachedWsdlProvider](#cachedwsdlprovider)
 - [~~HttPlugWsdlProvider~~](#httplugwsdlprovider)
 - [InMemoryWsdlProvider](#inmemorywsdlprovider)
 - [LocalWsdlProvider](#localwsdlprovider)
@@ -57,12 +57,12 @@ use Symfony\Component\Filesystem\Filesystem;
 
 $loader = new HttpWsdlLoader(
     new PluginClient($httpClient, [
-        // You can add WSDL middlewares in here ...
+        // You can add WSDL middlewares in here. E.g.: authentication, manipulations, ...
     ]),
-    Psr17FactoryDiscovery::findRequestFactory
+    Psr17FactoryDiscovery::findRequestFactory()
 );
 $provider = new CachedWsdlProvider($loader, new Filesystem(), sys_get_temp_dir());
-$wsdl = $provider->provide('http://somehost/service.wsdl');
+$wsdl = $provider->provide('https://somehost/service.wsdl');
 ```
 
 **Download permanent cache**

--- a/docs/wsdl-providers.md
+++ b/docs/wsdl-providers.md
@@ -25,7 +25,8 @@ $options = ExtSoapOptions::defaults('my.wsdl')
 
 Here is a list of built-in providers:
 
-- [HttPlugWsdlProvider](#httplugwsdlprovider)
+- [CachedWsdlProvider](#cached wsdl provider)
+- [~~HttPlugWsdlProvider~~](#httplugwsdlprovider)
 - [InMemoryWsdlProvider](#inmemorywsdlprovider)
 - [LocalWsdlProvider](#localwsdlprovider)
 - [MixedWsdlProvider](#mixedwsdlprovider)
@@ -33,7 +34,57 @@ Here is a list of built-in providers:
 Can't find the wsdl provider you were looking for?
 [It is always possible to create your own one!](#creating-your-own-wsdl-provider)
 
-## HttPlugWsdlProvider
+## CachedWsdlProvider
+
+This provider can permanently or temporary cache a (remote) WSDL.
+This one is very useful to use in production, where the WSDL shouldn't change too much.
+You can force it to load to a permanent location in e.g. a cronjob.
+It will improve performance since the soap-client won't have to fetch the WSDL remotely.
+
+**Dependencies**
+
+If you want to use Httplug for loading the WSDL, [you need to follow these installation guidelines](./handlers/httplug.md).
+
+**Usage**
+
+```php
+<?php
+use Http\Client\Common\PluginClient;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Phpro\SoapClient\Wsdl\Loader\HttpWsdlLoader;
+use Phpro\SoapClient\Wsdl\Provider\CachedWsdlProvider;
+use Symfony\Component\Filesystem\Filesystem;
+
+$loader = new HttpWsdlLoader(
+    new PluginClient($httpClient, [
+        // You can add WSDL middlewares in here ...
+    ]),
+    Psr17FactoryDiscovery::findRequestFactory
+);
+$provider = new CachedWsdlProvider($loader, new Filesystem(), sys_get_temp_dir());
+$wsdl = $provider->provide('http://somehost/service.wsdl');
+```
+
+**Download permanent cache**
+
+```php
+$provider->forcePermanentDownloads()->provide('http://somehost/service.wsdl');
+```
+
+This will store the WSDL in a permanent location.
+From now on, the provider will always load the permanent file.
+Unless you re-enable the force permanent method or remove the cache manually.
+This is typically something you would want to create a CLI command or a cronjob for. 
+
+
+**Note**
+
+Only the main WSDL file is being downloaded at the moment. Ext-soap imports additional files internally.
+
+
+## ~~HttPlugWsdlProvider~~
+
+*Deprecated* : Will be removed in v2.0 - Use the `CachedWsdlProvider` in combination with the `HttpWsdlLoader` instead.
 
 [HTTPlug](http://httplug.io/) is a HTTP client abstraction that can be used with multiple client packages.
 The HTTPlug WSDL provider can be used for downloading remote WSDLs.
@@ -42,20 +93,7 @@ This way, you will always be able to download and manipulate the WSDL file even 
 
 **Dependencies**
 
-Load HTTP plug core packages:
-
-```sh
-composer require psr/http-message:^1.0 php-http/httplug:^1.1 php-http/message-factory:^1.0 php-http/discovery:^1.3 php-http/message:^1.6 php-http/client-common:^1.6
-```
-
-**Select HTTP Client**
-
-Select one of the many clients you want to use to perform the HTTP requests:
-http://docs.php-http.org/en/latest/clients.html#clients-adapters
-
-```sh
-composer require php-http/client-implementation:^1.0
-```
+If you want to use Httplug for loading the WSDL, [you need to follow these installation guidelines](./handlers/httplug.md).
 
 **Usage**
 ```php

--- a/src/Phpro/SoapClient/Wsdl/Loader/HttpWsdlLoader.php
+++ b/src/Phpro/SoapClient/Wsdl/Loader/HttpWsdlLoader.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Wsdl\Loader;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+
+final class HttpWsdlLoader implements WsdlLoaderInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var RequestFactoryInterface
+     */
+    private $requestFactory;
+
+    public function __construct(
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory
+    ) {
+        $this->client = $client;
+        $this->requestFactory = $requestFactory;
+    }
+
+    public function load(string $wsdl): string
+    {
+        $response = $this->client->sendRequest(
+            $this->requestFactory->createRequest('GET', $wsdl)
+        );
+
+        return (string) $response->getBody();
+    }
+}

--- a/src/Phpro/SoapClient/Wsdl/Loader/WsdlLoaderInterface.php
+++ b/src/Phpro/SoapClient/Wsdl/Loader/WsdlLoaderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phpro\SoapClient\Wsdl\Loader;
+
+interface WsdlLoaderInterface
+{
+    /**
+     * Load the URL or file and return it's contents
+     * The difference between a WsdlProviderInterface is the fact that ext-soap is not able to automatically
+     * use the content of a wsdl file. Therefore a little transformation is needed.
+     */
+    public function load(string $wsdl): string;
+}

--- a/src/Phpro/SoapClient/Wsdl/Provider/CachedWsdlProvider.php
+++ b/src/Phpro/SoapClient/Wsdl/Provider/CachedWsdlProvider.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Wsdl\Provider;
+
+use Phpro\SoapClient\Wsdl\Loader\WsdlLoaderInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class CachedWsdlProvider implements WsdlProviderInterface
+{
+    public const LOCATION_PERMANENT = 'permanent';
+    public const LOCATION_TEMPORARY = 'temporary';
+
+    /**
+     * @var WsdlLoaderInterface
+     */
+    private $loader;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string
+     */
+    private $cacheDir;
+
+    /**
+     * @var string
+     */
+    private $target = self::LOCATION_TEMPORARY;
+
+    /**
+     * @var bool
+     */
+    private $forceDownload = false;
+
+    public function __construct(WsdlLoaderInterface $loader, Filesystem $filesystem, string $cacheDir)
+    {
+        $this->loader = $loader;
+        $this->cacheDir = $cacheDir;
+        $this->filesystem = $filesystem;
+    }
+
+    public function forcePermanentDownloads(): self
+    {
+        $new = clone $this;
+        $new->target = self::LOCATION_PERMANENT;
+        $new->forceDownload = true;
+
+        return $new;
+    }
+
+    public function provide(string $source): string
+    {
+        $filename = md5($source).'.wsdl';
+        $permanentLocation = $this->cacheDir.DIRECTORY_SEPARATOR.self::LOCATION_PERMANENT.DIRECTORY_SEPARATOR.$filename;
+        $temporaryLocation = $this->cacheDir.DIRECTORY_SEPARATOR.self::LOCATION_TEMPORARY.DIRECTORY_SEPARATOR.$filename;
+
+        if (!$this->forceDownload && $this->filesystem->exists($permanentLocation)) {
+            return $permanentLocation;
+        }
+
+        $target = self::LOCATION_PERMANENT === $this->target ? $permanentLocation : $temporaryLocation;
+        $this->filesystem->dumpFile($target, $this->loader->load($source));
+
+        return $target;
+    }
+}

--- a/src/Phpro/SoapClient/Wsdl/Provider/HttPlugWsdlProvider.php
+++ b/src/Phpro/SoapClient/Wsdl/Provider/HttPlugWsdlProvider.php
@@ -10,6 +10,10 @@ use Phpro\SoapClient\Middleware\MiddlewareInterface;
 use Phpro\SoapClient\Middleware\MiddlewareSupportingInterface;
 use Phpro\SoapClient\Util\Filesystem;
 
+/**
+ * @deprecated Use the CachedWsdlProvider in combination with the HttpWsdlLoader instead!
+ * TODO : this class will be removed in v2.0
+ */
 class HttPlugWsdlProvider implements WsdlProviderInterface, MiddlewareSupportingInterface
 {
     /**

--- a/test/PhproTest/SoapClient/Functional/Wsdl/Loader/HttpWsdlLoaderTest.php
+++ b/test/PhproTest/SoapClient/Functional/Wsdl/Loader/HttpWsdlLoaderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Functional\Wsdl;
+
+use Phpro\SoapClient\Wsdl\Loader\HttpWsdlLoader;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Message\RequestMatcher\RequestMatcher;
+use Http\Mock\Client;
+use Phpro\SoapClient\Wsdl\Loader\WsdlLoaderInterface;
+use Phpro\SoapClient\Wsdl\Provider\WsdlProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+class HttpWsdlLoaderTest extends TestCase
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var HttpWsdlLoader
+     */
+    private $loader;
+
+    protected function setUp(): void
+    {
+        $this->loader = new HttpWsdlLoader(
+            $this->client = new Client(),
+            Psr17FactoryDiscovery::findRequestFactory()
+        );
+    }
+
+    /** @test */
+    public function it_is_a_wsdl_loader(): void
+    {
+        self::assertInstanceOf(WsdlLoaderInterface::class, $this->loader);
+    }
+
+    /** @test */
+    public function it_can_load_wsdl(): void
+    {
+        $url = Psr17FactoryDiscovery::findUrlFactory()->createUri('http://localhost/some/service?wsdl');
+        $matcher = new RequestMatcher($url->getPath(), $url->getHost(), ['GET'], ['http']);
+        $response = Psr17FactoryDiscovery::findResponseFactory()->createResponse()->withBody(
+            Psr17FactoryDiscovery::findStreamFactory()->createStream($body = 'wsdl body')
+        );
+
+        $this->client->on($matcher, $response);
+
+        self::assertSame($body, $this->loader->load((string) $url));
+    }
+}

--- a/test/PhproTest/SoapClient/Functional/Wsdl/Provider/CachedWsdlProviderTest.php
+++ b/test/PhproTest/SoapClient/Functional/Wsdl/Provider/CachedWsdlProviderTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Functional\Wsdl;
+
+use Phpro\SoapClient\Wsdl\Provider\CachedWsdlProvider;
+use Phpro\SoapClient\Wsdl\Loader\WsdlLoaderInterface;
+use Phpro\SoapClient\Wsdl\Provider\WsdlProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Filesystem\Filesystem;
+
+class CachedWsdlProviderTest extends TestCase
+{
+    /**
+     * @var ObjectProphecy|WsdlLoader
+     */
+    private $loader;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var CachedWsdlProvider
+     */
+    private $wsdlProvider;
+
+    /**
+     * @var string
+     */
+    private $wsdl = 'http://localhost/some/service?wsdl';
+
+    /**
+     * @var string
+     */
+    private $targetDir;
+
+    protected function setUp(): void
+    {
+        $this->loader = $this->prophesize(WsdlLoaderInterface::class);
+        $this->loader->load($this->wsdl)->willReturn('wsdl');
+        $this->filesystem = new Filesystem();
+        $this->wsdlProvider = new CachedWsdlProvider(
+            $this->loader->reveal(),
+            $this->filesystem,
+            $this->targetDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'soap-test-'.random_int(100, 999)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->targetDir);
+    }
+
+    /** @test */
+    public function it_is_a_wsdl_provider(): void
+    {
+        self::assertInstanceOf(WsdlProviderInterface::class, $this->wsdlProvider);
+    }
+
+    /** @test */
+    public function it_falls_back_to_temporary_file_if_no_permanent_exists(): void
+    {
+        $result = $this->wsdlProvider->provide($this->wsdl);
+
+        self::assertStringContainsString(CachedWsdlProvider::LOCATION_TEMPORARY, $result);
+        self::assertFileExists($result);
+        self::assertStringEqualsFile($result, 'wsdl');
+    }
+
+    /** @test */
+    public function it_always_downloads_temporary_files_even_if_it_already_exists(): void
+    {
+        $this->loader->load($this->wsdl)->shouldBeCalledTimes(2);
+
+        $result = $this->wsdlProvider->provide($this->wsdl);
+        $result2 = $this->wsdlProvider->provide($this->wsdl);
+
+        self::assertSame($result, $result2);
+        self::assertFileExists($result);
+        self::assertStringEqualsFile($result, 'wsdl');
+    }
+
+    /** @test */
+    public function it_uses_permanent_version_if_it_exists(): void
+    {
+        $this->loader->load($this->wsdl)->shouldBeCalledTimes(1);
+        $permanent = $this->wsdlProvider->forcePermanentDownloads()->provide($this->wsdl);
+        $result = $this->wsdlProvider->provide($this->wsdl);
+
+        self::assertSame($permanent, $result);
+        self::assertStringContainsString(CachedWsdlProvider::LOCATION_PERMANENT, $result);
+        self::assertFileExists($result);
+        self::assertStringEqualsFile($result, 'wsdl');
+    }
+
+    /** @test */
+    public function it_is_able_to_force_download_permanent_version(): void
+    {
+        $this->loader->load($this->wsdl)->shouldBeCalledTimes(2);
+        $forcedProvider = $this->wsdlProvider->forcePermanentDownloads();
+        $result1 = $forcedProvider->provide($this->wsdl);
+        $result2 = $forcedProvider->provide($this->wsdl);
+
+        self::assertSame($result1, $result2);
+        self::assertStringContainsString(CachedWsdlProvider::LOCATION_PERMANENT, $result1);
+        self::assertFileExists($result1);
+        self::assertStringEqualsFile($result1, 'wsdl');
+    }
+}


### PR DESCRIPTION
Fixes #63

The old `HttPlugWsdlProvider` does not work exactly the way you would think it works.
This PR is contains an improved `CachedWsdlProvider` with a separated `HttpWsdlLoader`
This implementation makes it possible to cache a WSDL temporary or permanent.

Usage:
```php
<?php
use Http\Client\Common\PluginClient;
use Http\Discovery\Psr17FactoryDiscovery;
use Phpro\SoapClient\Wsdl\Loader\HttpWsdlLoader;
use Phpro\SoapClient\Wsdl\Provider\CachedWsdlProvider;
use Symfony\Component\Filesystem\Filesystem;

$loader = new HttpWsdlLoader(
    new PluginClient($httpClient, [
         // You can add WSDL middlewares in here. E.g.: authentication, manipulations, ...
    ]),
    Psr17FactoryDiscovery::findRequestFactory()
);
$provider = new CachedWsdlProvider($loader, new Filesystem(), sys_get_temp_dir());
$wsdl = $provider->provide('https://somehost/service.wsdl');
```

Another mode is the `forcePermanentDownloads` mode:

```php
$provider->forcePermanentDownloads()->provide('http://somehost/service.wsdl');
```

This enables you to create a CLI command that caches WSDLs for production environments that don't change often in a cronjob. This means that the WSDL won't be downloaded from the remote server on every request.


 