### PR TITLE
Add the ability to select specific services by port / service name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php-soap/engine": "^2.13.0",
         "php-soap/encoding": "~0.13",
         "php-soap/psr18-transport": "^1.7",
-        "php-soap/wsdl-reader": "~0.18",
+        "php-soap/wsdl-reader": "~0.19",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "~5.4 || ~6.0 || ~7.0",

--- a/docs/cli/generate-clientfactory.md
+++ b/docs/cli/generate-clientfactory.md
@@ -46,6 +46,7 @@ use Soap\Encoding\EncoderRegistry;
 use Soap\Psr18Transport\Psr18Transport;
 use Soap\Psr18Transport\Wsdl\Psr18Loader;
 use Soap\Wsdl\Loader\FlatteningLoader;
+use Soap\WsdlReader\Locator\ServiceSelectionCriteria
 use Soap\WsdlReader\Model\Definitions\SoapVersion;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -77,7 +78,12 @@ class CalculatorClientFactory
                     new RedisAdapter(RedisAdapter::createConnection('redis://localhost')),
                     new CacheConfig('my-wsdl-cache-key', ttlInSeconds: 3600)
                 )
-                ->withPreferredSoapVersion(SoapVersion::SOAP_12)
+                ->withWsdlServiceSelectionCriteria(
+                    ServiceSelectionCriteria::defaults()
+                        ->withPreferredSoapVersion(SoapVersion::SOAP_12)
+                        ->withServiceName('SpecificServiceName')
+                        ->withPortName('SpecificPortName')
+                )
         );
 
         $eventDispatcher = new EventDispatcher();

--- a/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClientFactoryGenerator.php
@@ -37,7 +37,7 @@ class ClientFactoryGenerator implements GeneratorInterface
         // ->withTransport()
         // If you want specific SOAP setting:
         // ->withWsdlParserContext()
-        // ->withPreferredSoapVersion()
+        // ->withWsdlServiceSelectionCriteria()
 );
 
 \$eventDispatcher = new EventDispatcher();

--- a/src/Phpro/SoapClient/Soap/EngineOptions.php
+++ b/src/Phpro/SoapClient/Soap/EngineOptions.php
@@ -27,9 +27,10 @@ final class EngineOptions
     private ?Transport $transport = null;
     private ?CacheItemPoolInterface $cache = null;
     private ?CacheConfig $cacheConfig = null;
-    private ?SoapVersion $preferredSoapVersion = null;
     private ?ParserContext $wsdlParserContext = null;
     private ?EncoderRegistry $encoderRegistry = null;
+
+    private ?ServiceSelectionCriteria $wsdlServiceSelectionCriteria = null;
 
     /**
      * @param non-empty-string $wsdl
@@ -81,18 +82,18 @@ final class EngineOptions
         return $clone;
     }
 
-    public function withPreferredSoapVersion(SoapVersion $preferredSoapVersion): self
-    {
-        $clone = clone $this;
-        $clone->preferredSoapVersion = $preferredSoapVersion;
-
-        return $clone;
-    }
-
     public function withEncoderRegistry(EncoderRegistry $registry): self
     {
         $clone = clone $this;
         $clone->encoderRegistry = $registry;
+
+        return $clone;
+    }
+
+    public function withWsdlServiceSelectionCriteria(ServiceSelectionCriteria $criteria): self
+    {
+        $clone = clone $this;
+        $clone->wsdlServiceSelectionCriteria = $criteria;
 
         return $clone;
     }
@@ -133,19 +134,11 @@ final class EngineOptions
         return $this->cacheConfig ?? new CacheConfig('soap-engine-'.md5($this->wsdl));
     }
 
-    /**
-     * @return Option<SoapVersion>
-     */
-    public function getPreferredSoapVersion(): Option
-    {
-        return from_nullable($this->preferredSoapVersion);
-    }
-
     public function getWsdlServiceSelectionCriteria(): ServiceSelectionCriteria
     {
-        return ServiceSelectionCriteria::defaults()
-            ->withAllowHttpPorts(false)
-            ->withPreferredSoapVersion($this->preferredSoapVersion);
+        return ($this->wsdlServiceSelectionCriteria ?? ServiceSelectionCriteria::defaults())
+            // HTTP ports are not supported in this SOAP-client
+            ->withAllowHttpPorts(false);
     }
 
     public function getEncoderRegistry(): EncoderRegistry

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
@@ -52,7 +52,7 @@ class MyclientFactory
                 // ->withTransport()
                 // If you want specific SOAP setting:
                 // ->withWsdlParserContext()
-                // ->withPreferredSoapVersion()
+                // ->withWsdlServiceSelectionCriteria()
         );
 
         \$eventDispatcher = new EventDispatcher();


### PR DESCRIPTION
Fixes https://github.com/phpro/soap-client/discussions/557

This allows for selecting specific ports / services in the WSDL:

https://github.com/php-soap/wsdl-reader/releases/tag/0.19.0

```diff
 EngineOptions::defaults($wsdl)
-     ->withPreferredSoapVersion(SoapVersion::SOAP_12)
+     ->withWsdlServiceSelectionCriteria(
+         ServiceSelectionCriteria::defaults()
+             ->withPreferredSoapVersion(SoapVersion::SOAP_12)
+             ->withServiceName('SpecificServiceName')
+             ->withPortName('SpecificPortName')
+     );
```