### PR TITLE
Do not set type hint and return type "mixed" on PHP < 8

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
@@ -59,7 +59,7 @@ class GetterAssembler implements AssemblerInterface
                     'parameters' => [],
                     'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
                     'body'       => sprintf('return $this->%s;', $property->getName()),
-                    'returntype' => $this->options->useReturnType() ? $property->getType() : null,
+                    'returntype' => $this->options->useReturnType() ? $property->getCodeReturnType() : null,
                     'docblock'   => DocBlockGeneratorFactory::fromArray([
                         'tags' => [
                             [

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
@@ -51,7 +51,7 @@ class SetterAssembler implements AssemblerInterface
         try {
             $parameterOptions = ['name' => $property->getName()];
             if ($this->options->useTypeHints()) {
-                $parameterOptions['type'] = $property->getType();
+                $parameterOptions['type'] = $property->getCodeReturnType();
             }
             $methodName = Normalizer::generatePropertyMethod('set', $property->getName());
             $class->removeMethod($methodName);

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -71,6 +71,20 @@ class Property
     }
 
     /**
+     * @return string|null
+     */
+    public function getCodeReturnType(): ?string
+    {
+        $type = $this->getType();
+
+        if ($type === 'mixed' && PHP_VERSION_ID < 80000) {
+            return null;
+        }
+
+        return $type;
+    }
+
+    /**
      * @return string
      */
     public function getterName(): string

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Model;
+
+use Phpro\SoapClient\CodeGenerator\Model\Property;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class PropertyTest
+ *
+ * @package PhproTest\SoapClient\Unit\CodeGenerator\Model
+ */
+class PropertyTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_null_type_pre_php8(): void
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            self::markTestSkipped('Pre PHP 8 only');
+        }
+        $property = new Property('test', 'mixed', 'App');
+        self::assertNull($property->getCodeReturnType());
+        self::assertEquals('mixed', $property->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_mixed_type_post_php8(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            self::markTestSkipped('Post PHP 8 only');
+        }
+        $property = new Property('test', 'mixed', 'App');
+        self::assertEquals('mixed', $property->getCodeReturnType());
+        self::assertEquals('mixed', $property->getType());
+    }
+}


### PR DESCRIPTION
Mixed is not a valid type on PHP < 8, it was introduced in 8.0.0 by https://wiki.php.net/rfc/mixed_type_v2
When useReturnType (getter) and/or useTypeHints (setter) are enabled, the assembler sets "mixed" both in docblocks and as PHP types in the code. The latter causes issues on PHP < 8.