### PR TITLE
Add WS-I Compliant QuotedSoapActionMiddleware

### DIFF
--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -16,6 +16,7 @@ Next, you can use one of the built-in middlewares:
 - [WsaMiddleware](#wsamiddleware)
 - [WsseMiddleware](#wssemiddleware)
 - [RemoveEmptyNodesMiddleware](#removeemptynodesmiddleware)
+- [WS-I Compliance/QuotedSoapActionMiddleware] (#wsicompliancequotedsoapactionmiddleware)
 - [Wsdl/DisableExtensionsMiddleware](#wsdldisableextensionsmiddleware)
 - [Wsdl/DisablePoliciesMiddleware](#wsdldisablepoliciesmiddleware)
 
@@ -116,6 +117,20 @@ If you need to remove all empty nodes from the request xml, you can simply add t
 **Usage**
 ```php
 $handler->addMiddleware(new RemoveEmptyNodesMiddleware());
+```
+
+
+### WS-I Compliance/QuotedSoapActionMiddleware
+
+The default SOAP client does not guarantee compatibility with the [WS-I basic profile](http://www.ws-i.org/Profiles/BasicProfile-1.0-2004-04-16.html).
+This middleware ensures that the action inside the SOAPAction header is wrapped with double quotes [as specified in rule R2744](http://www.ws-i.org/Profiles/BasicProfile-1.0-2004-04-16.html#R2744). 
+
+**Usage**
+```php
+use \Phpro\SoapClient\Middleware\WSICompliance\QuotedSoapActionMiddleware;
+
+$wsdlProvier = HttPlugWsdlProvider::create($client);
+$wsdlProvider->addMiddleware(new QuotedSoapActionMiddleware());
 ```
 
 

--- a/docs/middlewares.md
+++ b/docs/middlewares.md
@@ -16,7 +16,7 @@ Next, you can use one of the built-in middlewares:
 - [WsaMiddleware](#wsamiddleware)
 - [WsseMiddleware](#wssemiddleware)
 - [RemoveEmptyNodesMiddleware](#removeemptynodesmiddleware)
-- [WS-I Compliance/QuotedSoapActionMiddleware] (#wsicompliancequotedsoapactionmiddleware)
+- [WS-I Compliance/QuotedSoapActionMiddleware](#ws-i-compliancequotedsoapactionmiddleware)
 - [Wsdl/DisableExtensionsMiddleware](#wsdldisableextensionsmiddleware)
 - [Wsdl/DisablePoliciesMiddleware](#wsdldisablepoliciesmiddleware)
 

--- a/src/Phpro/SoapClient/Middleware/WSICompliance/QuotedSoapActionMiddleware.php
+++ b/src/Phpro/SoapClient/Middleware/WSICompliance/QuotedSoapActionMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Middleware\WSICompliance;
+
+use Http\Promise\Promise;
+use Phpro\SoapClient\Middleware\Middleware;
+use Phpro\SoapClient\Soap\HttpBinding\Detector\SoapActionDetector;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @see http://www.ws-i.org/Profiles/BasicProfile-1.0-2004-04-16.html#R2744
+ *
+ * Fixes error:
+ *
+ *  WS-I Compliance failure (R2744):
+ *  The value of the SOAPAction transport header must be double-quoted.
+ */
+class QuotedSoapActionMiddleware extends Middleware
+{
+    public function getName(): string
+    {
+        return 'WS-I-compliance-quoted_soap_action_middleware';
+    }
+
+    public function beforeRequest(callable $next, RequestInterface $request): Promise
+    {
+        $soapAction = SoapActionDetector::detectFromRequest($request);
+        $soapAction = trim($soapAction ?? '', '"\'');
+
+        return $next($request->withHeader('SOAPAction', '"'.$soapAction.'"'));
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Middleware/WSICompliance/QuotedSoapActionMiddlewareTest.php
+++ b/test/PhproTest/SoapClient/Unit/Middleware/WSICompliance/QuotedSoapActionMiddlewareTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Middleware\WSICompliance;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Http\Client\Common\PluginClient;
+use Http\Mock\Client;
+use Phpro\SoapClient\Middleware\MiddlewareInterface;
+use Phpro\SoapClient\Middleware\WSICompliance\QuotedSoapActionMiddleware;
+use PHPUnit\Framework\TestCase;
+
+class QuotedSoapActionMiddlewareTest extends TestCase
+{
+    /**
+     * @var PluginClient
+     */
+    private $client;
+
+    /**
+     * @var Client
+     */
+    private $mockClient;
+
+    /**
+     * @var QuotedSoapActionMiddleware
+     */
+    private $middleware;
+
+    /***
+     * Initialize all basic objects
+     */
+    protected function setUp(): void
+    {
+        $this->middleware = new QuotedSoapActionMiddleware();
+        $this->mockClient = new Client();
+        $this->client = new PluginClient($this->mockClient, [$this->middleware]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_a_middleware()
+    {
+        $this->assertInstanceOf(MiddlewareInterface::class, $this->middleware);
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_a_name()
+    {
+        $this->assertEquals('WS-I-compliance-quoted_soap_action_middleware', $this->middleware->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function it_wraps_the_action_with_quotes()
+    {
+        $this->mockClient->addResponse(new Response());
+        $this->client->sendRequest(new Request('POST', '/', ['SOAPAction' => 'action']));
+
+        $sentRequest = $this->mockClient->getRequests()[0];
+        $this->assertSame('"action"', $sentRequest->getHeader('SOAPAction')[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_keeps_the_action_quoted()
+    {
+        $this->mockClient->addResponse(new Response());
+        $this->client->sendRequest(new Request('POST', '/', ['SOAPAction' => '"action"']));
+
+        $sentRequest = $this->mockClient->getRequests()[0];
+        $this->assertSame('"action"', $sentRequest->getHeader('SOAPAction')[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_transforms_single_quotes()
+    {
+        $this->mockClient->addResponse(new Response());
+        $this->client->sendRequest(new Request('POST', '/', ['SOAPAction' => "'action'"]));
+
+        $sentRequest = $this->mockClient->getRequests()[0];
+        $this->assertSame('"action"', $sentRequest->getHeader('SOAPAction')[0]);
+    }
+}


### PR DESCRIPTION
The default SOAP client does not guarantee compatibility with the [WS-I basic profile](http://www.ws-i.org/Profiles/BasicProfile-1.0-2004-04-16.html).
This middleware ensures that the action inside the SOAPAction header is wrapped with double quotes [as specified in rule R2744](http://www.ws-i.org/Profiles/BasicProfile-1.0-2004-04-16.html#R2744). 

**Usage**
```php
use \Phpro\SoapClient\Middleware\WSICompliance\QuotedSoapActionMiddleware;

$wsdlProvier = HttPlugWsdlProvider::create($client);
$wsdlProvider->addMiddleware(new QuotedSoapActionMiddleware());
```