### PR TITLE
Rename engine factory

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -186,7 +186,7 @@ the factory now injects the caller into your soap client.
 
 ```php
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Soap\ExtSoapEngine\ExtSoapOptions;
 use Phpro\SoapClient\Caller\EventDispatchingCaller;
 use Phpro\SoapClient\Caller\EngineCaller;
@@ -195,7 +195,7 @@ class CalculatorClientFactory
 {
     public static function factory(string $wsdl) : CalculatorClient
     {
-        $engine = ExtSoapEngineFactory::create(
+        $engine = DefaultEngineFactory::create(
             ExtSoapOptions::defaults($wsdl, [])
                 ->withClassMap(CalculatorClassmap::getCollection())
         );
@@ -210,13 +210,13 @@ class CalculatorClientFactory
 
 You can opt-out on the event dispatching logic or decorate your own caller.
 
-The `ExtSoapEngineFactory` can now be configured with a transport and the metadata options.
+The `DefaultEngineFactory` can now be configured with a transport and the metadata options.
 Full example on how you can personalize your factory class:
 
 ```php
 use Http\Client\Common\PluginClient;
 use Http\Discovery\Psr18ClientDiscovery;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Phpro\SoapClient\Soap\ExtSoap\Metadata\Manipulators\DuplicateTypes\RemoveDuplicateTypesStrategy;use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorChain;
 use Phpro\SoapClient\Soap\Metadata\MetadataOptions;
 use Soap\ExtSoapEngine\ExtSoapOptions;
@@ -226,7 +226,7 @@ use Soap\Psr18Transport\Psr18Transport;
 use Soap\Psr18Transport\Wsdl\Psr18Loader;
 
 $httpClient = Psr18ClientDiscovery::find();
-$engine = ExtSoapEngineFactory::create(
+$engine = DefaultEngineFactory::create(
     ExtSoapOptions::defaults($wsdl, [])
         ->withClassMap(CalculatorClassmap::getCollection())
         ->withWsdlProvider(

--- a/docs/cli/generate-clientfactory.md
+++ b/docs/cli/generate-clientfactory.md
@@ -37,7 +37,7 @@ use Phpro\SoapClient\Soap\ExtSoap\Metadata\Manipulators\DuplicateTypes\Intersect
 use Phpro\SoapClient\Soap\Metadata\MetadataOptions;
 use Soap\Psr18Transport\Psr18Transport;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\ExtSoap\DefaultEngineFactory;
 use Soap\ExtSoapEngine\ExtSoapOptions;
 use Phpro\SoapClient\Caller\EventDispatchingCaller;
 use Phpro\SoapClient\Caller\EngineCaller;
@@ -46,7 +46,7 @@ class CalculatorClientFactory
 {
     public static function factory(string $wsdl) : CalculatorClient
     {
-        $engine = ExtSoapEngineFactory::create(
+        $engine = DefaultEngineFactory::create(
             ExtSoapOptions::defaults($wsdl, [])
                 ->withClassMap(CalculatorClassmap::getCollection()),
             Psr18Transport::createForClient(

--- a/docs/code-generation/configuration.md
+++ b/docs/code-generation/configuration.md
@@ -9,11 +9,11 @@ The code generation commands require a configuration file to determine how the S
 use Phpro\SoapClient\CodeGenerator\Config\Config;
 use Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Assembler;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\ExtSoap\DefaultEngineFactory;
 use Soap\ExtSoapEngine\ExtSoapOptions;
 
 return Config::create()
-    ->setEngine(ExtSoapEngineFactory::create(
+    ->setEngine(DefaultEngineFactory::create(
         ExtSoapOptions::defaults('wsdl.xml', [])
             ->disableWsdlCache()
     ))

--- a/docs/drivers/metadata.md
+++ b/docs/drivers/metadata.md
@@ -10,7 +10,7 @@ Therefore, we added some strategies to deal with duplicate types:
 
 **IntersectDuplicateTypesStrategy**
 
-Enabled by default when using `ExtSoapEngineFactory::create()`.
+Enabled by default when using `DefaultEngineFactory::create()`.
 
 This duplicate types strategy will merge all duplicate types into one big type which contains all properties.
 
@@ -18,16 +18,16 @@ This duplicate types strategy will merge all duplicate types into one big type w
 
 This duplicate types strategy will remove all duplicate types it finds.
 
-You can overwrite the strategy on the `ExtSoapEngineFactory` object inside the client factory:
+You can overwrite the strategy on the `DefaultEngineFactory` object inside the client factory:
 
 ```php
 <?php
 
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Phpro\SoapClient\Soap\ExtSoap\Metadata\Manipulators\DuplicateTypes\RemoveDuplicateTypesStrategy;
 use Phpro\SoapClient\Soap\Metadata\MetadataOptions;
 
-$engine = ExtSoapEngineFactory::create(
+$engine = DefaultEngineFactory::create(
     $options, $transport,
     MetadataOptions::empty()->withTypesManipulator(
         new RemoveDuplicateTypesStrategy()

--- a/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
@@ -5,7 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator;
 use Phpro\SoapClient\Caller\EngineCaller;
 use Phpro\SoapClient\Caller\EventDispatchingCaller;
 use Phpro\SoapClient\CodeGenerator\Context\ClientFactoryContext;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Soap\ExtSoapEngine\ExtSoapOptions;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Laminas\Code\Generator\ClassGenerator;
@@ -20,7 +20,7 @@ use Laminas\Code\Generator\MethodGenerator;
 class ClientFactoryGenerator implements GeneratorInterface
 {
     const BODY = <<<BODY
-\$engine = ExtSoapEngineFactory::create(
+\$engine = DefaultEngineFactory::create(
     ExtSoapOptions::defaults(\$wsdl, [])
         ->withClassMap(%2\$s::getCollection())
 );
@@ -45,7 +45,7 @@ BODY;
         $class->addUse($context->getClientFqcn());
         $class->addUse($context->getClassmapFqcn());
         $class->addUse(EventDispatcher::class);
-        $class->addUse(ExtSoapEngineFactory::class);
+        $class->addUse(DefaultEngineFactory::class);
         $class->addUse(ExtSoapOptions::class);
         $class->addUse(EventDispatchingCaller::class);
         $class->addUse(EngineCaller::class);

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -5,7 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
 use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
 use Laminas\Code\Generator\FileGenerator;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Soap\ExtSoapEngine\ExtSoapOptions;
 
 /**
@@ -32,7 +32,7 @@ BODY;
 RULESET;
 
     const ENGINE_BOILERPLATE = <<<EOENGINE
-->setEngine(\$engine = ExtSoapEngineFactory::create(
+->setEngine(\$engine = DefaultEngineFactory::create(
         ExtSoapOptions::defaults('%s', [])
             ->disableWsdlCache()
     ))
@@ -77,7 +77,7 @@ EOENGINE;
         $file->setUse('Phpro\\SoapClient\\CodeGenerator\\Rules');
         $file->setUse(Config::class);
         $file->setUse(ExtSoapOptions::class);
-        $file->setUse(ExtSoapEngineFactory::class);
+        $file->setUse(DefaultEngineFactory::class);
 
         $body .= $this->parseEngine($file, $context->getWsdl());
         foreach ($context->getSetters() as $name => $value) {

--- a/src/Phpro/SoapClient/Soap/DefaultEngineFactory.php
+++ b/src/Phpro/SoapClient/Soap/DefaultEngineFactory.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Phpro\SoapClient\Soap\ExtSoap;
+namespace Phpro\SoapClient\Soap;
 
 use Phpro\SoapClient\Soap\ExtSoap\Metadata\Manipulators\DuplicateTypes\IntersectDuplicateTypesStrategy;
 use Phpro\SoapClient\Soap\Metadata\MetadataFactory;
@@ -16,7 +16,7 @@ use Soap\ExtSoapEngine\ExtSoapMetadata;
 use Soap\ExtSoapEngine\ExtSoapOptions;
 use Soap\Psr18Transport\Psr18Transport;
 
-final class ExtSoapEngineFactory
+final class DefaultEngineFactory
 {
     public static function create(
         ExtSoapOptions $options,

--- a/test/PhproTest/SoapClient/Functional/Client/ClientTest.php
+++ b/test/PhproTest/SoapClient/Functional/Client/ClientTest.php
@@ -11,7 +11,7 @@ use Http\Client\Plugin\Vcr\ReplayPlugin;
 use Http\Discovery\Psr18ClientDiscovery;
 use Phpro\SoapClient\Caller\Caller;
 use Phpro\SoapClient\Caller\EngineCaller;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Phpro\SoapClient\Type\MixedResult;
 use Phpro\SoapClient\Type\MultiArgumentRequest;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +27,7 @@ class ClientTest extends TestCase
         $recorder = new FilesystemRecorder(VCR_CASSETTE_DIR.'/client');
         $namingStrategy = new PathNamingStrategy();
         $caller = new EngineCaller(
-            ExtSoapEngineFactory::create(
+            DefaultEngineFactory::create(
                 ExtSoapOptions::defaults(FIXTURE_DIR.'/wsdl/functional/calculator.wsdl'),
                 Psr18Transport::createForClient(
                     new PluginClient(

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
@@ -22,7 +22,7 @@ namespace App\Client;
 use App\Client\Myclient;
 use App\Classmap\SomeClassmap;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Soap\ExtSoapEngine\ExtSoapOptions;
 use Phpro\SoapClient\Caller\EventDispatchingCaller;
 use Phpro\SoapClient\Caller\EngineCaller;
@@ -31,7 +31,7 @@ class MyclientFactory
 {
     public static function factory(string \$wsdl) : \App\Client\Myclient
     {
-        \$engine = ExtSoapEngineFactory::create(
+        \$engine = DefaultEngineFactory::create(
             ExtSoapOptions::defaults(\$wsdl, [])
                 ->withClassMap(SomeClassmap::getCollection())
         );

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -18,10 +18,10 @@ use Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
 use Soap\ExtSoapEngine\ExtSoapOptions;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
 
 return Config::create()
-    ->setEngine(\$engine = ExtSoapEngineFactory::create(
+    ->setEngine(\$engine = DefaultEngineFactory::create(
         ExtSoapOptions::defaults('wsdl.xml', [])
             ->disableWsdlCache()
     ))
@@ -83,10 +83,10 @@ use Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
 use Soap\ExtSoapEngine\ExtSoapOptions;
-use Phpro\SoapClient\Soap\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
 
 return Config::create()
-    ->setEngine(\$engine = ExtSoapEngineFactory::create(
+    ->setEngine(\$engine = DefaultEngineFactory::create(
         ExtSoapOptions::defaults('wsdl.xml', [])
             ->disableWsdlCache()
     ))


### PR DESCRIPTION
Instead of using `ExtSoapEngineFactory` this PR will use `DefaultEngineFactory`.
This allows us to swap the implementation or add a `CuttingEdgeEngineFactory` for providing more experimental implementations.