### PR TITLE
Normalize unsignedint

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -30,7 +30,7 @@ class Normalizer
         'iterable' => 'iterable',
         'array' => 'array',
         'void' => 'void',
-        'unsignedInt' => 'int',
+        'unsignedInt' => 'float',
     ];
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -30,6 +30,7 @@ class Normalizer
         'iterable' => 'iterable',
         'array' => 'array',
         'void' => 'void',
+        'unsignedInt' => 'int',
     ];
 
     /**


### PR DESCRIPTION
UnsignedInt type is generated as custom type and later it fails when trying assign integer value to object. The unsignedInt is native soap type which means there is not type definition in WSDL.

For now the best solution is map this value to float.

If you have a better idea, feel free to suggest it, I'll try my best to implement it.