### PR TITLE
Mark non-intersecting types as nullable

### DIFF
--- a/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategyTest.php
@@ -11,6 +11,7 @@ use Soap\Engine\Metadata\Collection\PropertyCollection;
 use Soap\Engine\Metadata\Collection\TypeCollection;
 use Soap\Engine\Metadata\Model\Property;
 use Soap\Engine\Metadata\Model\Type;
+use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
 class IntersectDuplicateTypesStrategyTest extends TestCase
@@ -29,9 +30,10 @@ class IntersectDuplicateTypesStrategyTest extends TestCase
             new Type(XsdType::create('file'), new PropertyCollection(
                 new Property('prop1', XsdType::create('string')),
                 new Property('prop3', XsdType::create('string')),
+                new Property('prop4', XsdType::create('string')),
             )),
             new Type(XsdType::create('file'), new PropertyCollection(
-                new Property('prop1', XsdType::create('string')),
+                new Property('prop1', XsdType::create('int')),
                 new Property('prop2', XsdType::create('string')),
             )),
             new Type(XsdType::create('uppercased'), new PropertyCollection()),
@@ -44,14 +46,16 @@ class IntersectDuplicateTypesStrategyTest extends TestCase
         );
 
         $manipulated = $strategy($types);
+        $nullable = static fn(TypeMeta $meta) => $meta->withIsNullable(true);
 
         self::assertInstanceOf(TypeCollection::class, $manipulated);
         self::assertEquals(
             [
                 new Type(XsdType::create('file'), new PropertyCollection(
-                    new Property('prop1', XsdType::create('string')),
-                    new Property('prop3', XsdType::create('string')),
-                    new Property('prop2', XsdType::create('string')),
+                    new Property('prop1', XsdType::create('int')),
+                    new Property('prop3', XsdType::create('string')->withMeta($nullable)),
+                    new Property('prop4', XsdType::create('string')->withMeta($nullable)),
+                    new Property('prop2', XsdType::create('string')->withMeta($nullable)),
                 )),
                 new Type(XsdType::create('uppercased'), new PropertyCollection()),
                 new Type(XsdType::create('with-specialchar'), new PropertyCollection()),


### PR DESCRIPTION
This PR marks non-intersecting types as null whilst using the IntersectDuplicateTypesStrategy.

This results in nullable properties (getters, ...) during code generation with a default value of `null`.
So when the item is not available and you do try to access the property, you won't get an uninitialized error but null instead.

For example
```php
    /**
     * @var null | string
     */
    private ?string $Time = null;

    /**
     * @return null | string
     */
    public function getTime() : ?string
    {
        return $this->Time;
    }
```


This means that your code needs to validate wether the value is present or not (at all times) before using non intersecting properties.