### PR TITLE
Fix invalid array bounds during static analysis

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/MetaTypeEnhancer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/MetaTypeEnhancer.php
@@ -30,7 +30,10 @@ final class MetaTypeEnhancer implements TypeEnhancer
 
         $isArray = $this->meta->isList()->unwrapOr(false);
         if ($isArray) {
-            $type = 'array<'.(new ArrayBoundsCalculator())($this->meta).', '.$type.'>';
+            $nonEmpty = $this->meta->minOccurs()->unwrapOr(0) > 0;
+            $arrayType = $nonEmpty ? 'non-empty-array' : 'array';
+
+            $type = $arrayType.'<'.(new ArrayBoundsCalculator())($this->meta).', '.$type.'>';
         }
 
         $isNullable = (new IsConsideredNullableType())($this->meta);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
@@ -174,7 +174,7 @@ class MyType
     /**
      * Constructor
      *
-     * @param array<int<min,max>, string> \$prop1
+     * @param array<int<0,max>, string> \$prop1
      */
     public function __construct(array \$prop1)
     {

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -218,7 +218,7 @@ namespace MyNamespace;
 class MyType
 {
     /**
-     * @param array<int<min,max>, string> \$prop1
+     * @param array<int<0,max>, string> \$prop1
      * @return \$this
      */
     public function setProp1(array \$prop1) : static

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -276,7 +276,7 @@ namespace MyNamespace;
 class MyType
 {
     /**
-     * @return array<int<min,max>, string>
+     * @return array<int<0,max>, string>
      */
     public function getProp1() : array
     {

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
@@ -265,7 +265,7 @@ namespace MyNamespace;
 class MyType
 {
     /**
-     * @param array<int<min,max>, string> \$prop1
+     * @param array<int<0,max>, string> \$prop1
      * @return static
      */
     public function withProp1(array \$prop1) : static

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
@@ -57,15 +57,15 @@ namespace MyNamespace;
 use IteratorAggregate;
 
 /**
- * @phpstan-implements \IteratorAggregate<int<1,2>, string>
- * @psalm-implements \IteratorAggregate<int<1,2>, string>
+ * @phpstan-implements \IteratorAggregate<int<0,1>, string>
+ * @psalm-implements \IteratorAggregate<int<0,1>, string>
  */
 class MyType implements IteratorAggregate
 {
     /**
      * @return \ArrayIterator|string[]
-     * @phpstan-return \ArrayIterator<int<1,2>, string>
-     * @psalm-return \ArrayIterator<int<1,2>, string>
+     * @phpstan-return \ArrayIterator<int<0,1>, string>
+     * @psalm-return \ArrayIterator<int<0,1>, string>
      */
     public function getIterator() : \ArrayIterator
     {
@@ -98,15 +98,15 @@ namespace MyNamespace;
 use IteratorAggregate;
 
 /**
- * @phpstan-implements \IteratorAggregate<int<min,max>, string>
- * @psalm-implements \IteratorAggregate<int<min,max>, string>
+ * @phpstan-implements \IteratorAggregate<int<0,max>, string>
+ * @psalm-implements \IteratorAggregate<int<0,max>, string>
  */
 class MyType implements IteratorAggregate
 {
     /**
      * @return \ArrayIterator|string[]
-     * @phpstan-return \ArrayIterator<int<min,max>, string>
-     * @psalm-return \ArrayIterator<int<min,max>, string>
+     * @phpstan-return \ArrayIterator<int<0,max>, string>
+     * @psalm-return \ArrayIterator<int<0,max>, string>
      */
     public function getIterator() : \ArrayIterator
     {

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
@@ -222,7 +222,7 @@ namespace MyNamespace;
 class MyType
 {
     /**
-     * @var array<int<min,max>, string>
+     * @var array<int<0,max>, string>
      */
     private array \$prop1;
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
@@ -181,7 +181,7 @@ namespace MyNamespace;
 class MyType
 {
     /**
-     * @param array<int<min,max>, string> \$prop1
+     * @param array<int<0,max>, string> \$prop1
      */
     public function setProp1(array \$prop1) : void
     {

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/ArrayBoundsCalculatorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/ArrayBoundsCalculatorTest.php
@@ -27,23 +27,31 @@ class ArrayBoundsCalculatorTest extends TestCase
     {
         yield 'simpleType' => [
             new TypeMeta(),
-            'int<min,max>',
+            'int<0,max>',
         ];
         yield 'array' => [
             (new TypeMeta())->withIsList(true),
-            'int<min,max>',
+            'int<0,max>',
         ];
         yield 'min' => [
             (new TypeMeta())->withIsList(true)->withMinOccurs(1),
-            'int<1,max>',
+            'int<0,max>',
         ];
         yield 'max' => [
             (new TypeMeta())->withIsList(true)->withMaxOccurs(3),
-            'int<min,3>',
+            'int<0,2>',
         ];
         yield 'min-max' => [
             (new TypeMeta())->withIsList(true)->withMinOccurs(1)->withMaxOccurs(3),
-            'int<1,3>',
+            'int<0,2>',
+        ];
+        yield 'max-1' => [
+            (new TypeMeta())->withIsList(true)->withMaxOccurs(1),
+            'int<0,0>',
+        ];
+        yield 'max-0' => [
+            (new TypeMeta())->withIsList(true)->withMaxOccurs(0),
+            'never',
         ];
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/MetaTypeEnhancerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/MetaTypeEnhancerTest.php
@@ -36,19 +36,19 @@ class MetaTypeEnhancerTest extends TestCase
         yield 'array' => [
             (new TypeMeta())->withIsList(true),
             'simple',
-            'array<int<min,max>, simple>',
+            'array<int<0,max>, simple>',
             'array',
         ];
         yield 'min' => [
             (new TypeMeta())->withIsList(true)->withMinOccurs(1),
             'simple',
-            'array<int<1,max>, simple>',
+            'non-empty-array<int<0,max>, simple>',
             'array',
         ];
         yield 'max' => [
             (new TypeMeta())->withIsList(true)->withMaxOccurs(3),
             'simple',
-            'array<int<min,3>, simple>',
+            'array<int<0,2>, simple>',
             'array',
         ];
         yield 'nullable' => [
@@ -60,7 +60,7 @@ class MetaTypeEnhancerTest extends TestCase
         yield 'nullable-array' => [
             (new TypeMeta())->withIsList(true)->withIsNullable(true),
             'simple',
-            'null | array<int<min,max>, simple>',
+            'null | array<int<0,max>, simple>',
             '?array',
         ];
         yield 'enum' => [
@@ -72,13 +72,13 @@ class MetaTypeEnhancerTest extends TestCase
         yield 'enum-list' => [
             (new TypeMeta())->withEnums(['a', 'b'])->withIsList(true),
             'string',
-            "array<int<min,max>, 'a' | 'b'>",
+            "array<int<0,max>, 'a' | 'b'>",
             'array',
         ];
         yield 'nullable-enum-list' => [
             (new TypeMeta())->withEnums(['a', 'b'])->withIsList(true)->withIsNullable(true),
             'string',
-            "null | array<int<min,max>, 'a' | 'b'>",
+            "null | array<int<0,max>, 'a' | 'b'>",
             '?array',
         ];
         yield 'nullable-enum' => [
@@ -130,7 +130,7 @@ class MetaTypeEnhancerTest extends TestCase
                     ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
                 ]),
             'unionType',
-            "array<int<min,max>, string | list<int>>",
+            "array<int<0,max>, string | list<int>>",
             'array',
         ];
         yield 'nullable-array-of-union-with-list' => [
@@ -143,7 +143,7 @@ class MetaTypeEnhancerTest extends TestCase
                     ['type' => 'int', 'isList' => true, 'namespace' => 'xx'],
                 ]),
             'unionType',
-            "null | array<int<min,max>, string | list<int>>",
+            "null | array<int<0,max>, string | list<int>>",
             '?array',
         ];
     }


### PR DESCRIPTION
Fixes https://github.com/php-soap/wsdl-reader/issues/26

@lstrojny : I decided to go this way since it is the easiest way to go forward.

The array-bounds will always be calculated based on int<0, maxOccurs - 1>:
When minOccurs > 0, the array will become a non-empty-array.

Examples:

```php
// minOccurs=0, maxOccurs=-1
array<int<0, max>, Tv>

// minOccurs=1, maxOccurs=-1
non-empty-array<int<0, max>, Tv>

// minOccurs=0, maxOccurs=0
array<never, Tv>

// minOccurs=0, maxOccurs=1
array<int<0,0>, Tv>

// minOccurs=0, maxOccurs=2
array<int<0,1>, Tv>

// minOccurs=1, maxOccurs=2
non-empty-array<int<0,1>, Tv>
```

This should solve your issue.


If someone cares enough to improve this, I'm always open into considering something like:

```php
array{0: string, 1 ?: string, ...string}
```

(limited to x amount of items to avoid too large shapes being generated)

Yet I think this should be sufficient for now.

