### PR TITLE
work arround differences between guzzle-psr7 and nyholm-psr7 requests

### DIFF
--- a/src/Phpro/SoapClient/Xml/Xml.php
+++ b/src/Phpro/SoapClient/Xml/Xml.php
@@ -90,7 +90,8 @@ class Xml
     public static function fromStream(StreamInterface $stream): Xml
     {
         $xml = new DOMDocument();
-        // use magic __toString() instead of getContents() because otherwise the stream might not return the actual content
+        // use magic __toString() instead of getContents() because otherwise the stream
+        // might not return the actual content if already read beforehand.
         $xml->loadXML($stream->__toString());
 
         /** @phpstan-ignore-next-line */

--- a/src/Phpro/SoapClient/Xml/Xml.php
+++ b/src/Phpro/SoapClient/Xml/Xml.php
@@ -90,7 +90,8 @@ class Xml
     public static function fromStream(StreamInterface $stream): Xml
     {
         $xml = new DOMDocument();
-        $xml->loadXML($stream->getContents());
+        // use magic __toString() instead of getContents() because otherwise the stream might not return the actual content
+        $xml->loadXML($stream->__toString());
 
         /** @phpstan-ignore-next-line */
         return new static($xml);

--- a/src/Phpro/SoapClient/Xml/Xml.php
+++ b/src/Phpro/SoapClient/Xml/Xml.php
@@ -92,6 +92,7 @@ class Xml
         $xml = new DOMDocument();
         // use magic __toString() instead of getContents() because otherwise the stream
         // might not return the actual content if already read beforehand.
+        // see https://github.com/php-fig/http-message/blob/efd67d1dc14a7ef4fc4e518e7dee91c271d524e4/src/StreamInterface.php#L14-L28
         $xml->loadXML($stream->__toString());
 
         /** @phpstan-ignore-next-line */

--- a/src/Phpro/SoapClient/Xml/Xml.php
+++ b/src/Phpro/SoapClient/Xml/Xml.php
@@ -90,10 +90,10 @@ class Xml
     public static function fromStream(StreamInterface $stream): Xml
     {
         $xml = new DOMDocument();
-        // use magic __toString() instead of getContents() because otherwise the stream
-        // might not return the actual content if already read beforehand.
-        // see https://github.com/php-fig/http-message/blob/efd67d1dc14a7ef4fc4e518e7dee91c271d524e4/src/StreamInterface.php#L14-L28
-        $xml->loadXML($stream->__toString());
+
+        // rewind in case the stream was already read
+        $stream->rewind();
+        $xml->loadXML((string)$stream);
 
         /** @phpstan-ignore-next-line */
         return new static($xml);

--- a/test/PhproTest/SoapClient/Unit/Xml/SoapXmlTest.php
+++ b/test/PhproTest/SoapClient/Unit/Xml/SoapXmlTest.php
@@ -163,6 +163,19 @@ class SoapXmlTest extends TestCase
     /**
      * @test
      */
+    function it_is_possible_to_create_from_a_already_read_psr7_stream()
+    {
+        $rawXml = $this->xml->saveXML();
+        $stream = new Stream(fopen('php://memory', 'rwb'));
+        $stream->write($rawXml);
+
+        $xml = SoapXml::fromStream($stream);
+        $this->assertEquals($rawXml, $xml->getXmlDocument()->saveXML());
+    }
+
+    /**
+     * @test
+     */
     function it_can_convert_to_a_psr7_stream()
     {
         $rawXml = $this->xml->saveXML();


### PR DESCRIPTION
improve PSR7 compat in case streams were already read.
~~use magic __toString() instead of getContents() because otherwise the stream might not return the actual content~~

see https://github.com/Nyholm/psr7/issues/189 for more issue details and a repro.

tbh. I am not sure whether this fix is correct or whether there is a problem in the different PSR7 implementations.

I guess we fixed similar things in the past with e.g. https://github.com/phpro/soap-client/pull/325