### PR TITLE
Allow immutable changes on event request / response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "phpro/grumphp-shim": "~1.2.0",
         "phpspec/phpspec": "~7.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
-        "phpstan/phpstan": "^0.12.57",
+        "phpstan/phpstan": "^0.12.87",
         "phpunit/phpunit": "~9.4",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0.1",

--- a/src/Phpro/SoapClient/Client.php
+++ b/src/Phpro/SoapClient/Client.php
@@ -76,6 +76,10 @@ class Client implements ClientInterface
      * For backward compatibility with Symfony 4
      *
      * @deprecated : We will remove this method  in v2.0 in favour of injecting the internal dispatcher directly.
+     *
+     * @template T of Event\SoapEvent
+     * @param T $event
+     * @return T
      */
     private function dispatch(Event\SoapEvent $event, string $name = null): Event\SoapEvent
     {
@@ -95,8 +99,8 @@ class Client implements ClientInterface
      */
     protected function call(string $method, RequestInterface $request): ResultInterface
     {
-        $requestEvent = new Event\RequestEvent($this, $method, $request);
-        $this->dispatch($requestEvent, Events::REQUEST);
+        $requestEvent = $this->dispatch(new Event\RequestEvent($this, $method, $request), Events::REQUEST);
+        $request = $requestEvent->getRequest();
 
         try {
             $arguments = ($request instanceof MultiArgumentRequestInterface) ? $request->getArguments() : [$request];
@@ -115,8 +119,8 @@ class Client implements ClientInterface
             throw $soapException;
         }
 
-        $this->dispatch(new Event\ResponseEvent($this, $requestEvent, $result), Events::RESPONSE);
+        $responseEvent = $this->dispatch(new Event\ResponseEvent($this, $requestEvent, $result), Events::RESPONSE);
 
-        return $result;
+        return $responseEvent->getResponse();
     }
 }

--- a/src/Phpro/SoapClient/Event/Dispatcher/EventDispatcherInterface.php
+++ b/src/Phpro/SoapClient/Event/Dispatcher/EventDispatcherInterface.php
@@ -14,10 +14,10 @@ use Phpro\SoapClient\Event\SoapEvent;
 interface EventDispatcherInterface
 {
     /**
-     * @param SoapEvent   $event
+     * @template T of SoapEvent
+     * @param T $event
      * @param string|null $name Deprecated : will be removed  in v2.0!
-     *
-     * @return SoapEvent
+     * @return T
      */
     public function dispatch(SoapEvent $event, string $name = null): SoapEvent;
 }

--- a/src/Phpro/SoapClient/Event/Dispatcher/PsrEventDispatcher.php
+++ b/src/Phpro/SoapClient/Event/Dispatcher/PsrEventDispatcher.php
@@ -19,6 +19,12 @@ class PsrEventDispatcher implements EventDispatcherInterface
         $this->dispatcher = $dispatcher;
     }
 
+    /**
+     * @template T of SoapEvent
+     * @param T $event
+     * @param string|null $name Deprecated : will be removed  in v2.0!
+     * @return T
+     */
     public function dispatch(SoapEvent $event, string $name = null): SoapEvent
     {
         $this->dispatcher->dispatch($event);

--- a/src/Phpro/SoapClient/Event/Dispatcher/SymfonyEventDispatcher.php
+++ b/src/Phpro/SoapClient/Event/Dispatcher/SymfonyEventDispatcher.php
@@ -25,6 +25,12 @@ class SymfonyEventDispatcher implements EventDispatcherInterface
         $this->dispatcher = $eventDispatcher;
     }
 
+    /**
+     * @template T of SoapEvent
+     * @param T $event
+     * @param string|null $eventName Deprecated : will be removed  in v2.0!
+     * @return T
+     */
     public function dispatch(SoapEvent $event, string $eventName = null): SoapEvent
     {
         $interfacesImplemented = class_implements($this->dispatcher);

--- a/src/Phpro/SoapClient/Event/RequestEvent.php
+++ b/src/Phpro/SoapClient/Event/RequestEvent.php
@@ -62,4 +62,9 @@ class RequestEvent extends SoapEvent
     {
         return $this->client;
     }
+
+    public function registerRequest(RequestInterface $request): void
+    {
+        $this->request = $request;
+    }
 }

--- a/src/Phpro/SoapClient/Event/ResponseEvent.php
+++ b/src/Phpro/SoapClient/Event/ResponseEvent.php
@@ -17,7 +17,7 @@ class ResponseEvent extends SoapEvent
     protected $requestEvent;
 
     /**
-     * @var mixed
+     * @var ResultInterface
      */
     protected $response;
 
@@ -60,5 +60,10 @@ class ResponseEvent extends SoapEvent
     public function getClient(): Client
     {
         return $this->client;
+    }
+
+    public function registerResponse(ResultInterface $response): void
+    {
+        $this->response = $response;
     }
 }

--- a/test/PhproTest/SoapClient/Unit/Event/RequestEventTest.php
+++ b/test/PhproTest/SoapClient/Unit/Event/RequestEventTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit;
+
+use Phpro\SoapClient\Client;
+use Phpro\SoapClient\Event\RequestEvent;
+use Phpro\SoapClient\Type\RequestInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class RequestEventTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var Client & ObjectProphecy
+     */
+    private Client $client;
+
+    /**
+     * @var RequestInterface & ObjectProphecy
+     */
+    private RequestInterface $request;
+
+    private RequestEvent $event;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->prophesize(Client::class)->reveal();
+        $this->request = $this->prophesize(RequestInterface::class)->reveal();
+        $this->event = new RequestEvent($this->client, 'method', $this->request);
+    }
+
+    /** @test */
+    public function it_contains_a_client(): void
+    {
+        self::assertSame($this->client, $this->event->getClient());
+    }
+
+    /** @test */
+    public function it_contains_a_request(): void
+    {
+        self::assertSame($this->request, $this->event->getRequest());
+    }
+
+    /** @test */
+    public function it_contains_a_method(): void
+    {
+        self::assertSame('method', $this->event->getMethod());
+    }
+
+    /** @test */
+    public function it_can_overwrite_request(): void
+    {
+        $new = $this->prophesize(RequestInterface::class)->reveal();
+        $this->event->registerRequest($new);
+
+        self::assertSame($new, $this->event->getRequest());
+        self::assertNotSame($this->request, $this->event->getRequest());
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Event/ResponseEventTest.php
+++ b/test/PhproTest/SoapClient/Unit/Event/ResponseEventTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit;
+
+use Phpro\SoapClient\Client;
+use Phpro\SoapClient\Event\RequestEvent;
+use Phpro\SoapClient\Event\ResponseEvent;
+use Phpro\SoapClient\Type\RequestInterface;
+use Phpro\SoapClient\Type\ResultInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class ResponseEventTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var Client & ObjectProphecy
+     */
+    private Client $client;
+
+    /**
+     * @var RequestInterface & ObjectProphecy
+     */
+    private RequestInterface $request;
+
+    /**
+     * @var ResultInterface & ObjectProphecy
+     */
+    private ResultInterface $response;
+
+    private RequestEvent $requestEvent;
+    private ResponseEvent $event;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->prophesize(Client::class)->reveal();
+        $this->request = $this->prophesize(RequestInterface::class)->reveal();
+        $this->response = $this->prophesize(ResultInterface::class)->reveal();
+        $this->requestEvent = new RequestEvent($this->client, 'method', $this->request);
+
+        $this->event = new ResponseEvent($this->client, $this->requestEvent, $this->response);
+    }
+
+    /** @test */
+    public function it_contains_a_client(): void
+    {
+        self::assertSame($this->client, $this->event->getClient());
+    }
+
+    /** @test */
+    public function it_contains_a_request_event(): void
+    {
+        self::assertSame($this->requestEvent, $this->event->getRequestEvent());
+    }
+
+    /** @test */
+    public function it_contains_a_response(): void
+    {
+        self::assertSame($this->response, $this->event->getResponse());
+    }
+
+    /** @test */
+    public function it_can_overwrite_response(): void
+    {
+        $new = $this->prophesize(ResultInterface::class)->reveal();
+        $this->event->registerResponse($new);
+
+        self::assertSame($new, $this->event->getResponse());
+        self::assertNotSame($this->response, $this->event->getResponse());
+    }
+}


### PR DESCRIPTION
This PR allows you to make changes on an immutable request / response from within an event listener.

For example, if you want to set a specific session through a listener:

```php
class RegisterSessionListener
{
    public function onClientRequest(RequestEvent $event)
    {
        $event->registerRequest(
            $event->getRequest()->withSession('XXXX')
         );
    }
}
```


(Did not add tests for the client yet, since I am going to rewrite it for 2.0.0)
