### PR TITLE
Use fromString instead of fromStream when fetching the request body

### DIFF
--- a/src/Phpro/SoapClient/Middleware/WsseMiddleware.php
+++ b/src/Phpro/SoapClient/Middleware/WsseMiddleware.php
@@ -131,7 +131,7 @@ class WsseMiddleware extends Middleware
 
     public function beforeRequest(callable $handler, RequestInterface $request): Promise
     {
-        $xml = SoapXml::fromStream($request->getBody());
+        $xml = SoapXml::fromString((string)$request->getBody());
         $wsse = new WSSESoap($xml->getXmlDocument());
 
         // Prepare the WSSE soap class:


### PR DESCRIPTION
Trying to use WsseMiddleware with Guzzle 6 does not seem to work without this change; $stream->getContents() in ::fromStream() returns an empty string.