### PR TITLE
Use real type of iterator return value type hint

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/IteratorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/IteratorAssembler.php
@@ -75,7 +75,7 @@ class IteratorAssembler implements AssemblerInterface
                     'tags' => [
                         [
                             'name' => 'return',
-                            'description' => '\\ArrayIterator'
+                            'description' => '\\ArrayIterator|'. $firstProperty->getType() .'[]'
                         ],
                         [
                             'name' => 'phpstan-return',

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
@@ -59,7 +59,7 @@ use IteratorAggregate;
 class MyType implements IteratorAggregate
 {
     /**
-     * @return \ArrayIterator
+     * @return \ArrayIterator|array[]
      * @phpstan-return \ArrayIterator<array-key, array>
      * @psalm-return \ArrayIterator<array-key, array>
      */


### PR DESCRIPTION
This changes


    /**
     * @return \ArrayIterator
     * @phpstan-return \ArrayIterator<array-key, \My\Own\Type>
     * @psalm-return \ArrayIterator<array-key, \My\Own\Type>
     */

to


    /**
     * @return \ArrayIterator|\My\Own\Type[]
     * @phpstan-return \ArrayIterator<array-key, \My\Own\Type>
     * @psalm-return \ArrayIterator<array-key, \My\Own\Type>
     */

After this change, when i use `foreach ($client->getArrayOfXyz()->getIterator() as $item)` my IDE knows what type `$item` is and offers suggestions of methods to call on `$item` when I type `$item->`.