### PR TITLE
Add option to remove docblocks from getters and setters

### DIFF
--- a/docs/code-generation/assemblers.md
+++ b/docs/code-generation/assemblers.md
@@ -119,11 +119,11 @@ Example output:
     }
 ```
 
-Generating type-hints is disabled by default, but can be enabled by passing `FluentSetterAssemblerOption` instance to the constructor with the option withTypeHints set to true.
+Generating doc blocks is enabled by default, but can be disabled by passing `FluentSetterAssemblerOption` instance to the constructor with the option `withDocBlocks` set to false. This is normally used in conjunction with `withTypeHints`
 
 Example
 ```php
-new FluentSetterAssembler((new FluentSetterAssemblerOptions())->withTypeHints())
+new FluentSetterAssembler((new FluentSetterAssemblerOptions())->withDocBlocks(false)->withTypeHints())
 ```
 
 ```php
@@ -185,7 +185,12 @@ Example output:
     }
 ```
 
-This assembler needs to be constructed with an instance of `GetterAssemblerOptions`
+Generating doc blocks is enabled by default, but can be disabled by passing `GetterAssemblerOptions` instance to the constructor with the option `withDocBlocks` set to false. This is normally used in conjunction with `withTypeHints`
+
+Example
+```php
+new GetterAssembler((new GetterAssemblerOptions())->withDocBlocks(false)->withTypeHints())
+```
 
 ## InterfaceAssembler
 
@@ -375,8 +380,12 @@ Example output:
     }
 ```
 
-This assembler needs to be constructed with an instance of `SetterAssemblerOptions`.
+Generating doc blocks is enabled by default, but can be disabled by passing `SetterAssemblerOptions` instance to the constructor with the option `withDocBlocks` set to false. This is normally used in conjunction with `withTypeHints`
 
+Example
+```php
+new SetterAssembler((new SetterAssemblerOptions())->withDocBlocks(false)->withTypeHints())
+```
 
 ## TraitAssembler
 
@@ -435,6 +444,12 @@ Example output:
     }
 ```
 
+Generating doc blocks is enabled by default, but can be disabled by passing `ImmutableSetterAssemblerOptions` instance to the constructor with the option `withDocBlocks` set to false. This is normally used in conjunction with `withTypeHints`
+
+Example
+```php
+new ImmutableSetterAssembler((new ImmutableSetterAssemblerOptions())->withDocBlocks(false)->withTypeHints())
+```
 
 # Creating your own Assembler
 

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssembler.php
@@ -52,33 +52,33 @@ class FluentSetterAssembler implements AssemblerInterface
         try {
             $methodName = Normalizer::generatePropertyMethod('set', $property->getName());
             $class->removeMethod($methodName);
-            $class->addMethodFromGenerator(
-                MethodGenerator::fromArray([
-                    'name'       => $methodName,
-                    'parameters' => $this->getParameter($property),
-                    'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
-                    'body'       => sprintf(
-                        '$this->%1$s = $%1$s;%2$sreturn $this;',
-                        $property->getName(),
-                        $class::LINE_FEED
-                    ),
-                    'returntype' => $this->options->useReturnType()
-                        ? $class->getNamespaceName().'\\'.$class->getName()
-                        : null,
-                    'docblock'   => DocBlockGeneratorFactory::fromArray([
-                        'tags' => [
-                            [
-                                'name'        => 'param',
-                                'description' => sprintf('%s $%s', $property->getType(), $property->getName()),
-                            ],
-                            [
-                                'name'        => 'return',
-                                'description' => '$this',
-                            ],
+
+            $methodGenerator = new MethodGenerator($methodName);
+            $methodGenerator->setParameters($this->getParameter($property));
+            $methodGenerator->setVisibility(MethodGenerator::VISIBILITY_PUBLIC);
+            $methodGenerator->setBody(sprintf(
+                '$this->%1$s = $%1$s;%2$sreturn $this;',
+                $property->getName(),
+                $class::LINE_FEED
+            ));
+            if ($this->options->useReturnType()) {
+                $methodGenerator->setReturnType($class->getNamespaceName().'\\'.$class->getName());
+            }
+            if ($this->options->useDocBlocks()) {
+                $methodGenerator->setDocBlock(DocBlockGeneratorFactory::fromArray([
+                    'tags' => [
+                        [
+                            'name'        => 'param',
+                            'description' => sprintf('%s $%s', $property->getType(), $property->getName()),
                         ],
-                    ]),
-                ])
-            );
+                        [
+                            'name'        => 'return',
+                            'description' => '$this',
+                        ],
+                    ],
+                ]));
+            }
+            $class->addMethodFromGenerator($methodGenerator);
         } catch (\Exception $e) {
             throw AssemblerException::fromException($e);
         }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssemblerOptions.php
@@ -22,6 +22,11 @@ class FluentSetterAssemblerOptions
     private $returnType = false;
 
     /**
+     * @var bool
+     */
+    private $docBlocks = true;
+
+    /**
      * @return FluentSetterAssemblerOptions
      */
     public static function create(): FluentSetterAssemblerOptions
@@ -69,5 +74,26 @@ class FluentSetterAssemblerOptions
     public function useReturnType(): bool
     {
         return $this->returnType;
+    }
+
+    /**
+     * @param bool $withDocBlocks
+     *
+     * @return FluentSetterAssemblerOptions
+     */
+    public function withDocBlocks(bool $withDocBlocks = true): FluentSetterAssemblerOptions
+    {
+        $new = clone $this;
+        $new->docBlocks = $withDocBlocks;
+
+        return $new;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useDocBlocks(): bool
+    {
+        return $this->docBlocks;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssemblerOptions.php
@@ -22,6 +22,11 @@ class GetterAssemblerOptions
     private $returnType = false;
 
     /**
+     * @var bool
+     */
+    private $docBlocks = true;
+
+    /**
      * @return GetterAssemblerOptions
      */
     public static function create(): GetterAssemblerOptions
@@ -69,5 +74,26 @@ class GetterAssemblerOptions
     public function useReturnType(): bool
     {
         return $this->returnType;
+    }
+
+    /**
+     * @param bool $withDocBlocks
+     *
+     * @return GetterAssemblerOptions
+     */
+    public function withDocBlocks(bool $withDocBlocks = true): GetterAssemblerOptions
+    {
+        $new = clone $this;
+        $new->docBlocks = $withDocBlocks;
+
+        return $new;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useDocBlocks(): bool
+    {
+        return $this->docBlocks;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
@@ -66,32 +66,28 @@ class ImmutableSetterAssembler implements AssemblerInterface
             if ($this->options->useTypeHints()) {
                 $parameterOptions['type'] = $property->getType();
             }
-            $returnType = $this->options->useReturnTypes()
-                ? $class->getNamespaceName() . '\\' . $class->getName()
-                : null;
-            $class->addMethodFromGenerator(
-                MethodGenerator::fromArray(
-                    [
-                        'name' => $methodName,
-                        'parameters' => [$parameterOptions],
-                        'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
-                        'body' => implode($class::LINE_FEED, $lines),
-                        'returntype' => $returnType,
-                        'docblock' => DocBlockGeneratorFactory::fromArray([
-                            'tags' => [
-                                [
-                                    'name' => 'param',
-                                    'description' => sprintf('%s $%s', $property->getType(), $property->getName()),
-                                ],
-                                [
-                                    'name' => 'return',
-                                    'description' => $class->getName(),
-                                ],
-                            ],
-                        ]),
-                    ]
-                )
-            );
+
+            $methodGenerator = new MethodGenerator($methodName);
+            $methodGenerator->setParameters([$parameterOptions]);
+            $methodGenerator->setBody(implode($class::LINE_FEED, $lines));
+            if ($this->options->useReturnTypes()) {
+                $methodGenerator->setReturnType($class->getNamespaceName() . '\\' . $class->getName());
+            }
+            if ($this->options->useDocBlocks()) {
+                $methodGenerator->setDocBlock(DocBlockGeneratorFactory::fromArray([
+                    'tags' => [
+                        [
+                            'name' => 'param',
+                            'description' => sprintf('%s $%s', $property->getType(), $property->getName()),
+                        ],
+                        [
+                            'name' => 'return',
+                            'description' => $class->getName(),
+                        ],
+                    ],
+                ]));
+            }
+            $class->addMethodFromGenerator($methodGenerator);
         } catch (\Exception $e) {
             throw AssemblerException::fromException($e);
         }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssemblerOptions.php
@@ -19,6 +19,11 @@ class ImmutableSetterAssemblerOptions
     private $returnTypes = false;
 
     /**
+     * @var bool
+     */
+    private $docBlocks = true;
+
+    /**
      * @return ImmutableSetterAssemblerOptions
      */
     public function withTypeHints(): ImmutableSetterAssemblerOptions
@@ -62,5 +67,26 @@ class ImmutableSetterAssemblerOptions
     public static function create(): ImmutableSetterAssemblerOptions
     {
         return new self();
+    }
+
+    /**
+     * @param bool $withDocBlocks
+     *
+     * @return ImmutableSetterAssemblerOptions
+     */
+    public function withDocBlocks(bool $withDocBlocks = true): ImmutableSetterAssemblerOptions
+    {
+        $new = clone $this;
+        $new->docBlocks = $withDocBlocks;
+
+        return $new;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useDocBlocks(): bool
+    {
+        return $this->docBlocks;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
@@ -55,24 +55,23 @@ class SetterAssembler implements AssemblerInterface
             }
             $methodName = Normalizer::generatePropertyMethod('set', $property->getName());
             $class->removeMethod($methodName);
-            $class->addMethodFromGenerator(
-                MethodGenerator::fromArray(
-                    [
-                        'name' => $methodName,
-                        'parameters' => [$parameterOptions],
-                        'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
-                        'body' => sprintf('$this->%1$s = $%1$s;', $property->getName()),
-                        'docblock' => DocBlockGeneratorFactory::fromArray([
-                            'tags' => [
-                                [
-                                    'name' => 'param',
-                                    'description' => sprintf('%s $%s', $property->getType(), $property->getName()),
-                                ],
-                            ],
-                        ]),
-                    ]
-                )
-            );
+
+            $methodGenerator = new MethodGenerator($methodName);
+            $methodGenerator->setParameters([$parameterOptions]);
+            $methodGenerator->setVisibility(MethodGenerator::VISIBILITY_PUBLIC);
+            $methodGenerator->setBody(sprintf('$this->%1$s = $%1$s;', $property->getName()));
+            if ($this->options->useDocBlocks()) {
+                $methodGenerator->setDocBlock(DocBlockGeneratorFactory::fromArray([
+                    'tags' => [
+                        [
+                            'name' => 'param',
+                            'description' => sprintf('%s $%s', $property->getType(), $property->getName()),
+                        ],
+                    ],
+                ]));
+            }
+
+            $class->addMethodFromGenerator($methodGenerator);
         } catch (\Exception $e) {
             throw AssemblerException::fromException($e);
         }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssemblerOptions.php
@@ -17,6 +17,11 @@ class SetterAssemblerOptions
     private $typeHints = false;
 
     /**
+     * @var bool
+     */
+    private $docBlocks = true;
+
+    /**
      * @return SetterAssemblerOptions
      */
     public static function create(): SetterAssemblerOptions
@@ -43,5 +48,26 @@ class SetterAssemblerOptions
     public function useTypeHints(): bool
     {
         return $this->typeHints;
+    }
+
+    /**
+     * @param bool $withDocBlocks
+     *
+     * @return SetterAssemblerOptions
+     */
+    public function withDocBlocks(bool $withDocBlocks = true): SetterAssemblerOptions
+    {
+        $new = clone $this;
+        $new->docBlocks = $withDocBlocks;
+
+        return $new;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useDocBlocks(): bool
+    {
+        return $this->docBlocks;
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -105,6 +105,37 @@ CODE;
         $this->assertEquals($expected, $code);
     }
 
+
+    /**
+     * @test
+     */
+    function it_assembles_with_no_doc_blocks()
+    {
+        $assembler = new FluentSetterAssembler((new FluentSetterAssemblerOptions())->withDocBlocks(false));
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+    public function setProp1(\$prop1)
+    {
+        \$this->prop1 = \$prop1;
+        return \$this;
+    }
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
     /**
      * @test
      */

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -107,6 +107,38 @@ CODE;
     /**
      * @test
      */
+    public function it_assembles_with_no_doc_blocks()
+    {
+        $options = (new GetterAssemblerOptions())
+            ->withDocBlocks(false);
+        $assembler = new GetterAssembler($options);
+
+        $context = $this->createContext('prop2');
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+    public function getProp2()
+    {
+        return \$this->prop2;
+    }
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @test
+     */
     function it_assembles_property_methodnames_correctly()
     {
         $options = (new GetterAssemblerOptions())->withBoolGetters();

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
@@ -111,6 +111,38 @@ CODE;
     }
 
     /**
+     * @test
+     */
+    function it_assembles_with_no_doc_blocks()
+    {
+        $assembler = new ImmutableSetterAssembler((new ImmutableSetterAssemblerOptions())->withDocBlocks(false));
+        $context = $this->createContextWithLongType();
+
+        $assembler->assemble($context);
+
+        $generated = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+    public function withProp1(\$prop1)
+    {
+        \$new = clone \$this;
+        \$new->prop1 = \$prop1;
+
+        return \$new;
+    }
+
+
+}
+
+CODE;
+        $this->assertEquals($expected, $generated);
+    }
+
+    /**
      * @return PropertyContext
      */
     private function createContext()

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
@@ -70,6 +70,36 @@ CODE;
         $this->assertEquals($expected, $code);
     }
 
+
+    /**
+     * @test
+     */
+    function it_assembles_with_no_doc_blocks()
+    {
+        $assembler = new SetterAssembler((new SetterAssemblerOptions())->withDocBlocks(false));
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+
+    public function setProp1(\$prop1)
+    {
+        \$this->prop1 = \$prop1;
+    }
+
+
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
In this PR we add `withDocBlocks` option to Getters and Setters generators the same way we have it in the Constructor generator