### PR TITLE
Rework code generator models for easier 3rd-party class type encoders

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Model/TypeMapSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/TypeMapSpec.php
@@ -21,7 +21,7 @@ class TypeMapSpec extends ObjectBehavior
     function let()
     {
         $this->beConstructedWith($namespace = 'MyNamespace', [
-            new Type($namespace, 'type1', [
+            new Type($namespace, 'type1', 'type1', [
                 new Property('prop1', 'string', $namespace, XsdType::create('string'))
             ], XsdType::create('MyType'))
         ]);

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/TypeSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/TypeSpec.php
@@ -4,6 +4,7 @@ namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Soap\Engine\Metadata\Model\TypeMeta;
@@ -22,6 +23,7 @@ class TypeSpec extends ObjectBehavior
         $this->beConstructedWith(
             $namespace = 'MyNamespace',
             'myType',
+            'MyType',
             [new Property('prop1', 'string', $namespace, XsdType::create('string'))],
             XsdType::create('MyType')
         );
@@ -58,7 +60,7 @@ class TypeSpec extends ObjectBehavior
 
     function it_should_not_replace_underscores_in_paths()
     {
-        $this->beConstructedWith('MyNamespace', 'my_type_3_2', ['prop1' => 'string'], XsdType::create('MyType'));
+        $this->beConstructedWith('MyNamespace', 'my_type_3_2', Normalizer::normalizeClassname('my_type_3_2'), ['prop1' => 'string'], XsdType::create('MyType'));
         $this->getFileInfo('my/some_dir')->getPathname()->shouldReturn('my/some_dir/MyType32.php');
     }
 
@@ -67,6 +69,7 @@ class TypeSpec extends ObjectBehavior
         $this->beConstructedWith(
             $namespace = 'MyNamespace',
             'Final',
+            Normalizer::normalizeClassname('Final'),
             [new Property('xor', 'string', $namespace, XsdType::create('string'))],
             XsdType::create('MyType')
         );

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRuleSpec.php
@@ -58,28 +58,28 @@ class IsAbstractTypeRuleSpec extends ObjectBehavior
 
     function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'NotAbstract', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'NotAbstract', 'NotAbstract', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
     function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRuleSpec.php
@@ -61,28 +61,28 @@ class IsExtendingTypeRuleSpec extends ObjectBehavior
 
     function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', 'MyExtending', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', 'MyExtending', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'NotExtending', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'NotExtending', 'NotExtending', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
     function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', 'MyExtending', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRuleSpec.php
@@ -56,28 +56,28 @@ class IsRequestRuleSpec extends ObjectBehavior
 
     function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', 'RequestType', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', 'RequestType', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
     function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', 'RequestType', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsResultRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsResultRuleSpec.php
@@ -56,28 +56,28 @@ class IsResultRuleSpec extends ObjectBehavior
 
     function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', 'ResultType', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', 'ResultType', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
     function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', 'ResultType', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRuleSpec.php
@@ -48,48 +48,48 @@ class TypeMapRuleSpec extends ObjectBehavior
 
     function it_can_apply_to_type_context(RuleInterface $rule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', 'SomeType', [], XsdType::create('MyType')));
         $rule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_apply_to_property_context(RuleInterface $rule, PropertyContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', 'SomeType', [], XsdType::create('MyType')));
         $rule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_apply_the_default_assembler_to_unknown_types(RuleInterface $defaultRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'UnknownType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'UnknownType', 'UnknownType', [], XsdType::create('MyType')));
         $defaultRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_not_apply_to_knwon_types_with_no_rule(TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'NullType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'NullType', 'NullType', [], XsdType::create('MyType')));
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
     function it_can_not_apply_if_rule_does_not_apply(RuleInterface $rule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', 'SomeType', [], XsdType::create('MyType')));
         $rule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
     function it_applies_a_specified_rule_to_known_types(RuleInterface $rule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', 'SomeType', [], XsdType::create('MyType')));
         $rule->apply($context)->shouldBeCalled();
         $this->apply($context);
     }
 
     function it_applies_the_default_rule_to_unknown_types(RuleInterface $defaultRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'UnknownType', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'UnknownType', 'UnknownType', [], XsdType::create('MyType')));
         $defaultRule->apply($context)->shouldBeCalled();
         $this->apply($context);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/TypenameMatchesRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/TypenameMatchesRuleSpec.php
@@ -44,28 +44,28 @@ class TypenameMatchesRuleSpec extends ObjectBehavior
 
     function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'TypeName', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'TypeName', 'TypeName', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_apply_to_property_context( RuleInterface $subRule, PropertyContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'TypeName', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'TypeName', 'TypeName', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
     function it_can_not_apply_on_invalid_regex(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
     function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'TypeName', [], XsdType::create('MyType')));
+        $context->getType()->willReturn(new Type('MyNamespace', 'TypeName', 'TypeName', [], XsdType::create('MyType')));
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/TypeGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/TypeGeneratorSpec.php
@@ -48,6 +48,7 @@ class TypeGeneratorSpec extends ObjectBehavior
         $type = new Type(
             $namespace = 'MyNamespace',
             'MyType',
+            'MyType',
             [new Property('prop1', 'string', $namespace, XsdType::create('string'))],
             XsdType::create('MyType')
         );
@@ -71,6 +72,7 @@ class TypeGeneratorSpec extends ObjectBehavior
     {
         $type = new Type(
             $namespace = 'MyNamespace',
+            'MyType',
             'MyType',
             [new Property('prop1', 'string', $namespace, XsdType::create('string'))],
             XsdType::create('MyType')

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethod.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethod.php
@@ -2,6 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Soap\Engine\Metadata\Model\Method as MetadataMethod;
 use Soap\Engine\Metadata\Model\MethodMeta;
 use Soap\Engine\Metadata\Model\Parameter as MetadataParameter;
@@ -35,6 +36,8 @@ class ClientMethod
     private MethodMeta $meta;
 
     /**
+     * @internal - Use ClientMethod::fromMetadata instead
+     *
      * TypeModel constructor.
      *
      * @param non-empty-string $name
@@ -71,7 +74,7 @@ class ClientMethod
                 iterator_to_array($method->getParameters())
             ),
             ReturnType::fromMetaData($parameterNamespace, $method->getReturnType()),
-            $parameterNamespace,
+            Normalizer::normalizeNamespace($parameterNamespace),
             $method->getMeta()
         );
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethodMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethodMap.php
@@ -18,6 +18,8 @@ class ClientMethodMap
     private $methods;
 
     /**
+     * @internal - Use ClientMethodMap::fromMetadata instead
+     *
      * ClientMethodMap constructor.
      *
      * @param array|ClientMethod[] $methods

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Parameter.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Parameter.php
@@ -31,6 +31,8 @@ class Parameter
     private TypeMeta $meta;
 
     /**
+     * @internal - Use Parameter::fromMetadata instead
+     *
      * Parameter constructor.
      *
      * @param non-empty-string $name
@@ -39,9 +41,9 @@ class Parameter
      */
     public function __construct(string $name, string $type, string $namespace, XsdType $xsdType)
     {
-        $this->name = Normalizer::normalizeProperty($name);
-        $this->type = Normalizer::normalizeDataType($type);
-        $this->namespace = Normalizer::normalizeNamespace($namespace);
+        $this->name = $name;
+        $this->type = $type;
+        $this->namespace = $namespace;
         $this->xsdType = $xsdType;
         $this->meta = $xsdType->getMeta();
     }
@@ -55,9 +57,9 @@ class Parameter
         $typeName = (new TypeNameCalculator())($type);
 
         return new self(
-            non_empty_string()->assert($parameter->getName()),
-            non_empty_string()->assert($typeName),
-            $parameterNamespace,
+            Normalizer::normalizeProperty(non_empty_string()->assert($parameter->getName())),
+            Normalizer::normalizeDataType(non_empty_string()->assert($typeName)),
+            Normalizer::normalizeNamespace($parameterNamespace),
             $type
         );
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
@@ -27,6 +27,8 @@ final class ReturnType
     private TypeMeta $meta;
 
     /**
+     * @internal - Use ReturnType::fromMetaData instead
+     *
      * Property constructor.
      *
      * @param non-empty-string $type
@@ -34,8 +36,8 @@ final class ReturnType
      */
     public function __construct(string $type, string $namespace, XsdType $xsdType)
     {
-        $this->type = Normalizer::normalizeDataType($type);
-        $this->namespace = Normalizer::normalizeNamespace($namespace);
+        $this->type = $type;
+        $this->namespace = $namespace;
         $this->xsdType = $xsdType;
         $this->meta = $xsdType->getMeta();
     }
@@ -51,8 +53,8 @@ final class ReturnType
         $typeName = (new TypeNameCalculator())($returnType);
 
         return new self(
-            non_empty_string()->assert($typeName),
-            $namespace,
+            Normalizer::normalizeDataType(non_empty_string()->assert($typeName)),
+            Normalizer::normalizeNamespace($namespace),
             $returnType
         );
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
@@ -42,17 +42,20 @@ class Type
     private TypeMeta $meta;
 
     /**
+     * @internal - Use Type::fromMetadata instead
+     *
      * TypeModel constructor.
      *
      * @param non-empty-string     $namespace
      * @param non-empty-string     $xsdName
+     * @param non-empty-string     $name
      * @param Property[] $properties
      */
-    public function __construct(string $namespace, string $xsdName, array $properties, XsdType $xsdType)
+    public function __construct(string $namespace, string $xsdName, string $name, array $properties, XsdType $xsdType)
     {
-        $this->namespace = Normalizer::normalizeNamespace($namespace);
+        $this->namespace = $namespace;
         $this->xsdName = $xsdName;
-        $this->name = Normalizer::normalizeClassname($xsdName);
+        $this->name = $name;
         $this->properties = $properties;
         $this->xsdType = $xsdType;
         $this->meta = $xsdType->getMeta();
@@ -63,9 +66,12 @@ class Type
      */
     public static function fromMetadata(string $namespace, MetadataType $type): self
     {
+        $xsdName = non_empty_string()->assert($type->getName());
+
         return new self(
-            $namespace,
-            non_empty_string()->assert($type->getName()),
+            Normalizer::normalizeNamespace($namespace),
+            $xsdName,
+            Normalizer::normalizeClassname($xsdName),
             array_map(
                 function (MetadataProperty $property) use ($namespace) {
                     return Property::fromMetaData(

--- a/src/Phpro/SoapClient/CodeGenerator/Model/TypeMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/TypeMap.php
@@ -25,6 +25,8 @@ class TypeMap
     private $namespace;
 
     /**
+     * @internal - Use TypeMap::fromMetadata instead
+     *
      * TypeMap constructor.
      *
      * @param non-empty-string $namespace

--- a/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/Calculator/TypeNameCalculator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeEnhancer/Calculator/TypeNameCalculator.php
@@ -28,11 +28,11 @@ final class TypeNameCalculator
         $isList = $meta->isList()->unwrapOr(false);
         if ($isList) {
             $memberType = $type->getMemberTypes()[0] ?? 'mixed';
-            return $isKnownType ? $type->getName() : $memberType;
+            return $isKnownType ? $normalizedTypeName : $memberType;
         }
 
         if ($isKnownType) {
-            return $type->getName();
+            return $normalizedTypeName;
         }
 
         return $type->getBaseTypeOrFallbackToName();

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -278,7 +278,10 @@ class Normalizer
         return $use;
     }
 
-    public static function isConsideredExistingThirdPartyClass(string $class)
+    /**
+     * @phpstan-assert-if-true non-empty-string $class
+     */
+    public static function isConsideredExistingThirdPartyClass(string $class): bool
     {
         return str_contains($class, '\\') && class_exists($class);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/AbstractClassAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/AbstractClassAssemblerTest.php
@@ -67,7 +67,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace ='MyNamespace', 'MyType', [
+        $type = new Type($namespace ='MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
             Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
@@ -84,6 +84,7 @@ CODE;
             new Type(
                 $namespace,
                 'MyType',
+                'MyType',
                 [
                     Property::fromMetaData(
                         $namespace,

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
@@ -80,7 +80,7 @@ CODE;
     {
         $assembler = new ConstructorAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
             Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
             Property::fromMetaData($namespace, new MetaProperty('prop3', XsdType::guess('SomeClass'))),
@@ -153,7 +153,7 @@ CODE;
     {
         $assembler = new ConstructorAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData(
                 $namespace,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
@@ -193,7 +193,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
             Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
@@ -92,7 +92,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
             Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendingTypeAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendingTypeAssemblerTest.php
@@ -91,7 +91,7 @@ CODE;
     {
         $assembler = new ExtendingTypeAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [], XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
 
         $context = new TypeContext($class, $type);
         $assembler->assemble($context);
@@ -116,7 +116,7 @@ CODE;
     {
         $assembler = new ExtendingTypeAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
             'type' => 'string',
             'namespace' => 'xsd',
             'isSimple' => true,
@@ -144,7 +144,7 @@ CODE;
     private function createContext(?string $importedNamespace = null)
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($importedNamespace ?? 'MyNamespace', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
+        $type = new Type($importedNamespace ?? 'MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
             'type' => 'MyBaseType',
             'namespace' => 'xxxx'
         ])));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FinalClassAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FinalClassAssemblerTest.php
@@ -67,7 +67,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace ='MyNamespace', 'MyType', [
+        $type = new Type($namespace ='MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
             Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'), new TypeMeta());

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -199,7 +199,7 @@ CODE;
     {
         $assembler = new FluentSetterAssembler((new FluentSetterAssemblerOptions()));
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData(
                 $namespace,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
@@ -239,7 +239,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData(
                 $namespace,
                 new MetaProperty('prop1', XsdType::guess('string'))
@@ -255,7 +255,7 @@ CODE;
     private function createContextWithAnUnknownType()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('foobar'))),
         ], XsdType::create('MyType'));
 
@@ -274,7 +274,7 @@ CODE;
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -257,7 +257,7 @@ CODE;
     {
         $assembler = new GetterAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData(
                 $namespace,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
@@ -298,12 +298,12 @@ CODE;
         $properties = [
             'prop1' => Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string'))),
             'prop2' => Property::fromMetaData('ns1', new MetaProperty('prop2', XsdType::guess('int'))),
-            'prop3' => Property::fromMetaData('ns1', new MetaProperty('prop3', XsdType::guess('boolean'))),
+            'prop3' => Property::fromMetaData('ns1', new MetaProperty('prop3', XsdType::guess('bool'))),
             'prop4' => Property::fromMetaData('ns1', new MetaProperty('prop4', XsdType::guess('My_Response'))),
         ];
 
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties[$propertyName];
 
         return new PropertyContext($class, $type, $property);
@@ -321,7 +321,7 @@ CODE;
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
@@ -246,7 +246,7 @@ CODE;
     {
         $assembler = new ImmutableSetterAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData(
                 $namespace,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
@@ -288,7 +288,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string'))),
         ], XsdType::create('MyType'));
 
@@ -307,7 +307,7 @@ CODE;
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
@@ -48,7 +48,7 @@ class InterfaceAssemblerTest extends TestCase
     {
         $assembler = new InterfaceAssembler('MyUsedClass');
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [], XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
         $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string')));
         $context = new PropertyContext($class, $type, $property);
         $this->assertTrue($assembler->canAssemble($context));
@@ -84,7 +84,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
             Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
@@ -126,7 +126,7 @@ CODE;
     {
         $metaConfigurator ??= identity();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $metaConfigurator($meta
                     ->withIsList(true)

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
@@ -77,7 +77,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
             Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
@@ -203,7 +203,7 @@ CODE;
     {
         $assembler = new PropertyAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData(
                 $namespace,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
@@ -301,7 +301,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withDocs('Type specific docs')
             ))),
@@ -316,7 +316,7 @@ CODE;
     private function createContextWithLongType()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData(
                 'This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever',
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
@@ -331,7 +331,7 @@ CODE;
     private function createContextWithNullableType()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withDocs('Type specific docs')->withIsNullable(true)
             ))),

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/RequestAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/RequestAssemblerTest.php
@@ -70,7 +70,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
             Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultAssemblerTest.php
@@ -70,7 +70,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
             Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
@@ -142,7 +142,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
@@ -162,7 +162,7 @@ CODE;
     {
         $assembler = new SetterAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', [
+        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData(
                 $namespace,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
@@ -200,7 +200,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [
             $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string'))),
         ], XsdType::create('MyType'));
 
@@ -219,7 +219,7 @@ CODE;
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/TraitAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/TraitAssemblerTest.php
@@ -94,7 +94,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [], XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
@@ -48,7 +48,7 @@ class UseAssemblerTest extends TestCase
     {
         $assembler = new UseAssembler('MyUsedClass');
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [], XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
         $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string')));
         $context = new PropertyContext($class, $type, $property);
         $this->assertTrue($assembler->canAssemble($context));
@@ -178,7 +178,7 @@ CODE;
     {
         $assembler = new UseAssembler('SomeOtherClass');
         $class = new ClassGenerator('MyType');
-        $type = new Type('', 'MyType', [], XsdType::create('MyType'));
+        $type = new Type('', 'MyType', 'MyType', [], XsdType::create('MyType'));
         $context = new TypeContext($class, $type);
 
         $assembler->assemble($context);
@@ -225,7 +225,7 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', [], XsdType::create('MyType'));
+        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);
     }


### PR DESCRIPTION
Fixes https://github.com/phpro/soap-client/issues/543

@rauanmayemir  This should fix the `Decimal` type replacement issues you encountered during code generation. Can you validate if this works for you?