### PR TITLE
Feature: Add ClosureAssembler

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClosureAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClosureAssembler.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Assembler;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\Exception\AssemblerException;
+
+/**
+ * Class FinalClassAssembler
+ *
+ * @package Phpro\SoapClient\CodeGenerator\Assembler
+ */
+class ClosureAssembler implements AssemblerInterface
+{
+
+    /**
+     * @var callable
+     */
+    private $canAssembleClosure;
+
+    /**
+     * @var callable
+     */
+    private $assembleClosure;
+
+
+    /**
+     * ClosureAssembler constructor.
+     * @param callable $canAssembleClosure
+     * @param callable $assembleClosure
+     */
+    public function __construct(callable $canAssembleClosure, callable $assembleClosure)
+    {
+        $this->canAssembleClosure = $canAssembleClosure;
+        $this->assembleClosure = $assembleClosure;
+    }
+
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canAssemble(ContextInterface $context): bool
+    {
+        return call_user_func($this->canAssembleClosure, $context);
+    }
+
+    /**
+     * @param ContextInterface|TypeContext $context
+     */
+    public function assemble(ContextInterface $context)
+    {
+        call_user_func($this->assembleClosure, $context);
+    }
+}


### PR DESCRIPTION
`ClosureAssembler` - This implementation makes it possible use closure/callback

Usage:

```php
   $config ->addRule(new Rules\AssembleRule(new Assembler\ClosureAssembler(
        function(ContextInterface $context): bool {
            return $context instanceof TypeContext;
        },
        function(ContextInterface $context) {

            // some code...
        })
    ))
```