### PR TITLE
Add static analysis support for enumerations

### DIFF
--- a/docs/known-issues/ext-soap.md
+++ b/docs/known-issues/ext-soap.md
@@ -64,6 +64,9 @@ Since PHP does not have an internal `enum` type,
 ext-soap will transform the data to the type that is determined in the `xsd:restriction` section.
 The soap client will never try to validate the input against the configured enumerations inside the WSDL.
 
+We've added basic support for enumerations in this package so that issues can be resolved at static analysis level.
+However, during runtime, it is not possible to validate these enumerations without creating a custom typemap.
+
 For example:
 ```xml
 <xsd:simpleType name="PhoneTypeEnum">
@@ -81,6 +84,12 @@ For example:
 - If you do want to use a custom class for the enumerations type, you can create a type converter like this:
 
 ```php
+enum PhoneTypeEnum : string {
+    case HOME = 'Home';
+    case GSM = 'Gsm';
+    case OFFICE = 'Office';
+}
+
 $soapOptions = [
     'typemap' => [
         [
@@ -90,10 +99,10 @@ $soapOptions = [
                 $doc = new \DOMDocument();
                 $doc->loadXML($xml);
 
-                return new PhoneTypeEnum($doc->textContent);
+                return PhoneTypeEnum::from($doc->textContent);
             },
             'to_xml' => function(PhoneTypeEnum $enum) {
-                return sprintf('<PhoneTypeEnum>%s</PhoneTypeEnum>', $enum->getValue());
+                return sprintf('<PhoneTypeEnum>%s</PhoneTypeEnum>', $enum->value);
             },
         ],
     ],

--- a/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/Calculator/EnumValuesCalculator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/Calculator/EnumValuesCalculator.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator;
+
+use Soap\Engine\Metadata\Model\TypeMeta;
+use function Psl\Str\join;
+use function Psl\Type\non_empty_string;
+use function Psl\Vec\map;
+
+final class EnumValuesCalculator
+{
+    /**
+     * @param TypeMeta $meta
+     * @return non-empty-string
+     */
+    public function __invoke(TypeMeta $meta): string
+    {
+        return non_empty_string()->assert(
+            join(
+                map(
+                    $meta->enums()->unwrapOr([]),
+                    static fn (string $value) => "'".addcslashes($value, "'")."'",
+                ),
+                ' | '
+            )
+        );
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/MetaTypeEnhancer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/MetaTypeEnhancer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Phpro\SoapClient\CodeGenerator\TypeEnhancer;
 
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\ArrayBoundsCalculator;
+use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\EnumValuesCalculator;
 use Soap\Engine\Metadata\Model\TypeMeta;
 
 final class MetaTypeEnhancer implements TypeEnhancer
@@ -19,6 +20,11 @@ final class MetaTypeEnhancer implements TypeEnhancer
      */
     public function asDocBlockType(string $type): string
     {
+        $enums = $this->meta->enums()->unwrapOr([]);
+        if ($enums) {
+            $type = (new EnumValuesCalculator())($this->meta);
+        }
+
         $isArray = $this->meta->isList()->unwrapOr(false);
         if ($isArray) {
             $type = 'array<'.(new ArrayBoundsCalculator())($this->meta).', '.$type.'>';
@@ -26,7 +32,7 @@ final class MetaTypeEnhancer implements TypeEnhancer
 
         $isNullable = $this->meta->isNullable()->unwrapOr(false);
         if ($isNullable) {
-            $type = 'null|'.$type;
+            $type = 'null | '.$type;
         }
 
         return $type;

--- a/test/PhproTest/SoapClient/Functional/ExtSoap/Encoding/EnumTest.php
+++ b/test/PhproTest/SoapClient/Functional/ExtSoap/Encoding/EnumTest.php
@@ -133,17 +133,20 @@ class EnumTest extends AbstractSoapTestCase
                             return null;
                         }
 
-                        return $this->createEnum($doc->textContent);
+                        return OfficeEnum::from($doc->textContent)->value;
                     },
                     'to_xml' => function($enum) {
-                        return sprintf('<PhoneTypeEnum>%s</PhoneTypeEnum>', $enum);
+                        return sprintf(
+                            '<PhoneTypeEnum>%s</PhoneTypeEnum>',
+                            $enum ? OfficeEnum::from($enum)->value : ''
+                        );
                     },
                 ]
             ]
         ]);
         $engine = new SimpleEngine($this->driver, $this->transport);
 
-        $input = $this->createEnum('Home');
+        $input = OfficeEnum::HOME->value;
         $response = $engine->request('validate', [$input]);
         $lastRequestInfo = $this->transport->collectLastRequestInfo();
 
@@ -157,27 +160,15 @@ class EnumTest extends AbstractSoapTestCase
             $lastRequestInfo->getLastResponse()
         );
     }
+}
 
-    private function createEnum(string $value) {
-        return new class ($value) {
-            /**
-             * @var string
-             */
-            private $value;
+enum OfficeEnum : string {
+    case HOME = 'Home';
+    case GSM = 'Gsm';
+    case OFFICE = 'Office';
 
-            public function __construct(string $value)
-            {
-                if (!in_array($value, ['Home', 'Office', 'Gsm'], true)) {
-                    throw new \Exception('Unknown enum value ' . $value);
-                }
-
-                $this->value = $value;
-            }
-
-            public function __toString()
-            {
-                return $this->value;
-            }
-        };
-    }
+    /**
+     * sadly __toString is not possible on enums.
+     * Otherwise, soap would just be able to use php enums...
+     */
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/EnumValuesCalculatorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/EnumValuesCalculatorTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\TypeEnhancer\Calculator;
+
+use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\EnumValuesCalculator;
+use PHPUnit\Framework\TestCase;
+use Psl\Type\Exception\AssertException;
+use Soap\Engine\Metadata\Model\TypeMeta;
+
+class EnumValuesCalculatorTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideExpectations
+     */
+    public function it_can_enhance_types(
+        TypeMeta $meta,
+        string $expected,
+    ): void{
+        $calculator = new EnumValuesCalculator();
+
+        self::assertSame($expected, $calculator($meta));
+    }
+
+    /** @test */
+    public function it_fails_on_empty_enumerations(): void
+    {
+        $this->expectException(AssertException::class);
+
+        (new EnumValuesCalculator())(new TypeMeta());
+    }
+
+    public function provideExpectations()
+    {
+        yield 'single' => [
+            (new TypeMeta())->withEnums(['a']),
+            "'a'",
+        ];
+        yield 'multi' => [
+            (new TypeMeta())->withEnums(['a', 'b']),
+            "'a' | 'b'",
+        ];
+        yield 'numeric' => [
+            (new TypeMeta())->withEnums(['0', '1']),
+            "'0' | '1'",
+        ];
+        yield 'quoted' => [
+            (new TypeMeta())->withEnums(['a', '\'b']),
+            "'a' | '\\'b'",
+        ];
+        yield 'not-quoted' => [
+            (new TypeMeta())->withEnums(['a', '"b']),
+            "'a' | '\"b'",
+        ];
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/MetaTypeEnhancerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/MetaTypeEnhancerTest.php
@@ -54,14 +54,38 @@ class MetaTypeEnhancerTest extends TestCase
         yield 'nullable' => [
             (new TypeMeta())->withIsNullable(true),
             'simple',
-            'null|simple',
+            'null | simple',
             '?simple',
         ];
         yield 'nullable-array' => [
             (new TypeMeta())->withIsList(true)->withIsNullable(true),
             'simple',
-            'null|array<int<min,max>, simple>',
+            'null | array<int<min,max>, simple>',
             '?array',
+        ];
+        yield 'enum' => [
+            (new TypeMeta())->withEnums(['a', 'b']),
+            'string',
+            "'a' | 'b'",
+            'string',
+        ];
+        yield 'enum-list' => [
+            (new TypeMeta())->withEnums(['a', 'b'])->withIsList(true),
+            'string',
+            "array<int<min,max>, 'a' | 'b'>",
+            'array',
+        ];
+        yield 'nullable-enum-list' => [
+            (new TypeMeta())->withEnums(['a', 'b'])->withIsList(true)->withIsNullable(true),
+            'string',
+            "null | array<int<min,max>, 'a' | 'b'>",
+            '?array',
+        ];
+        yield 'nullable-enum' => [
+            (new TypeMeta())->withEnums(['a', 'b'])->withIsNullable(true),
+            'string',
+            "null | 'a' | 'b'",
+            '?string',
         ];
     }
 }


### PR DESCRIPTION
It's currently not possible to use PHP enums together with PHP's soap-client.
In this PR, all enum values will be added to the docblock types.

This way, your static analyser will be able to determine the input and output. 
However, there is no value validation happening at runtime.
This means that if an enumeration was added or removed, you won't get any errors.


This PR adds support for:

```php
        yield 'enum' => [
            (new TypeMeta())->withEnums(['a', 'b']),
            'string',
            "'a' | 'b'",
            'string',
        ];
        yield 'enum-list' => [
            (new TypeMeta())->withEnums(['a', 'b'])->withIsList(true),
            'string',
            "array<int<min,max>, 'a' | 'b'>",
            'array',
        ];
        yield 'nullable-enum-list' => [
            (new TypeMeta())->withEnums(['a', 'b'])->withIsList(true)->withIsNullable(true),
            'string',
            "null | array<int<min,max>, 'a' | 'b'>",
            '?array',
        ];
        yield 'nullable-enum' => [
            (new TypeMeta())->withEnums(['a', 'b'])->withIsNullable(true),
            'string',
            "null | 'a' | 'b'",
            '?string',
        ];
```