### PR TITLE
define composer conflict with php-http/guzzle6-adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "symfony/validator": "~4.0 || ~5.0"
     },
     "conflict": {
-        "php-http/guzzle6-adapter": "1.*"
+        "php-http/guzzle6-adapter": "<2.0"
     },
     "suggest": {
         "ext-soap": "If you want to use PHP's ext-soap driver.",

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
         "squizlabs/php_codesniffer": "~3.5",
         "symfony/validator": "~4.0 || ~5.0"
     },
+    "conflict": {
+        "php-http/guzzle6-adapter": "1.*"
+    },
     "suggest": {
         "ext-soap": "If you want to use PHP's ext-soap driver.",
         "php-http/client-common": "For gaining control over the HTTP layer",


### PR DESCRIPTION
because of "BC breaking" kind-of changes in https://github.com/phpro/soap-client/commit/e8f2b55761bc52272632ac39af2517fc7c8116a0

see https://github.com/phpro/soap-client/commit/e8f2b55761bc52272632ac39af2517fc7c8116a0#commitcomment-46282702