### PR TITLE
Re-add possibility to use symfony v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         "php-soap/psr18-transport": "^1.0",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "~5.3 || ~6.0",
-        "symfony/event-dispatcher": "~5.3 || ~6.0",
-        "symfony/filesystem": "~5.3 || ~6.0",
-        "symfony/validator": "~5.3 || ~6.0"
+        "symfony/console": "~4.4 || ~5.3 || ~6.0",
+        "symfony/event-dispatcher": "~4.4 || ~5.3 || ~6.0",
+        "symfony/filesystem": "~4.4 || ~5.3 || ~6.0",
+        "symfony/validator": "~4.4 || ~5.3 || ~6.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.4.0",


### PR DESCRIPTION
Magento (in its latest release 2.4.4) still uses `symfony/console` in Version 4.4 with PHP8.1:
`magento/framework 103.0.4 requires symfony/console (~4.4.0)`

The possibility to use Symfony v4 was removed in cc141b3b743e2f535172a259343fde2447818713 with implementing PHP8.1 compatibility, despite Symfony v4 also supports PHP8.

@veewee As we're currently upgrading our customer's project to Magento 2.4.4 and want to use the latest version of `phpro/soap-client` we'd be very happy if you could merge this asap.

Thanks in advance.