### PR TITLE
Add support for union types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpro/grumphp-shim": "^1.14",
         "phpspec/phpspec": "~7.2",
         "phpspec/prophecy-phpunit": "^2.0.1",
-        "phpstan/phpstan": "^1.9.0",
+        "phpstan/phpstan": "^1.10.15",
         "phpunit/phpunit": "~9.5",
         "squizlabs/php_codesniffer": "^3.7.1"
     },

--- a/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/Calculator/UnionTypesCalculator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/Calculator/UnionTypesCalculator.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator;
+
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Soap\Engine\Metadata\Model\TypeMeta;
+use function Psl\Str\join;
+use function Psl\Type\non_empty_string;
+use function Psl\Vec\map;
+
+final class UnionTypesCalculator
+{
+    /**
+     * @param TypeMeta $meta
+     * @return non-empty-string
+     */
+    public function __invoke(TypeMeta $meta): string
+    {
+        return non_empty_string()->assert(
+            join(
+                map(
+                    $meta->unions()->unwrapOr([]),
+                    /**
+                     * @var array{type: non-empty-string, isList: bool} $union
+                     * @return non-empty-string
+                     */
+                    static function (array $union): string {
+                        $type = $union['type'];
+                        $type = Normalizer::isKnownType($type) ? $type : Normalizer::normalizeClassname($type);
+
+                        return $union['isList'] ? 'list<'.$type.'>' : $type;
+                    }
+                ),
+                ' | '
+            )
+        );
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -200,22 +200,6 @@ class Normalizer
     }
 
     /**
-     * @param non-empty-string $fqn
-     *
-     * @return non-empty-string
-     */
-    public static function normalizeClassnameInFQN(string $fqn): string
-    {
-        if (self::isKnownType($fqn)) {
-            return $fqn;
-        }
-
-        $className = self::getClassNameFromFQN($fqn);
-
-        return substr($fqn, 0, -1 * \strlen($className)).self::normalizeClassname($className);
-    }
-
-    /**
      * @param non-empty-string $property
      *
      * @return non-empty-string

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/UnionTypesCalculatorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/UnionTypesCalculatorTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\TypeEnhancer\Calculator;
+
+use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\UnionTypesCalculator;
+use PHPUnit\Framework\TestCase;
+use Psl\Type\Exception\AssertException;
+use Soap\Engine\Metadata\Model\TypeMeta;
+
+class UnionTypesCalculatorTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideExpectations
+     */
+    public function it_can_enhance_types(
+        TypeMeta $meta,
+        string $expected,
+    ): void{
+        $calculator = new UnionTypesCalculator();
+
+        self::assertSame($expected, $calculator($meta));
+    }
+
+    /** @test */
+    public function it_fails_on_empty_enumerations(): void
+    {
+        $this->expectException(AssertException::class);
+
+        (new UnionTypesCalculator())(new TypeMeta());
+    }
+
+    public function provideExpectations()
+    {
+        yield 'single' => [
+            (new TypeMeta())->withUnions([
+                ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
+            ]),
+            "string",
+        ];
+        yield 'multi' => [
+            (new TypeMeta())->withUnions([
+                ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
+                ['type' => 'int', 'isList' => false, 'namespace' => 'xx'],
+            ]),
+            "string | int",
+        ];
+        yield 'list' => [
+            (new TypeMeta())->withUnions([
+                ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
+                ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
+            ]),
+            "string | list<int>",
+        ];
+        yield 'complexType' => [
+            (new TypeMeta())->withUnions([
+                ['type' => 'My_Type', 'isList' => false, 'namespace' => 'xx'],
+                ['type' => 'Your_Type', 'isList' => true, 'namespace' => 'xx'],
+            ]),
+            "MyType | list<YourType>",
+        ];
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/MetaTypeEnhancerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/MetaTypeEnhancerTest.php
@@ -87,5 +87,64 @@ class MetaTypeEnhancerTest extends TestCase
             "null | 'a' | 'b'",
             '?string',
         ];
+        yield 'union' => [
+            (new TypeMeta())
+                ->withIsAlias(true)
+                ->withUnions([
+                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
+                    ['type' => 'int', 'isList' => false, 'namespace' => 'xx'],
+                ]),
+            'unionType',
+            "string | int",
+            'mixed',
+        ];
+        yield 'union-with-list' => [
+            (new TypeMeta())
+                ->withIsAlias(true)
+                ->withUnions([
+                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
+                    ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
+                ]),
+            'unionType',
+            "string | list<int>",
+            'mixed',
+        ];
+        yield 'nullable-union-with-list' => [
+            (new TypeMeta())
+                ->withIsAlias(true)
+                ->withIsNullable(true)
+                ->withUnions([
+                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
+                    ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
+                ]),
+            'unionType',
+            "null | string | list<int>",
+            '?mixed',
+        ];
+        yield 'array-of-union-with-list' => [
+            (new TypeMeta())
+                ->withIsList(true)
+                ->withIsAlias(true)
+                ->withUnions([
+                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
+                    ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
+                ]),
+            'unionType',
+            "array<int<min,max>, string | list<int>>",
+            'array',
+        ];
+        yield 'nullable-array-of-union-with-list' => [
+            (new TypeMeta())
+                ->withIsList(true)
+                ->withIsAlias(true)
+                ->withIsNullable(true)
+                ->withUnions([
+                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
+                    ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
+                ]),
+            'unionType',
+            "null | array<int<min,max>, string | list<int>>",
+            '?array',
+        ];
     }
 }


### PR DESCRIPTION
This PR adds support for XSD union "alias" types.

Examples:

```xml
<simpleType name="testType">
    <list>
        <simpleType>
            <restriction base="int"/>
        </simpleType>
    </list>
</simpleType>

<simpleType name="testType">
    <union memberTypes="string int float"/>
</simpleType>


<simpleType name="testType">
    <union>
        <simpleType>
            <restriction base="float"/>
        </simpleType>
        <simpleType>
            <list itemType="int"/>
        </simpleType>
    </union>
</simpleType>
```

It supports following cases:

```php
        yield 'union' => [
            (new TypeMeta())
                ->withIsAlias(true)
                ->withUnions([
                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
                    ['type' => 'int', 'isList' => false, 'namespace' => 'xx'],
                ]),
            'unionType',
            "string | int",
            'mixed',
        ];
        yield 'union-with-list' => [
            (new TypeMeta())
                ->withIsAlias(true)
                ->withUnions([
                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
                    ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
                ]),
            'unionType',
            "string | list<int>",
            'mixed',
        ];
        yield 'nullable-union-with-list' => [
            (new TypeMeta())
                ->withIsAlias(true)
                ->withIsNullable(true)
                ->withUnions([
                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
                    ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
                ]),
            'unionType',
            "null | string | list<int>",
            '?mixed',
        ];
        yield 'array-of-union-with-list' => [
            (new TypeMeta())
                ->withIsList(true)
                ->withIsAlias(true)
                ->withUnions([
                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
                    ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
                ]),
            'unionType',
            "array<int<min,max>, string | list<int>>",
            'array',
        ];
        yield 'nullable-array-of-union-with-list' => [
            (new TypeMeta())
                ->withIsList(true)
                ->withIsAlias(true)
                ->withIsNullable(true)
                ->withUnions([
                    ['type' => 'string', 'isList' => false, 'namespace' => 'xx'],
                    ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
                ]),
            'unionType',
            "null | array<int<min,max>, string | list<int>>",
            '?array',
        ];
```