### PR TITLE
upgrade grumphp-shim to v1.3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php-http/mock-client": "^1.3",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "php-vcr/php-vcr": "1.4.5",
-        "phpro/grumphp-shim": "~1.2.0",
+        "phpro/grumphp-shim": "~1.3.3",
         "phpspec/phpspec": "~7.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpstan/phpstan": "^0.12.87",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php-http/mock-client": "^1.3",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "php-vcr/php-vcr": "1.4.5",
-        "phpro/grumphp-shim": "~1.3.3",
+        "phpro/grumphp-shim": "^1.3.3",
         "phpspec/phpspec": "~7.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpstan/phpstan": "^0.12.87",


### PR DESCRIPTION
[should fix amphp issues on windows-ci](https://github.com/phpro/soap-client/pull/383#issuecomment-879083592):

```
PHP Fatal error:  Uncaught TypeError: fclose(): supplied resource is not a valid stream resource in phar://D:/a/soap-client/soap-client/vendor/phpro/grumphp-shim/grumphp.phar/vendor/amphp/process/lib/Internal/Windows/Runner.php:171
Stack trace:
#0 phar://D:/a/soap-client/soap-client/vendor/phpro/grumphp-shim/grumphp.phar/vendor/amphp/process/lib/Internal/Windows/Runner.php(171): fclose()
#1 phar://D:/a/soap-client/soap-client/vendor/phpro/grumphp-shim/grumphp.phar/vendor/amphp/process/lib/Internal/Windows/Runner.php(155): _HumbugBoxec703235665e\Amp\Process\Internal\Windows\Runner->free()
#2 phar://D:/a/soap-client/soap-client/vendor/phpro/grumphp-shim/grumphp.phar/vendor/amphp/process/lib/Process.php(65): _HumbugBoxec703235665e\Amp\Process\Internal\Windows\Runner->destroy()
#3 [internal function]: _HumbugBoxec703235665e\Amp\Process\Process->__destruct()
#4 {main}
  thrown in phar://D:/a/soap-client/soap-client/vendor/phpro/grumphp-shim/grumphp.phar/vendor/amphp/process/lib/Internal/Windows/Runner.php on line 171
Error: Process completed with exit code 1.
```