### PR TITLE
Fall back to complexType name when the element is a link to a complexType

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ReturnTypeSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ReturnTypeSpec.php
@@ -35,4 +35,18 @@ class ReturnTypeSpec extends ObjectBehavior
     {
         $this->getMeta()->shouldBeLike(new TypeMeta());
     }
+
+    public function it_falls_back_to_complex_type_if_its_an_element_referencing_this_type(): void
+    {
+        $this->beConstructedThrough(
+            'fromMetaData',
+            [
+                'My\Namespace',
+                XsdType::create('ElementType')
+                    ->withXmlTypeName('ComplexType')
+            ]
+        );
+
+        $this->getType()->shouldReturn('\\My\\Namespace\\ComplexType');
+    }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClassMapAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClassMapAssembler.php
@@ -80,7 +80,7 @@ class ClassMapAssembler implements AssemblerInterface
                 '%snew ClassMap(\'%s\', \'%s\', %s::class),',
                 $indentation,
                 $type->getXsdType()->getXmlNamespace(),
-                $type->getXsdType()->getXmlTypeName(),
+                $type->getXsdType()->getName(),
                 'Type\\'.$type->getName()
             );
         }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
@@ -45,6 +45,9 @@ final class ReturnType
      */
     public static function fromMetaData(string $namespace, XsdType $returnType): self
     {
+        // Element types that are referencing complex types, should result in the complexType according to ext-soap:
+        $returnType = $returnType->copy($returnType->getXmlTypeName() ?: $returnType->getName());
+
         $typeName = (new TypeNameCalculator())($returnType);
 
         return new self(

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
@@ -92,7 +92,6 @@ CODE;
                 ],
                 (new XsdType('MyType'))
                     ->withXmlNamespace('http://my-namespace.com')
-                    ->withXmlTypeName('MyType'),
             ),
         ]);
 


### PR DESCRIPTION
Given following types:

```xml
<xs:complexType name="versionResponse">
    <xs:sequence>
        <xs:element minOccurs="0" name="version" type="xs:string" />
    </xs:sequence>
</xs:complexType>
<xs:element name="esfVersionResponse" nillable="true" type="tns:versionResponse"/>
```

And following operation:

```xml
<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
    <wsdl:portType name="VersionService">
        <wsdl:operation name="getEsfVersion">
            <soap:operation soapAction="" style="document"/>
            <wsdl:input name="getEsfVersion"><soap:body use="literal"/></wsdl:input>
            <wsdl:output name="getEsfVersionResponse"><soap:body use="literal"/></wsdl:output>
        </wsdl:operation>
    </wsdl:portType>
    
    <!-- snap -->
    
    <wsdl:message name="getEsfVersion">
        <wsdl:part element="tns:esfVersionRequest" name="esfVersionRequest">
        </wsdl:part>
    </wsdl:message>
    <wsdl:message name="getEsfVersionResponse">
        <wsdl:part element="tns:esfVersionResponse" name="esfVersionResponse">
        </wsdl:part>
    </wsdl:message>
</wsdl:definitions>
```

A request to `getEsfVersion` will result into the complexType `VersonResponse`.


```php
    /**
     * @param RequestInterface & Type\EsfVersionRequest $esfVersionRequest
     * @return ResultInterface & Type\VersionResponse
     * @throws SoapException
     */
    public function getEsfVersion(\App\Type\EsfVersionRequest $esfVersionRequest) : \App\Type\VersionResponse
    {
        $response = ($this->caller)('getEsfVersion', $esfVersionRequest);

        \Psl\Type\instance_of(\App\Type\VersionResponse::class)->assert($response);
        \Psl\Type\instance_of(\Phpro\SoapClient\Type\ResultInterface::class)->assert($response);

        return $response;
    }
```

Resulting in:

```php
dump($client->getEsfVersion(
    new \App\Type\EsfVersionRequest()
));
```

```
> ^ App\Type\VersionResponse^ {#191
    -version: "InvoiceV2"
}
```

This is how ext-soap works internally as well, making the generated code compatible with both the vanilla encoder package and ext-soap.

/cc @rauanmayemir This should solve the issue you have with the VersionService.