### PR TITLE
feat: add common naming convention option for getter assmebler

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Util/NormalizerSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Util/NormalizerSpec.php
@@ -72,6 +72,17 @@ class NormalizerSpec extends ObjectBehavior
         $this->normalizeProperty('My-./final*prop_123')->shouldReturn('MyFinalProp_123');
     }
 
+    function it_noramizes_properties_for_common_naming_convention()
+    {
+        $this->normalizePropertyForCommonNamingConvention('prop1')->shouldReturn('prop1');
+        $this->normalizePropertyForCommonNamingConvention('final')->shouldReturn('final');
+        $this->normalizePropertyForCommonNamingConvention('Final')->shouldReturn('Final');
+        $this->normalizePropertyForCommonNamingConvention('UpperCased')->shouldReturn('UpperCased');
+        $this->normalizePropertyForCommonNamingConvention('my-./*prop_123')->shouldReturn('myProp123');
+        $this->normalizePropertyForCommonNamingConvention('My-./*prop_123')->shouldReturn('MyProp123');
+        $this->normalizePropertyForCommonNamingConvention('My-./final*prop_123')->shouldReturn('MyFinalProp123');
+    }
+
     function it_normalizes_datatypes()
     {
         $this->normalizeDataType('string')->shouldReturn('string');
@@ -101,6 +112,19 @@ class NormalizerSpec extends ObjectBehavior
         $this->generatePropertyMethod('get', 'My-./final*prop_123')->shouldReturn('getMyFinalProp_123');
         $this->generatePropertyMethod('get', 'final')->shouldReturn('getFinal');
         $this->generatePropertyMethod('set', 'Final')->shouldReturn('setFinal');
+    }
+
+    function it_generates_common_naming_convention_property_methods()
+    {
+        $this->generateCommonNamingConventionPropertyMethod('get', 'prop1')->shouldReturn('getProp1');
+        $this->generateCommonNamingConventionPropertyMethod('set', 'prop1')->shouldReturn('setProp1');
+        $this->generateCommonNamingConventionPropertyMethod('get', 'prop1_test*./')->shouldReturn('getProp1Test');
+        $this->generateCommonNamingConventionPropertyMethod('get', 'UpperCased')->shouldReturn('getUpperCased');
+        $this->generateCommonNamingConventionPropertyMethod('get', 'my-./*prop_123')->shouldReturn('getMyProp123');
+        $this->generateCommonNamingConventionPropertyMethod('get', 'My-./*prop_123')->shouldReturn('getMyProp123');
+        $this->generateCommonNamingConventionPropertyMethod('get', 'My-./final*prop_123')->shouldReturn('getMyFinalProp123');
+        $this->generateCommonNamingConventionPropertyMethod('get', 'final')->shouldReturn('getFinal');
+        $this->generateCommonNamingConventionPropertyMethod('set', 'Final')->shouldReturn('setFinal');
     }
 
     function it_gets_classname_from_fqn()

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
@@ -51,7 +51,11 @@ class GetterAssembler implements AssemblerInterface
         $property = $context->getProperty();
         try {
             $prefix = $this->getPrefix($property);
-            $methodName = Normalizer::generatePropertyMethod($prefix, $property->getName());
+            if ($this->options->useCommonNamingConvention()) {
+                $methodName = Normalizer::generateCommonNamingConventionPropertyMethod($prefix, $property->getName());
+            } else {
+                $methodName = Normalizer::generatePropertyMethod($prefix, $property->getName());
+            }
             $class->removeMethod($methodName);
 
             $methodGenerator = new MethodGenerator($methodName);

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssemblerOptions.php
@@ -27,6 +27,11 @@ class GetterAssemblerOptions
     private $docBlocks = true;
 
     /**
+     * @var bool
+     */
+    private $commonNamingConvention = false;
+
+    /**
      * @return GetterAssemblerOptions
      */
     public static function create(): GetterAssemblerOptions
@@ -95,5 +100,26 @@ class GetterAssemblerOptions
     public function useDocBlocks(): bool
     {
         return $this->docBlocks;
+    }
+
+    /**
+     * @param bool $withCommonNamingConvention
+     *
+     * @return GetterAssemblerOptions
+     */
+    public function withCommonNamingConvention(bool $withCommonNamingConvention = true): GetterAssemblerOptions
+    {
+        $new = clone $this;
+        $new->commonNamingConvention = $withCommonNamingConvention;
+
+        return $new;
+    }
+
+    /**
+     * @return bool
+     */
+    public function useCommonNamingConvention(): bool
+    {
+        return $this->commonNamingConvention;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -224,6 +224,16 @@ class Normalizer
     }
 
     /**
+     * @param non-empty-string $property
+     *
+     * @return non-empty-string
+     */
+    public static function normalizePropertyForCommonNamingConvention(string $property): string
+    {
+        return self::camelCase($property, '{[^a-z0-9]+}i');
+    }
+
+    /**
      * @param non-empty-string $type
      *
      * @return non-empty-string
@@ -249,6 +259,17 @@ class Normalizer
     public static function generatePropertyMethod(string $prefix, string $property): string
     {
         return strtolower($prefix).ucfirst(self::normalizeProperty($property));
+    }
+
+    /**
+     * @param non-empty-string $prefix
+     * @param non-empty-string $property
+     *
+     * @return non-empty-string
+     */
+    public static function generateCommonNamingConventionPropertyMethod(string $prefix, string $property): string
+    {
+        return strtolower($prefix).ucfirst(self::normalizePropertyForCommonNamingConvention($property));
     }
 
     /**

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -219,6 +219,37 @@ CODE;
     }
 
     /**
+     * @test
+     */
+    function it_assembles_a_property_with_common_naming_convention()
+    {
+        $options = (new GetterAssemblerOptions())->withCommonNamingConvention();
+        $assembler = new GetterAssembler($options);
+        $context = $this->createContext('prop5');
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+    /**
+     * @return string
+     */
+    public function getProp5()
+    {
+        return \$this->prop_5;
+    }
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+
+    /**
      * @param string $propertyName
      * @return PropertyContext
      */
@@ -229,6 +260,7 @@ CODE;
             'prop2' => new Property('prop2', 'int', 'ns1'),
             'prop3' => new Property('prop3', 'boolean', 'ns1'),
             'prop4' => new Property('prop4', 'My_Response', 'ns1'),
+            'prop5' => new Property('prop_5', 'string', 'ns1'),
         ];
 
         $class = new ClassGenerator('MyType', 'MyNamespace');


### PR DESCRIPTION
This PR propose to add an option in GetterAssemblerOptions (`commonNamingConvention`) in order to have getters that the popular `symfony/property-access` component could use.

If property name contains an underscore (i.e. `my_prop`), the getter generated without this option is `getMy_prop`. Whereas `symfony/property-access` waits for `getMyProp`. (https://symfony.com/doc/current/components/property_access.html#using-getters)

This options allows to use Symfony Serializer and Symfony tools like `dd`.