### PR TITLE
Remove patching from Generate commands

### DIFF
--- a/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
@@ -129,20 +129,6 @@ class GenerateClassmapCommand extends Command
      */
     protected function handleClassmap(ClassMapGenerator $generator, TypeMap $typeMap, string $path): bool
     {
-        // Handle existing class:
-        if ($this->filesystem->fileExists($path)) {
-            if ($this->handleExistingFile($generator, $typeMap, $path)) {
-                return true;
-            }
-
-            // Ask if a class can be overwritten if it contains errors
-            if (!$this->askForOverwrite()) {
-                $this->output->writeln(sprintf('Skipping %s', $path));
-
-                return false;
-            }
-        }
-
         // Try to create a new class:
         try {
             $file = new FileGenerator();
@@ -154,66 +140,6 @@ class GenerateClassmapCommand extends Command
         }
 
         return true;
-    }
-
-    /**
-     * An existing file was found. Try to patch or ask if it can be overwritten.
-     *
-     * @param ClassMapGenerator $generator
-     * @param TypeMap           $typeMap
-     * @param string            $path
-     * @return bool
-     */
-    protected function handleExistingFile(ClassMapGenerator $generator, TypeMap $typeMap, $path): bool
-    {
-        $this->output->write(sprintf('Type %s exists. Trying to patch ...', $path));
-        $patched = $this->patchExistingFile($generator, $typeMap, $path);
-
-        if ($patched) {
-            $this->output->writeln('Patched!');
-
-            return true;
-        }
-
-        $this->output->writeln('Could not patch.');
-
-        return false;
-    }
-
-    /**
-     * This method tries to patch an existing type class.
-     *
-     * @param ClassMapGenerator $generator
-     * @param TypeMap           $typeMap
-     * @param string            $path
-     * @return bool
-     * @internal param Type $type
-     */
-    protected function patchExistingFile(ClassMapGenerator $generator, TypeMap $typeMap, $path): bool
-    {
-        try {
-            $this->filesystem->createBackup($path);
-            $file = FileGenerator::fromReflectedFileName($path);
-            $this->generateClassmap($file, $generator, $typeMap, $path);
-        } catch (\Exception $e) {
-            $this->output->writeln('<fg=red>'.$e->getMessage().'</fg=red>');
-            $this->filesystem->removeBackup($path);
-
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function askForOverwrite(): bool
-    {
-        $overwriteByDefault = $this->input->getOption('overwrite');
-        $question = new ConfirmationQuestion('Do you want to overwrite it?', $overwriteByDefault);
-
-        return $this->getHelper('question')->ask($this->input, $this->output, $question);
     }
 
     /**

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
@@ -127,20 +127,6 @@ class GenerateClientCommand extends Command
      */
     protected function handleClient(ClientGenerator $generator, Client $client, string $path): bool
     {
-        // Handle existing class:
-        if ($this->filesystem->fileExists($path)) {
-            if ($this->handleExistingFile($generator, $client, $path)) {
-                return true;
-            }
-
-            // Ask if a class can be overwritten if it contains errors
-            if (!$this->askForOverwrite()) {
-                $this->output->writeln(sprintf('Skipping %s', $client->getName()));
-
-                return false;
-            }
-        }
-
         // Try to create a blanco class:
         try {
             $file = new FileGenerator();
@@ -152,66 +138,6 @@ class GenerateClientCommand extends Command
         }
 
         return true;
-    }
-
-    /**
-     * An existing file was found. Try to patch or ask if it can be overwritten.
-     *
-     * @param GeneratorInterface $generator
-     * @param Client $client
-     * @param string $path
-     * @return bool
-     */
-    protected function handleExistingFile(GeneratorInterface $generator, Client $client, $path): bool
-    {
-        $this->output->write(sprintf('Class %s exists. Trying to patch ...', $client->getName()));
-        $patched = $this->patchExistingFile($generator, $client, $path);
-
-        if ($patched) {
-            $this->output->writeln('Patched!');
-
-            return true;
-        }
-
-        $this->output->writeln('Could not patch.');
-
-        return false;
-    }
-
-    /**
-     * This method tries to patch an existing type class.
-     *
-     * @param GeneratorInterface $generator
-     * @param Client $client
-     * @param string $path
-     * @return bool
-     * @internal param Type $type
-     */
-    protected function patchExistingFile(GeneratorInterface $generator, Client $client, $path): bool
-    {
-        try {
-            $this->filesystem->createBackup($path);
-            $file = FileGenerator::fromReflectedFileName($path);
-            $this->generateClient($file, $generator, $client, $path);
-        } catch (\Exception $e) {
-            $this->output->writeln('<fg=red>'.$e->getMessage().'</fg=red>');
-            $this->filesystem->removeBackup($path);
-
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function askForOverwrite(): bool
-    {
-        $overwriteByDefault = $this->input->getOption('overwrite');
-        $question = new ConfirmationQuestion('Do you want to overwrite it?', $overwriteByDefault);
-
-        return $this->getHelper('question')->ask($this->input, $this->output, $question);
     }
 
     /**

--- a/src/Phpro/SoapClient/Util/Filesystem.php
+++ b/src/Phpro/SoapClient/Util/Filesystem.php
@@ -62,30 +62,4 @@ class Filesystem
         $this->ensureDirectoryExists(\dirname($path));
         file_put_contents($path, $content);
     }
-
-    /**
-     * @param string $file
-     */
-    public function createBackup(string $file)
-    {
-        if (!$this->fileExists($file)) {
-            throw new RuntimeException('Could not create a backup from a non existing file: '.$file);
-        }
-
-        $backupFile = preg_replace('{\.backup$}', '', $file).'.backup';
-        copy($file, $backupFile);
-    }
-
-    /**
-     * @param string $file
-     */
-    public function removeBackup(string $file)
-    {
-        $backupFile = preg_replace('{\.backup$}', '', $file).'.backup';
-        if (!$this->fileExists($backupFile)) {
-            return;
-        }
-
-        unlink($backupFile);
-    }
 }


### PR DESCRIPTION
As discussed in #354 we can remove "patching" existing files from Generate commands as it is quirky and doesn't provide much value and only complicates the codebase. 