### PR TITLE
Detect linked complexTypes as ResultInterface as well

### DIFF
--- a/src/Phpro/SoapClient/Soap/Metadata/Detector/ResponseTypesDetector.php
+++ b/src/Phpro/SoapClient/Soap/Metadata/Detector/ResponseTypesDetector.php
@@ -6,16 +6,27 @@ namespace Phpro\SoapClient\Soap\Metadata\Detector;
 
 use Soap\Engine\Metadata\Collection\MethodCollection;
 use Soap\Engine\Metadata\Model\Method;
+use function Psl\Dict\unique;
+use function Psl\Vec\filter;
+use function Psl\Vec\flat_map;
+use function Psl\Vec\values;
 
 final class ResponseTypesDetector
 {
     public function __invoke(MethodCollection $methods): array
     {
-        return array_unique(array_map(
-            static function (Method $method): string {
-                return $method->getReturnType()->getName();
-            },
-            iterator_to_array($methods)
-        ));
+        return values(
+            unique(
+                filter(
+                    flat_map(
+                        $methods,
+                        static fn (Method $method): array => [
+                            $method->getReturnType()->getName(),
+                            $method->getReturnType()->getXmlTypeName()
+                        ]
+                    )
+                )
+            )
+        );
     }
 }

--- a/test/PhproTest/SoapClient/Unit/Soap/Metadata/Detector/ResponseTypesDetectorTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Metadata/Detector/ResponseTypesDetectorTest.php
@@ -18,17 +18,17 @@ class ResponseTypesDetectorTest extends TestCase
     public function it_can_detect_request_types(): void
     {
         $methods = new MethodCollection(
-            new Method('method1', new ParameterCollection(), XsdType::create('Response1')),
+            new Method('method1', new ParameterCollection(), XsdType::create('Response1')->withXmlTypeName('Response1')),
             new Method('method3', new ParameterCollection(
                 new Parameter('param1', XsdType::create('RequestType2')),
                 new Parameter('param2', XsdType::create('RequestType3'))
-            ), XsdType::create('Response2')),
+            ), XsdType::create('Response2')->withXmlTypeName('LinkedResponse2ComplexType')),
             new Method('method1', new ParameterCollection(), XsdType::create('string'))
         );
 
         $detected = (new ResponseTypesDetector())($methods);
         self::assertSame(
-            ['Response1', 'Response2', 'string'],
+            ['Response1', 'Response2', 'LinkedResponse2ComplexType', 'string'],
             $detected
         );
     }


### PR DESCRIPTION
Fixes https://github.com/phpro/soap-client/pull/546#issuecomment-2379079650, #550

The ResultAssembler is not able to detect wether an element with linked complexType is being used as the result.
More info: https://github.com/phpro/soap-client/pull/546

```php
    ->addRule(
        new Rules\IsResultRule(
            $engine->getMetadata(),
            new Rules\MultiRule([
                new Rules\AssembleRule(new Assembler\ResultAssembler()),
            ])
        )
    )
```

Given

```xml
<xs:complexType name="versionResponse">
    <xs:sequence>
        <xs:element minOccurs="0" name="version" type="xs:string" />
    </xs:sequence>
</xs:complexType>
<xs:element name="esfVersionResponse" nillable="true" type="tns:versionResponse"/>
```

This assembler can now detect that both `esfVersionResponse` and `versionResponse` should be marked as `ResultInterface`.
