### PR TITLE
Fix: deprecated notice AbusedClient

### DIFF
--- a/src/Phpro/SoapClient/Soap/Driver/ExtSoap/AbusedClient.php
+++ b/src/Phpro/SoapClient/Soap/Driver/ExtSoap/AbusedClient.php
@@ -48,6 +48,7 @@ class AbusedClient extends \SoapClient
         return new self($options->getWsdl(), $options->getOptions());
     }
 
+    #[\ReturnTypeWillChange]
     public function __doRequest($request, $location, $action, $version, $oneWay = 0)
     {
         $this->storedRequest = new SoapRequest($request, $location, $action, $version, (int) $oneWay);


### PR DESCRIPTION
In order to fix a deprecated notice with PHP 8.1.

Deprecated function: Return type of Phpro\SoapClient\Soap\Driver\ExtSoap\AbusedClient::__doRequest($request, $location, $action, $version, $oneWay = 0) should either be compatible with SoapClient::__doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): ?string, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice.