### PR TITLE
Use return types from JsonSerializable/IteratorAggregate (fixes PHP 8.1 deprecations)

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/IteratorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/IteratorAssembler.php
@@ -71,6 +71,7 @@ class IteratorAssembler implements AssemblerInterface
                     'return new \\ArrayIterator(is_array($this->%1$s) ? $this->%1$s : []);',
                     $firstProperty->getName()
                 ),
+                'returntype' => 'ArrayIterator',
                 'docblock' => DocBlockGeneratorFactory::fromArray([
                     'tags' => [
                         [

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/JsonSerializableAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/JsonSerializableAssembler.php
@@ -6,7 +6,6 @@ use JsonSerializable;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
-use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\MethodGenerator;
@@ -61,14 +60,7 @@ class JsonSerializableAssembler implements AssemblerInterface
                 'parameters' => [],
                 'visibility' => MethodGenerator::VISIBILITY_PUBLIC,
                 'body' => $this->generateJsonSerializeBody($type, $class),
-                'docblock' => DocBlockGeneratorFactory::fromArray([
-                    'tags' => [
-                        [
-                            'name' => 'return',
-                            'description' => 'array'
-                        ]
-                    ]
-                ])
+                'returntype' => 'array',
             ])
         );
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
@@ -63,7 +63,7 @@ class MyType implements IteratorAggregate
      * @phpstan-return \ArrayIterator<array-key, array>
      * @psalm-return \ArrayIterator<array-key, array>
      */
-    public function getIterator()
+    public function getIterator() : \ArrayIterator
     {
         return new \ArrayIterator(is_array(\$this->prop1) ? \$this->prop1 : []);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
@@ -54,10 +54,7 @@ use JsonSerializable;
 
 class MyType implements JsonSerializable
 {
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize() : array
     {
         return [
             'prop1' => \$this->prop1,


### PR DESCRIPTION
This fixes the new deprecation warnings in PHP 8.1.

> PHP Deprecated:  Return type of `<class>::jsonSerialize()` should either be compatible with `JsonSerializable::jsonSerialize(): mixed`, or the `#[\ReturnTypeWillChange]` attribute should be used to temporarily suppress the notice in `<file>` on line `<line>`

- I was unsure whether to keep the more general types from the interfaces (`mixed` and `Traversable`) or the specific types already present in the docblocks (`array` and `ArrayIterator`). I went for the latter.
- I looked up other cases of the same problem (in the `Assembler` namespace) but I couldn't find any — I'm not yet so familiar with this project.