### PR TITLE
Add docblocks question to Config Wizard command

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
@@ -11,6 +11,8 @@ class ConfigContext implements ContextInterface
      */
     private $wsdl;
 
+    private bool $generateDocblocks = true;
+
     public function addSetter(string $name, string $value): self
     {
         $this->setters[$name] = $value;
@@ -43,5 +45,17 @@ class ConfigContext implements ContextInterface
         $this->wsdl = $wsdl;
 
         return $this;
+    }
+
+    public function setGenerateDocblocks(bool $generateDocblocks): self
+    {
+        $this->generateDocblocks = $generateDocblocks;
+
+        return $this;
+    }
+
+    public function isGenerateDocblocks(): bool
+    {
+        return $this->generateDocblocks;
     }
 }

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -61,6 +61,7 @@ class GenerateConfigCommand extends Command
         }
 
         $context->setWsdl($io->ask('Wsdl location (URL or path to file)', null, $required));
+        $context->setGenerateDocblocks($io->confirm('Should methods be generated with docblocks?', true));
         $name = $io->ask(
             'Generic name used to name this client (Results in <name>Client <name>Classmap etc.)',
             null,


### PR DESCRIPTION
As mentioned by @janvernieuwe in #352 I've added a question to Wizard command whether methods should be generated with a docblock. It simplifies it a little as we have `withDocblocks` setting on many levels (for getters, setters, and the constructor).