### PR TITLE
Enhance client factory param

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "phpspec/phpspec": "~7.2",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpstan/phpstan": "^1.12.7",
-        "phpunit/phpunit": "~10.5",
+        "phpunit/phpunit": "~10.5.37",
         "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/cache": "^6.4 || ^7.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,10 @@
-<phpunit bootstrap="./test/bootstrap.php" colors="true">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    displayDetailsOnPhpunitDeprecations="true"
+    bootstrap="./test/bootstrap.php"
+    colors="true"
+>
     <testsuites>
         <testsuite name="Unit">
             <directory>./test/PhproTest/SoapClient/Unit</directory>

--- a/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
@@ -77,6 +77,12 @@ BODY;
                             'This factory can be used as a starting point '.
                             'to create your own specialized factory. Feel free to modify.'
                         )
+                        ->setTags([
+                            [
+                                'name' => 'param',
+                                'description' => 'non-empty-string $wsdl',
+                            ],
+                        ])
                 )
         );
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
@@ -33,6 +33,8 @@ class MyclientFactory
     /**
      * This factory can be used as a starting point to create your own specialized
      * factory. Feel free to modify.
+     *
+     * @param non-empty-string \$wsdl
      */
     public static function factory(string \$wsdl) : \App\Client\Myclient
     {

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/ArrayBoundsCalculatorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/ArrayBoundsCalculatorTest.php
@@ -23,7 +23,7 @@ class ArrayBoundsCalculatorTest extends TestCase
         self::assertSame($expected, $calculator($meta));
     }
 
-    public function provideExpectations()
+    public static function provideExpectations()
     {
         yield 'simpleType' => [
             new TypeMeta(),

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/EnumValuesCalculatorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/EnumValuesCalculatorTest.php
@@ -31,7 +31,7 @@ class EnumValuesCalculatorTest extends TestCase
         (new EnumValuesCalculator())(new TypeMeta());
     }
 
-    public function provideExpectations()
+    public static function provideExpectations()
     {
         yield 'empty' => [
             (new TypeMeta())->withEnums(['']),

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/TypeNameCalculatorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/TypeNameCalculatorTest.php
@@ -21,7 +21,7 @@ class TypeNameCalculatorTest extends TestCase
 
     }
 
-    public function provideTypeNameCalculations()
+    public static function provideTypeNameCalculations()
     {
         yield 'complexType' => [
             XsdType::create('ComplexType')->withMeta(

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/UnionTypesCalculatorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/Calculator/UnionTypesCalculatorTest.php
@@ -31,7 +31,7 @@ class UnionTypesCalculatorTest extends TestCase
         (new UnionTypesCalculator())(new TypeMeta());
     }
 
-    public function provideExpectations()
+    public static function provideExpectations()
     {
         yield 'single' => [
             (new TypeMeta())->withUnions([

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/MetaTypeEnhancerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeEnhancer/MetaTypeEnhancerTest.php
@@ -25,7 +25,7 @@ class MetaTypeEnhancerTest extends TestCase
         self::assertSame($expectedPhp, $enhancer->asPhpType($type));
     }
 
-    public function provideExpectations()
+    public static function provideExpectations()
     {
         yield 'simpleType' => [
             new TypeMeta(),


### PR DESCRIPTION
Generates psalm compatible param signature for the client factory.

```php
    /**
     * This factory can be used as a starting point to create your own specialized
     * factory. Feel free to modify.
     *
     * @param non-empty-string $wsdl
     */
    public static function factory(string $wsdl) : \App\AppClient
```