### PR TITLE
Add support for inheritance based on WSDL metadata

### DIFF
--- a/docs/code-generation/assemblers.md
+++ b/docs/code-generation/assemblers.md
@@ -6,9 +6,11 @@ to generate the code you want to add to the generated SOAP types.
  
 # Built-in assemblers
 
+- [AbstractClassAssembler](#abstractclassassembler)
 - [ClassMapAssembler](#classmapassembler)
 - [ConstructorAssembler](#constructorassembler)
 - [ExtendAssembler](#extendassembler)
+- [ExtendingTypeAssembler](#extendingtypeassembler)
 - [FinalClassAssembler](#finalclassassembler)
 - [FluentSetterAssembler](#fluentsetterassembler)
 - [GetterAssembler](#getterassembler)
@@ -25,6 +27,22 @@ to generate the code you want to add to the generated SOAP types.
 - [TraitAssembler](#traitassembler)
 - [UseAssembler](#useassembler)
 
+
+## AbstractClassAssembler
+
+The `AbstractClassAssembler` can be used to mark a generated class as abstract.
+
+Example output:
+
+```php
+
+abstract class MyType
+{
+
+
+}
+
+```
 
 ## ClassMapAssembler
 
@@ -154,6 +172,7 @@ final class MyType
 }
 
 ```
+
 ## ExtendAssembler
 
 The `ExtendAssembler` will add a parent class to the generated class.
@@ -163,6 +182,21 @@ Example output:
 ```php
 
 class MyType extends DType
+{
+
+
+}
+```
+
+## ExtendingTypeAssembler
+
+The `ExtendingTypeAssembler` will add the parent class that is provided by the WSDL metadata to the generated class.
+
+Example output:
+
+```php
+
+class MyType extends BaseType
 {
 
 

--- a/docs/code-generation/rules.md
+++ b/docs/code-generation/rules.md
@@ -12,6 +12,8 @@ The goal of a rule is to run a code assembler.
 
 - [AssemblerRule](#assemblerrule)
 - [ClientMethodMatchesRule](#clientmethodmatchesrule)
+- [IsAbstractTypeRule](#isabstracttyperule)
+- [IsExtendingTypeRule](#isextendingtyperule)
 - [IsRequestRule](#isrequestrule)
 - [IsResultRule](#isresultrule)
 - [MultiRule](#multirule)
@@ -51,6 +53,50 @@ The regular expression will be matched against the method name added to the gene
 If the regular expression matches and the subRule is accepted, the defined assembler will run.
  
 In the example above, a custom `RemoveClientMethodAssembler` is is used to remove the `demoSetup` method from the Client completely.
+
+## IsAbstractTypeRule
+
+```php
+use Phpro\SoapClient\CodeGenerator\Assembler;
+use Phpro\SoapClient\CodeGenerator\Rules;
+use Soap\Engine\Metadata\Metadata;
+
+assert($metadata instanceof Metadata);
+
+new Rules\IsAbstractTypeRule(
+    $metadata,
+    new Rules\AssembleRule(new Assembler\AbstractClassAssembler())
+)
+```
+
+The `IsAbstractTypeRule` can be used in the "types" generation command and contains the engine's metadata and a subRule.
+The rule will detect all abstract types based on the provided SOAP metadata.
+If the type matches an abstract type and the subRule is accepted, the defined assembler will run.
+
+This rule can be used to e.g. mark the PHP class as abstract.
+
+
+## IsExtendingTypeRule
+
+```php
+use Phpro\SoapClient\CodeGenerator\Assembler;
+use Phpro\SoapClient\CodeGenerator\Rules;
+use Soap\Engine\Metadata\Metadata;
+
+assert($metadata instanceof Metadata);
+
+new Rules\IsExtendingTypeRule(
+    $metadata,
+    new Rules\AssembleRule(new Assembler\ExtendingTypeAssembler())
+)
+```
+
+The `IsExtendingTypeRule` can be used in the "types" generation command and contains the engine's metadata and a subRule.
+The rule will detect all types that extend another SOAP type based on the provided SOAP metadata.
+If the type matches an abstract type and the subRule is accepted, the defined assembler will run.
+
+This rule can be used to make the PHP class of a type extend the base PHP class that is provided by the metadata.
+
 
 ## IsRequestRule
 

--- a/docs/known-issues/ext-soap.md
+++ b/docs/known-issues/ext-soap.md
@@ -2,7 +2,6 @@
 
 - [Duplicate typenames](#duplicate-typenames)
 - [Enumerations](#enumerations)
-- [Occurs](#occurs)
 
 Isn't your issue listed below? Feel free to provide additional issues in a functional test.
 
@@ -106,17 +105,3 @@ More information:
 - [Lack of validation in php-src](https://github.com/php/php-src/blob/php-7.2.10/ext/soap/php_encoding.c#L3172-L3200)
 
 **[Find out how you can help out here 💚](https://github.com/php-soap/.github/blob/main/HELPING_OUT.md)**
-
-
-## Occurs
-
-It is possible that the WSDL file contains `minOccurs` and `maxOccurs` on XSD elements.
-Ext-soap will not make this information available through the public API of the SOAP client.
-Therefore, we cannot predict during code generation if a type will definitely be an array or possibly be nullable.
-
-Currently, this issue can be avoided by not generating too strict types in the soap-client and optionally by using the [IteratorAssembler](../code-generation/assemblers.md#iteratorassembler).
-A better solution would be to parse the WSDL manually and add that information to the metadata.
-From that point on we can take this information into consideration during code generation.
-
-**[Find out how you can help out here 💚](https://github.com/php-soap/.github/blob/main/HELPING_OUT.md)**
-

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRuleSpec.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
+use Phpro\SoapClient\CodeGenerator\Rules\IsAbstractTypeRule;
+use PhpSpec\ObjectBehavior;
+use Soap\Engine\Metadata\Collection\PropertyCollection;
+use Soap\Engine\Metadata\Collection\TypeCollection;
+use Soap\Engine\Metadata\Metadata;
+use Soap\Engine\Metadata\Model\Type as MetaType;
+use Soap\Engine\Metadata\Model\TypeMeta;
+use Soap\Engine\Metadata\Model\XsdType;
+
+/**
+ * Class IsAbstractTypeRuleSpec
+ *
+ * @package spec\Phpro\SoapClient\CodeGenerator\Rules
+ * @mixin IsAbstractTypeRule
+ */
+class IsAbstractTypeRuleSpec extends ObjectBehavior
+{
+    function let(Metadata $metadata, RuleInterface $subRule)
+    {
+        $metadata->getTypes()->willReturn(new TypeCollection(
+            new MetaType(
+                XsdType::create('MyAbstract')->withMeta(
+                    static fn (TypeMeta $meta): TypeMeta => $meta->withIsAbstract(true)
+                ),
+                new PropertyCollection()
+            ),
+            new MetaType(
+                XsdType::create('NotAbstract'),
+                new PropertyCollection()
+            ),
+        ));
+        $this->beConstructedWith($metadata, $subRule);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(IsAbstractTypeRule::class);
+    }
+
+    function it_is_a_rule()
+    {
+        $this->shouldImplement(RuleInterface::class);
+    }
+
+    function it_can_not_apply_to_regular_context(ContextInterface $context)
+    {
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', [], new TypeMeta()));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(true);
+    }
+
+    function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', [], new TypeMeta()));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(true);
+    }
+
+    function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'NotAbstract', [], new TypeMeta()));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', [], new TypeMeta()));
+        $subRule->appliesToContext($context)->willReturn(false);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_appies_subrule_when_applied(RuleInterface $subRule, ContextInterface $context)
+    {
+        $subRule->apply($context)->shouldBeCalled();
+        $this->apply($context);
+    }
+}

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRuleSpec.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
+use Phpro\SoapClient\CodeGenerator\Rules\IsExtendingTypeRule;
+use PhpSpec\ObjectBehavior;
+use Soap\Engine\Metadata\Collection\PropertyCollection;
+use Soap\Engine\Metadata\Collection\TypeCollection;
+use Soap\Engine\Metadata\Metadata;
+use Soap\Engine\Metadata\Model\Type as MetaType;
+use Soap\Engine\Metadata\Model\TypeMeta;
+use Soap\Engine\Metadata\Model\XsdType;
+
+/**
+ * Class IsExtendingTypeRuleSpec
+ *
+ * @package spec\Phpro\SoapClient\CodeGenerator\Rules
+ * @mixin IsExtendingTypeRule
+ */
+class IsExtendingTypeRuleSpec extends ObjectBehavior
+{
+    function let(Metadata $metadata, RuleInterface $subRule)
+    {
+        $metadata->getTypes()->willReturn(new TypeCollection(
+            new MetaType(
+                XsdType::create('MyExtending')->withMeta(
+                    static fn (TypeMeta $meta): TypeMeta => $meta->withExtends([
+                        'type' => 'BaseType',
+                        'namespace' => 'xxx',
+                    ])
+                ),
+                new PropertyCollection()
+            ),
+            new MetaType(
+                XsdType::create('NotExtending'),
+                new PropertyCollection()
+            ),
+        ));
+        $this->beConstructedWith($metadata, $subRule);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(IsExtendingTypeRule::class);
+    }
+
+    function it_is_a_rule()
+    {
+        $this->shouldImplement(RuleInterface::class);
+    }
+
+    function it_can_not_apply_to_regular_context(ContextInterface $context)
+    {
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', [], new TypeMeta()));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(true);
+    }
+
+    function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', [], new TypeMeta()));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(true);
+    }
+
+    function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'NotExtending', [], new TypeMeta()));
+        $subRule->appliesToContext($context)->willReturn(true);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
+    {
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', [], new TypeMeta()));
+        $subRule->appliesToContext($context)->willReturn(false);
+        $this->appliesToContext($context)->shouldReturn(false);
+    }
+
+    function it_appies_subrule_when_applied(RuleInterface $subRule, ContextInterface $context)
+    {
+        $subRule->apply($context)->shouldBeCalled();
+        $this->apply($context);
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/AbstractClassAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/AbstractClassAssembler.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Assembler;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+
+/**
+ * Class FinalClassAssembler
+ *
+ * @package Phpro\SoapClient\CodeGenerator\Assembler
+ */
+class AbstractClassAssembler implements AssemblerInterface
+{
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canAssemble(ContextInterface $context): bool
+    {
+        return $context instanceof TypeContext;
+    }
+
+    /**
+     * @param ContextInterface|TypeContext $context
+     */
+    public function assemble(ContextInterface $context)
+    {
+        $class = $context->getClass();
+        $class->setAbstract(true);
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendingTypeAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendingTypeAssembler.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Assembler;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Phpro\SoapClient\Exception\AssemblerException;
+
+/**
+ * Class ExtendingTypeAssembler
+ *
+ * @package Phpro\SoapClient\CodeGenerator\Assembler
+ */
+class ExtendingTypeAssembler implements AssemblerInterface
+{
+    /**
+     * @param ContextInterface $context
+     *
+     * @return bool
+     */
+    public function canAssemble(ContextInterface $context): bool
+    {
+        return $context instanceof TypeContext;
+    }
+
+    /**
+     * @param ContextInterface|TypeContext $context
+     */
+    public function assemble(ContextInterface $context)
+    {
+        $type = $context->getType();
+        $meta = $type->getMeta();
+        $extending = $meta->extends()->unwrapOr(null);
+
+        if (!$extending) {
+            return;
+        }
+
+        $namespace = $type->getNamespace();
+        $typeName = Normalizer::normalizeClassname($extending['type']);
+        $extendedClassName = sprintf('\\%s\\%s', $namespace, $typeName);
+
+        try {
+            $extendAssembler = new ExtendAssembler($extendedClassName);
+            if ($extendAssembler->canAssemble($context)) {
+                $extendAssembler->assemble($context);
+            }
+        } catch (\Exception $e) {
+            throw AssemblerException::fromException($e);
+        }
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -86,6 +86,7 @@ EOENGINE;
         $body .= $this->parseIndentedRuleSet($file, $this->generateGetterSetterRuleSet($context));
         $body .= $this->parseIndentedRuleSet($file, $this->generateRequestRuleSet($context));
         $body .= $this->parseIndentedRuleSet($file, self::RULESET_RESPONSE);
+        $body .= $this->parseIndentedRuleSet($file, $this->generateInheritanceRules());
 
         $file->setBody($body.';'.GeneratorInterface::EOL);
 
@@ -142,5 +143,23 @@ REQUEST;
     )
 )
 REQUEST;
+    }
+
+    private function generateInheritanceRules(): string
+    {
+        return <<<INHERITANCE
+->addRule(
+    new Rules\IsExtendingTypeRule(
+        \$engine->getMetadata(),
+        new Rules\AssembleRule(new Assembler\ExtendingTypeAssembler())
+    )
+)
+->addRule(
+    new Rules\IsAbstractTypeRule(
+        \$engine->getMetadata(),
+        new Rules\AssembleRule(new Assembler\AbstractClassAssembler())
+    )
+)
+INHERITANCE;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRule.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Soap\Engine\Metadata\Metadata;
+use Soap\Engine\Metadata\Model\Type;
+use function Psl\Type\non_empty_string;
+
+class IsAbstractTypeRule implements RuleInterface
+{
+    private Metadata $metadata;
+    private RuleInterface $subRule;
+
+    /**
+     * @var list<string>|null
+     */
+    private $abstractTypes = null;
+
+    public function __construct(Metadata $metadata, RuleInterface $subRule)
+    {
+        $this->metadata = $metadata;
+        $this->subRule = $subRule;
+    }
+
+    public function appliesToContext(ContextInterface $context): bool
+    {
+        if (!$context instanceof TypeContext && !$context instanceof PropertyContext) {
+            return false;
+        }
+
+        $type = $context->getType();
+        if (!in_array($type->getName(), $this->listAbstractTypes(), true)) {
+            return false;
+        }
+
+        return $this->subRule->appliesToContext($context);
+    }
+
+    public function apply(ContextInterface $context)
+    {
+        $this->subRule->apply($context);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listAbstractTypes(): array
+    {
+        if (null === $this->abstractTypes) {
+            $this->abstractTypes = $this->metadata->getTypes()->reduce(
+                /**
+                 * @param list<string> $abstractTypes
+                 * @return list<string>
+                 */
+                static function (array $abstractTypes, Type $type): array {
+                    if (!$type->getXsdType()->getMeta()->isAbstract()->unwrapOr(false)) {
+                        return $abstractTypes;
+                    }
+
+                    return [
+                        ...$abstractTypes,
+                        Normalizer::normalizeClassname(non_empty_string()->assert($type->getName())),
+                    ];
+                },
+                []
+            );
+        }
+
+        return $this->abstractTypes;
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRule.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\CodeGenerator\Rules;
+
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Soap\Engine\Metadata\Metadata;
+use Soap\Engine\Metadata\Model\Type;
+use function Psl\Type\non_empty_string;
+
+class IsExtendingTypeRule implements RuleInterface
+{
+    private Metadata $metadata;
+    private RuleInterface $subRule;
+
+    /**
+     * @var list<string>|null
+     */
+    private $extendingTypes = null;
+
+    public function __construct(Metadata $metadata, RuleInterface $subRule)
+    {
+        $this->metadata = $metadata;
+        $this->subRule = $subRule;
+    }
+
+    public function appliesToContext(ContextInterface $context): bool
+    {
+        if (!$context instanceof TypeContext && !$context instanceof PropertyContext) {
+            return false;
+        }
+
+        $type = $context->getType();
+        if (!in_array($type->getName(), $this->listExtendingTypes(), true)) {
+            return false;
+        }
+
+        return $this->subRule->appliesToContext($context);
+    }
+
+    public function apply(ContextInterface $context)
+    {
+        $this->subRule->apply($context);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listExtendingTypes(): array
+    {
+        if (null === $this->extendingTypes) {
+            $this->extendingTypes = $this->metadata->getTypes()->reduce(
+                /**
+                 * @param list<string> $extendingTypes
+                 * @return list<string>
+                 */
+                static function (array $extendingTypes, Type $type): array {
+                    if (!$type->getXsdType()->getMeta()->extends()->unwrapOr(false)) {
+                        return $extendingTypes;
+                    }
+
+                    return [
+                        ...$extendingTypes,
+                        Normalizer::normalizeClassname(non_empty_string()->assert($type->getName()))
+                    ];
+                },
+                []
+            );
+        }
+
+        return $this->extendingTypes;
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/AbstractClassAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/AbstractClassAssemblerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Assembler;
+
+use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
+use Phpro\SoapClient\CodeGenerator\Assembler\AbstractClassAssembler;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Property;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PHPUnit\Framework\TestCase;
+use Laminas\Code\Generator\ClassGenerator;
+use Soap\Engine\Metadata\Model\Property as MetaProperty;
+use Soap\Engine\Metadata\Model\TypeMeta;
+use Soap\Engine\Metadata\Model\XsdType;
+
+/**
+ * Class AbstractClassAssemblerTest
+ *
+ * @package PhproTest\SoapClient\Unit\CodeGenerator\Assembler
+ */
+class AbstractClassAssemblerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    function it_is_an_assembler()
+    {
+        $assembler = new AbstractClassAssembler();
+        $this->assertInstanceOf(AssemblerInterface::class, $assembler);
+    }
+
+    /**
+     * @test
+     */
+    function it_can_assemble_type_context()
+    {
+        $assembler = new AbstractClassAssembler();
+        $context = $this->createContext();
+        $this->assertTrue($assembler->canAssemble($context));
+    }
+
+    /**
+     * @test
+     */
+    function it_assembles_a_type()
+    {
+        $assembler = new AbstractClassAssembler();
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+abstract class MyType
+{
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @return TypeContext
+     */
+    private function createContext()
+    {
+        $class = new ClassGenerator('MyType', 'MyNamespace');
+        $type = new Type($namespace ='MyNamespace', 'MyType', [
+            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
+        ], new TypeMeta());
+
+        return new TypeContext($class, $type);
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendingTypeAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendingTypeAssemblerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Assembler;
+
+use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
+use Phpro\SoapClient\CodeGenerator\Assembler\ExtendingTypeAssembler;
+use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PHPUnit\Framework\TestCase;
+use Laminas\Code\Generator\ClassGenerator;
+use Soap\Engine\Metadata\Model\TypeMeta;
+
+/**
+ * Class ExtendingTypeAssemblerTest
+ *
+ * @package PhproTest\SoapClient\Unit\CodeGenerator\Assembler
+ */
+class ExtendingTypeAssemblerTest extends TestCase
+{
+
+    /**
+     * @test
+     */
+    function it_is_an_assembler()
+    {
+        $assembler = new ExtendingTypeAssembler();
+        $this->assertInstanceOf(AssemblerInterface::class, $assembler);
+    }
+
+    /**
+     * @test
+     */
+    function it_can_assemble_type_context()
+    {
+        $assembler = new ExtendingTypeAssembler();
+        $context = $this->createContext();
+        $this->assertTrue($assembler->canAssemble($context));
+    }
+
+    /**
+     * @test
+     */
+    function it_assembles_a_type()
+    {
+        $assembler = new ExtendingTypeAssembler();
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+use \MyNamespace\MyBaseType;
+
+class MyType extends MyBaseType
+{
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @test
+     */
+    function it_skips_assambling_on_non_extending_type()
+    {
+        $assembler = new ExtendingTypeAssembler();
+        $class = new ClassGenerator('MyType', 'MyNamespace');
+        $type = new Type('MyNamespace', 'MyType', [], new TypeMeta());
+
+        $context = new TypeContext($class, $type);
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @return TypeContext
+     */
+    private function createContext()
+    {
+        $class = new ClassGenerator('MyType', 'MyNamespace');
+        $type = new Type('MyNamespace', 'MyType', [], (new TypeMeta())->withExtends([
+            'type' => 'MyBaseType',
+            'namespace' => 'xxxx'
+        ]));
+
+        return new TypeContext($class, $type);
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -53,6 +53,18 @@ return Config::create()
             ])
         )
     )
+    ->addRule(
+        new Rules\IsExtendingTypeRule(
+            \$engine->getMetadata(),
+            new Rules\AssembleRule(new Assembler\ExtendingTypeAssembler())
+        )
+    )
+    ->addRule(
+        new Rules\IsAbstractTypeRule(
+            \$engine->getMetadata(),
+            new Rules\AssembleRule(new Assembler\AbstractClassAssembler())
+        )
+    )
 ;
 
 CONTENT;
@@ -111,6 +123,18 @@ return Config::create()
             new Rules\MultiRule([
                 new Rules\AssembleRule(new Assembler\ResultAssembler()),
             ])
+        )
+    )
+    ->addRule(
+        new Rules\IsExtendingTypeRule(
+            \$engine->getMetadata(),
+            new Rules\AssembleRule(new Assembler\ExtendingTypeAssembler())
+        )
+    )
+    ->addRule(
+        new Rules\IsAbstractTypeRule(
+            \$engine->getMetadata(),
+            new Rules\AssembleRule(new Assembler\AbstractClassAssembler())
         )
     )
 ;


### PR DESCRIPTION
Adds support for common inheritance (extends + abstract) problems.
It uses the generated WSDL metadata in order to decide whether it should apply abstract or extends.

Tested on https://onlineavl2svc-uk.navmanwireless.com/OnlineAVL/API/V2.1/Service.asmx?wsdl

```php
return Config::create()
    // ....
    ->addRule(
        new Rules\IsExtendingTypeRule(
            $engine->getMetadata(),
            new Rules\AssembleRule(new Assembler\ExtendingTypeAssembler())
        )
    )
    ->addRule(
        new Rules\IsAbstractTypeRule(
            $engine->getMetadata(),
            new Rules\AssembleRule(new Assembler\AbstractClassAssembler())
        )
    )
;
```

These rules will automatically be applied when generating the configuration file!

Meta:

```
BaseFieldValue
==============

> http://onlineavl2.navmanwireless.com/0907/:BaseFieldValue

+------------+-------+
| Meta       | Value |
+------------+-------+
| isAbstract | true  |
| docs       |       |
+------------+-------+


StringFieldValue
================

> http://onlineavl2.navmanwireless.com/0907/:StringFieldValue extends BaseFieldValue {
    ?string $Value
  }

+------------+-------------------------------------------------------------------+
| Meta       | Value                                                             |
+------------+-------------------------------------------------------------------+
| isAbstract | false                                                             |
| docs       |                                                                   |
| extends    | {                                                                 |
|            |     "type": "BaseFieldValue",                                     |
|            |     "namespace": "http:\/\/onlineavl2.navmanwireless.com\/0907\/" |
|            | }                                                                 |
+------------+-------------------------------------------------------------------+
```


Result:

```php
abstract class BaseFieldValue
{
}

class StringFieldValue extends BaseFieldValue
{
    /**
     * @var null|string
     */
    private ?string $Value;
}


```
