### PR TITLE
Use external classes as property types.

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Util/NormalizerSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Util/NormalizerSpec.php
@@ -4,6 +4,7 @@ namespace spec\Phpro\SoapClient\CodeGenerator\Util;
 
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use PhpSpec\ObjectBehavior;
+use Psl\Option\Option;
 
 /**
  * Class NormalizerSpec
@@ -98,11 +99,27 @@ class NormalizerSpec extends ObjectBehavior
         $this->getClassNameFromFQN('Vendor\Namespace\MyClass')->shouldReturn('MyClass');
     }
 
+    function it_gets_namespace_from_fqn()
+    {
+        $this->getNamespaceFromFQN('\Namespace\MyClass')->shouldReturn('Namespace');
+        $this->getNamespaceFromFQN('Vendor\Namespace\MyClass')->shouldReturn('Vendor\Namespace');
+        $this->getNamespaceFromFQN('ExistingPHPClass')->shouldReturn('');
+    }
+
     function it_gets_complete_use_statement()
     {
         $this->getCompleteUseStatement('Namespace\MyClass',
             'ClassAlias')->shouldReturn('Namespace\MyClass as ClassAlias');
         $this->getCompleteUseStatement('Namespace\MyClass', null)->shouldReturn('Namespace\MyClass');
         $this->getCompleteUseStatement('MyClass', '')->shouldReturn('MyClass');
+    }
+
+    /** @test */
+    public function it_knows_about_third_party_classes(): void
+    {
+        $this->isConsideredExistingThirdPartyClass('DateTime')->shouldReturn(false);
+        $this->isConsideredExistingThirdPartyClass('\DateTime')->shouldReturn(true);
+        $this->isConsideredExistingThirdPartyClass(Option::class)->shouldReturn(true);
+        $this->isConsideredExistingThirdPartyClass('Unkown\Class')->shouldReturn(false);
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -252,6 +252,17 @@ class Normalizer
     }
 
     /**
+     * @param non-empty-string $name
+     */
+    public static function getNamespaceFromFQN($name): string
+    {
+        $arr = explode('\\', ltrim($name, '\\'));
+        array_pop($arr);
+
+        return implode('\\', $arr);
+    }
+
+    /**
      * @param non-empty-string      $useName
      * @param non-empty-string|null $useAlias
      *
@@ -265,5 +276,10 @@ class Normalizer
         }
 
         return $use;
+    }
+
+    public static function isConsideredExistingThirdPartyClass(string $class)
+    {
+        return str_contains($class, '\\') && class_exists($class);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
@@ -4,7 +4,8 @@ namespace PhproTest\SoapClient\Unit\CodeGenerator\Model;
 
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use PHPUnit\Framework\TestCase;
-use Soap\Engine\Metadata\Model\TypeMeta;
+use Psl\Option\Option;
+use Soap\Engine\Metadata\Model\Property as EngineProperty;
 use Soap\Engine\Metadata\Model\XsdType;
 
 /**
@@ -22,5 +23,39 @@ class PropertyTest extends TestCase
         $property = new Property('test', 'mixed', 'App', XsdType::create('mixed'));
         self::assertEquals('mixed', $property->getPhpType());
         self::assertEquals('mixed', $property->getType());
+    }
+
+    /** @test */
+    public function it_can_use_fqcn_to_3rd_party_classes_as_type_name(): void
+    {
+        $property = Property::fromMetaData(
+            'MyApp',
+            new EngineProperty(
+                'property',
+                $xsdType = XsdType::create(Option::class)
+            )
+        );
+
+        self::assertEquals('\\' . Option::class, $property->getType());
+        self::assertNotSame($xsdType, $property->getXsdType());
+        self::assertSame('Option', $property->getXsdType()->getName());
+        self::assertSame('Option', $property->getXsdType()->getBaseType());
+    }
+
+    /** @test */
+    public function it_can_use_a_php_built_in_class_as_type_name(): void
+    {
+        $property = Property::fromMetaData(
+            'MyApp',
+            new EngineProperty(
+                'property',
+                $xsdType = XsdType::create('\\'. \DateInterval::class)
+            )
+        );
+
+        self::assertEquals('\\' . \DateInterval::class, $property->getType());
+        self::assertNotSame($xsdType, $property->getXsdType());
+        self::assertSame('DateInterval', $property->getXsdType()->getName());
+        self::assertSame('DateInterval', $property->getXsdType()->getBaseType());
     }
 }


### PR DESCRIPTION
Fixes #543, #531

Allows to specify a PHP class as property type:

```php
use Phpro\SoapClient\Soap\Metadata\Manipulators\TypeReplacer\TypeReplacer;
use Soap\Engine\Metadata\Model\XsdType;
use Soap\WsdlReader\Metadata\Predicate\IsOfType;

class GuidTypeReplacer implements TypeReplacer
{
    public function __invoke(XsdType $xsdType): XsdType
    {
        $check = new IsOfType('http://microsoft.com/wsdl/types/', 'guid');
        if (!$check($xsdType)) {
            return $xsdType;
        }

        return $xsdType->copy(\Ramsey\Uuid\UuidInterface::class);
    }
}
```

This will result in:

```php

namespace MyNamespace;

class MyType
{
    /**
     * Type specific docs
     *
     * @var \Ramsey\Uuid\UuidInterface
     */
    private \Ramsey\Uuid\UuidInterface $prop1;
}
```

(it will also be known this way in the other assemblers like Getters, Setters, ...)


/cc @rauanmayemir: The implementation is a bit tricky, but it does the job. Feel free to play around with it.