### PR TITLE
Add other reserved keywords

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -31,6 +31,7 @@ class Normalizer
     /**
      * @var array
      * @see https://secure.php.net/manual/en/reserved.keywords.php
+     * @see https://www.php.net/manual/en/reserved.other-reserved-words.php
      */
     private static $reservedKeywords = [
         '__halt_compiler',
@@ -100,7 +101,21 @@ class Normalizer
         'while',
         'xor',
         'yield',
-        'void'
+        'void',
+
+        // Other reserved words:
+        'int',
+        'true',
+        'false',
+        'null',
+        'void',
+        'bool',
+        'float',
+        'string',
+        'object',
+        'resource',
+        'mixed',
+        'numeric'
     ];
 
     /**


### PR DESCRIPTION
Fixes #308 

Added the keywords from https://www.php.net/manual/en/reserved.other-reserved-words.php to the list of reserved keywords.
The generated type of Object will now be named `ObjectType`