### PR TITLE
Allow properties and getters to be marked as nullable from codegenertion

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
@@ -9,6 +9,7 @@ use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
+use Soap\Engine\Metadata\Model\TypeMeta;
 
 /**
  * Class GetterAssembler
@@ -49,6 +50,12 @@ class GetterAssembler implements AssemblerInterface
     {
         $class = $context->getClass();
         $property = $context->getProperty();
+
+        // Property might be forced to be nullable by the code generator.
+        if ($this->options->useOptionalValue()) {
+            $property = $property->withMeta(fn(TypeMeta $meta): TypeMeta => $meta->withIsNullable(true));
+        }
+
         try {
             $prefix = $this->getPrefix($property);
             $methodName = Normalizer::generatePropertyMethod($prefix, $property->getName());

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssemblerOptions.php
@@ -25,6 +25,7 @@ class GetterAssemblerOptions
      * @var bool
      */
     private $docBlocks = true;
+    private bool $optionalValue = false;
 
     /**
      * @return GetterAssemblerOptions
@@ -95,5 +96,18 @@ class GetterAssemblerOptions
     public function useDocBlocks(): bool
     {
         return $this->docBlocks;
+    }
+
+    public function withOptionalValue(bool $withOptionalValue = true): self
+    {
+        $new = clone $this;
+        $new->optionalValue = $withOptionalValue;
+
+        return $new;
+    }
+
+    public function useOptionalValue(): bool
+    {
+        return $this->optionalValue;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/PropertyAssemblerOptions.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/PropertyAssemblerOptions.php
@@ -14,6 +14,7 @@ class PropertyAssemblerOptions
     private bool $typeHints = true;
     private bool $docBlocks = true;
     private string $visibility = PropertyGenerator::VISIBILITY_PRIVATE;
+    private bool $optionalValue = false;
 
     public static function create(): PropertyAssemblerOptions
     {
@@ -63,5 +64,18 @@ class PropertyAssemblerOptions
     public function useDocBlocks(): bool
     {
         return $this->docBlocks;
+    }
+
+    public function withOptionalValue(bool $withOptionalValue = true): self
+    {
+        $new = clone $this;
+        $new->optionalValue = $withOptionalValue;
+
+        return $new;
+    }
+
+    public function useOptionalValue(): bool
+    {
+        return $this->optionalValue;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -5,6 +5,7 @@ namespace Phpro\SoapClient\CodeGenerator\Model;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\MetaTypeEnhancer;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\TypeEnhancer;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Soap\Engine\Metadata\Metadata;
 use Soap\Engine\Metadata\Model\Property as MetadataProperty;
 use Soap\Engine\Metadata\Model\TypeMeta;
 use function Psl\Type\non_empty_string;
@@ -127,5 +128,19 @@ class Property
     public function getMeta(): TypeMeta
     {
         return $this->meta;
+    }
+
+    /**
+     * @param callable(TypeMeta): TypeMeta $metaProvider
+     */
+    public function withMeta(callable $metaProvider): self
+    {
+        $meta = $metaProvider($this->meta);
+
+        $new = clone $this;
+        $new->meta = $meta;
+        $new->typeEnhancer = new MetaTypeEnhancer($meta);
+
+        return $new;
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -72,6 +72,35 @@ CODE;
     /**
      * @test
      */
+    function it_assembles_an_optional_value()
+    {
+        $assembler = new GetterAssembler(GetterAssemblerOptions::create()->withOptionalValue());
+        $context = $this->createContext();
+        $assembler->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+    /**
+     * @return null | string
+     */
+    public function getProp1() : ?string
+    {
+        return \$this->prop1;
+    }
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @test
+     */
     public function it_assembles_without_return_type()
     {
         $options = (new GetterAssemblerOptions())

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
@@ -61,6 +61,36 @@ CODE;
     /**
      * @test
      */
+    function it_assembles_property_with_default_value()
+    {
+        $assembler = new PropertyAssembler(
+            PropertyAssemblerOptions::create()->withOptionalValue()
+        );
+        $context = $this->createContext();
+        $assembler->assemble($context);
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+    /**
+     * Type specific docs
+     *
+     * @var null | string
+     */
+    private ?string \$prop1 = null;
+}
+
+CODE;
+
+        $this->assertEquals($expected, $code);
+    }
+
+
+    /**
+     * @test
+     */
     function it_assembles_with_visibility_without_default_value()
     {
         $assembler = new PropertyAssembler(
@@ -199,6 +229,39 @@ class MyType
 
 CODE;
 
+        $this->assertEquals($expected, $code);
+    }
+
+    /**
+     * @test
+     */
+    function it_overwrite_props_during_assembling()
+    {
+        $context = $this->createContext();
+
+        $assembler1 = new PropertyAssembler();
+        $assembler1->assemble($context);
+
+        $assembler2 = new PropertyAssembler(
+            PropertyAssemblerOptions::create()->withVisibility(PropertyGenerator::VISIBILITY_PUBLIC)
+        );
+        $assembler2->assemble($context);
+
+        $code = $context->getClass()->generate();
+        $expected = <<<CODE
+namespace MyNamespace;
+
+class MyType
+{
+    /**
+     * Type specific docs
+     *
+     * @var string
+     */
+    public string \$prop1;
+}
+
+CODE;
         $this->assertEquals($expected, $code);
     }
 


### PR DESCRIPTION
When your class is built-around immutable `with`-ers, it might make sense to force all properties or getters to be optional. This will solve PHP issues when using your generated class when property values are not assigned yet:

```php
new PropertyAssembler(
    PropertyAssemblerOptions::create()->withOptionalValue()
);
```

```php
namespace MyNamespace;

class MyType
{
    /**
     * Type specific docs
     *
     * @var null | string
     */
    private ?string \$prop1 = null;
}

```