### PR TITLE
Improve ValidatorSubscriber error messages by including property path.

### DIFF
--- a/spec/Phpro/SoapClient/Event/Subscriber/ValidatorSubscriberSpec.php
+++ b/spec/Phpro/SoapClient/Event/Subscriber/ValidatorSubscriberSpec.php
@@ -36,7 +36,9 @@ class ValidatorSubscriberSpec extends ObjectBehavior
         ConstraintViolation $violation2
     ) {
         $event = new RequestEvent('method', $request->getWrappedObject());
+        $violation1->getPropertyPath()->willReturn('one.two');
         $violation1->getMessage()->willReturn('error 1');
+        $violation2->getPropertyPath()->willReturn('one.two');
         $violation2->getMessage()->willReturn('error 2');
         $validator->validate($request)->willReturn(new ConstraintViolationList([
             $violation1->getWrappedObject(),

--- a/src/Phpro/SoapClient/Event/Subscriber/ValidatorSubscriber.php
+++ b/src/Phpro/SoapClient/Event/Subscriber/ValidatorSubscriber.php
@@ -56,7 +56,7 @@ class ValidatorSubscriber implements EventSubscriberInterface
         $strErrors = [];
         /** @var ConstraintViolationInterface $error */
         foreach ($errors as $error) {
-            $strErrors[] = $error->getMessage();
+            $strErrors[] = $error->getPropertyPath().': '.$error->getMessage();
         }
 
         return implode(GeneratorInterface::EOL, $strErrors);


### PR DESCRIPTION
This PR aims at improving the error messages thrown by ValidatorSubscriber, by including the property path on which the error message is occurring.

For example, at the moment all we get is:

```
Phpro\SoapClient\Exception\RequestException: This value should not be null.
```

With this PR, we would know which property to check:

```
Phpro\SoapClient\Exception\RequestException: requestDetails.products: This value should not be null.
```
