### PR TITLE
Drop default request Content-Length header, in favor of late computation

### DIFF
--- a/spec/Phpro/SoapClient/Soap/HttpBinding/Builder/Psr7RequestBuilderSpec.php
+++ b/spec/Phpro/SoapClient/Soap/HttpBinding/Builder/Psr7RequestBuilderSpec.php
@@ -50,7 +50,6 @@ class Psr7RequestBuilderSpec extends ObjectBehavior
         $result->shouldBeAnInstanceOf(RequestInterface::class);
         $result->getMethod()->shouldBe('POST');
         $result->getHeader('Content-Type')[0]->shouldBe('text/xml; charset="utf-8"');
-        $result->getHeader('Content-Length')[0]->shouldBe((string) strlen($content));
         $result->hasHeader('SOAPAction')->shouldBe(true);
         $result->getHeader('SOAPAction')[0]->shouldBe($action);
         $result->getUri()->__toString()->shouldBe($endpoint);
@@ -79,7 +78,6 @@ class Psr7RequestBuilderSpec extends ObjectBehavior
         $result->shouldBeAnInstanceOf(RequestInterface::class);
         $result->getMethod()->shouldBe('POST');
         $result->getHeader('Content-Type')[0]->shouldBe('application/soap+xml; charset="utf-8"; action="http://www.soapaction.com"');
-        $result->getHeader('Content-Length')[0]->shouldBe((string) strlen($content));
         $result->hasHeader('SOAPAction')->shouldBe(false);
         $result->getUri()->__toString()->shouldBe($endpoint);
     }

--- a/src/Phpro/SoapClient/Soap/HttpBinding/Builder/Psr7RequestBuilder.php
+++ b/src/Phpro/SoapClient/Soap/HttpBinding/Builder/Psr7RequestBuilder.php
@@ -189,7 +189,6 @@ class Psr7RequestBuilder
     private function prepareSoap11Headers(): array
     {
         $headers = [];
-        $headers['Content-Length'] = (string) $this->soapMessage->getSize();
         $headers['SOAPAction'] = $this->soapAction;
         $headers['Content-Type'] = 'text/xml; charset="utf-8"';
 
@@ -210,7 +209,6 @@ class Psr7RequestBuilder
             return $headers;
         }
 
-        $headers['Content-Length'] = (string) $this->soapMessage->getSize();
         $headers['Content-Type'] = 'application/soap+xml; charset="utf-8"' . '; action="' . $this->soapAction . '"';
 
         return $headers;


### PR DESCRIPTION
Fixes #416 