### PR TITLE
Feature: ConstructorAssembler add option to call parent constructor

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
@@ -75,6 +75,10 @@ class ConstructorAssembler implements AssemblerInterface
             'shortdescription' => 'Constructor'
         ]);
 
+        if ($this->options->useCallParentConstructor())) {
+            $body[] = 'parent::__construct();';
+        }
+
         foreach ($type->getProperties() as $property) {
             $body[] = sprintf('$this->%1$s = $%1$s;', $property->getName());
             $withTypeHints = $this->options->useTypeHints() ? ['type' => $property->getType()] : [];

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssemblerOptions.php
@@ -14,6 +14,11 @@ class ConstructorAssemblerOptions
     /**
      * @var bool
      */
+    private $callParentConstructor = false;
+
+    /**
+     * @var bool
+     */
     private $typeHints = false;
 
     /**
@@ -28,6 +33,28 @@ class ConstructorAssemblerOptions
     {
         return new self();
     }
+
+    /**
+     * @param bool $withCallParentConstructor
+     *
+     * @return ConstructorAssemblerOptions
+     */
+    public function withCallParentConstructor(bool $withCallParentConstructor = true): ConstructorAssemblerOptions
+    {
+        $new = clone $this;
+        $new->callParentConstructor = $withCallParentConstructor;
+
+        return $new;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useCallParentConstructor(): bool
+    {
+        return $this->callParentConstructor;
+    }
+
 
     /**
      * @param bool $withTypeHints


### PR DESCRIPTION
Option to generate constructors which call their parent constructor.
Adds the functionality to automatically set properties etc. to all extending classes from one single base class (parent).