### PR TITLE
Add support for simple element return types in soap methods

### DIFF
--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ReturnTypeSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ReturnTypeSpec.php
@@ -31,6 +31,34 @@ class ReturnTypeSpec extends ObjectBehavior
         $this->getType()->shouldReturn('\\My\\Namespace\\Type');
     }
 
+    function it_can_fall_back_to_mixed_on_unkown_extension_of_simple_type()
+    {
+        $this->beConstructedWith(
+            'Type',
+            'My\Namespace',
+            XsdType::create('Type')
+                ->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true))
+        );
+
+        $this->getType()->shouldReturn('mixed');
+    }
+
+    function it_can_fall_back_to_simple_type()
+    {
+        $this->beConstructedWith(
+            'Type',
+            'My\Namespace',
+            XsdType::create('Type')
+                ->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true)->withExtends([
+                    'isSimple' => true,
+                    'type' => 'string',
+                    'namespace' => 'http://www.w3.org/2001/XMLSchema',
+                ]))
+        );
+
+        $this->getType()->shouldReturn('string');
+    }
+
     public function it_has_type_meta(): void
     {
         $this->getMeta()->shouldBeLike(new TypeMeta());

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
@@ -66,6 +66,13 @@ final class ReturnType
         if (Normalizer::isKnownType($this->type)) {
             return $this->type;
         }
+        
+        if ($this->meta->isSimple()->unwrapOr(false)) {
+            return $this->meta->extends()
+                ->filter(static fn (array $extends): bool => $extends['isSimple'])
+                ->map(static fn (array $extends): string => $extends['type'])
+                ->unwrapOr('mixed');
+        }
 
         return '\\'.$this->namespace.'\\'.Normalizer::normalizeClassname($this->type);
     }


### PR DESCRIPTION
A response / request can be linked to a 'simple' element type:

```xml
            <element name="IFC_AcknowledgeReceipt" type="anyType" />
```

In that case, code generation resulted in `MixedResult<IFC_AcknowledgeReceipt>` but should be `MixedResult<mixed>`.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
             xmlns:tns="http://example.com/customerdetails"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://example.com/customerdetails"
             name="CustomerDetailsService">

    <!-- Data Types -->
    <types>
        <schema xmlns="http://www.w3.org/2001/XMLSchema"
                targetNamespace="http://example.com/customerdetails">
            <element name="IFC_AcknowledgeReceipt" type="anyType" />
        </schema>
    </types>

    <!-- Message Definitions -->
    <message name="GetCustomerDetailsRequestMessage">
        <part name="parameters" element="tns:IFC_AcknowledgeReceipt" />
    </message>
    <message name="GetCustomerDetailsResponseMessage">
        <part name="parameters" element="tns:IFC_AcknowledgeReceipt" />
    </message>

    <!-- Port Type (Abstract Interface) -->
    <portType name="CustomerDetailsPortType">
        <operation name="GetCustomerDetails">
            <input message="tns:GetCustomerDetailsRequestMessage" />
            <output message="tns:GetCustomerDetailsResponseMessage" />
        </operation>
    </portType>

    <!-- Binding (Concrete Implementation) -->
    <binding name="CustomerDetailsBinding" type="tns:CustomerDetailsPortType">
        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
        <operation name="GetCustomerDetails">
            <soap:operation soapAction="http://example.com/GetCustomerDetails" />
            <input>
                <soap:body use="literal" />
            </input>
            <output>
                <soap:body use="literal" />
            </output>
        </operation>
    </binding>

    <!-- Service Definition -->
    <service name="CustomerDetailsService">
        <documentation>This service provides customer details based on customer ID.</documentation>
        <port name="CustomerDetailsPort" binding="tns:CustomerDetailsBinding">
            <soap:address location="http://example.com/customerdetails/service" />
        </port>
    </service>
</definitions>

```