### PR TITLE
Fixes binary response error in tests

### DIFF
--- a/src/Phpro/SoapClient/Soap/HttpBinding/Converter/Psr7ToLastRequestInfoConverter.php
+++ b/src/Phpro/SoapClient/Soap/HttpBinding/Converter/Psr7ToLastRequestInfoConverter.php
@@ -36,7 +36,7 @@ class Psr7ToLastRequestInfoConverter
             );
 
             $requestHeaders = trim($requestParts[0] ?? '');
-            $requestBody = $requestParts[1] ?? '';
+            $requestBody = (string)$request->getBody();
         }
 
         if ($responseString) {
@@ -47,7 +47,7 @@ class Psr7ToLastRequestInfoConverter
             );
 
             $responseHeaders = trim($responseParts[0] ?? '');
-            $responseBody = $responseParts[1] ?? '';
+            $responseBody = (string)$response->getBody();
         }
 
         // Reset the bodies:


### PR DESCRIPTION
You could get this as body in the tests:
![image](https://user-images.githubusercontent.com/7813447/91541957-61a8d780-e91d-11ea-8e0d-61850fed3c56.png)

This fixes that, so that valid xml is returned instead.