### PR TITLE
Generated constructor is descripbed by @param instead of @var.

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
@@ -85,7 +85,7 @@ class ConstructorAssembler implements AssemblerInterface
 
             if ($this->options->useDocBlocks()) {
                 $docblock->setTag([
-                    'name' => 'var',
+                    'name' => 'param',
                     'description' => sprintf('%s $%s', $property->getType(), $property->getName())
                 ]);
             }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
@@ -26,7 +26,7 @@ class ConstructorAssemblerTest extends TestCase
         $assembler = new ConstructorAssembler();
         $this->assertInstanceOf(AssemblerInterface::class, $assembler);
     }
-    
+
     /**
      * @test
      */
@@ -55,8 +55,8 @@ class MyType
     /**
      * Constructor
      *
-     * @var string \$prop1
-     * @var int \$prop2
+     * @param string \$prop1
+     * @param int \$prop2
      */
     public function __construct(\$prop1, \$prop2)
     {
@@ -95,9 +95,9 @@ class MyType
     /**
      * Constructor
      *
-     * @var string \$prop1
-     * @var int \$prop2
-     * @var \MyNamespace\SomeClass \$prop3
+     * @param string \$prop1
+     * @param int \$prop2
+     * @param \MyNamespace\SomeClass \$prop3
      */
     public function __construct(string \$prop1, int \$prop2, \MyNamespace\SomeClass \$prop3)
     {


### PR DESCRIPTION
The phpstan does not understand annotation `@var` for parameters in constructor for generated files.

You are using @param too in [your code](https://github.com/phpro/soap-client/blob/439f92226e4c93a0663d843dcaf65d62b16de54a/src/Phpro/SoapClient/Type/MixedResult.php#L20).