### PR TITLE
Cache driver instead of the full engine to avoid transport serialization

### DIFF
--- a/.github/workflows/grumphp.yml
+++ b/.github/workflows/grumphp.yml
@@ -30,7 +30,7 @@ jobs:
               id: composercache
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.composercache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/src/Phpro/SoapClient/Soap/DefaultEngineFactory.php
+++ b/src/Phpro/SoapClient/Soap/DefaultEngineFactory.php
@@ -3,7 +3,8 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap;
 
-use Soap\CachedEngine\CachedEngine;
+use Psr\Cache\CacheItemPoolInterface;
+use Soap\CachedEngine\CachedDriver;
 use Soap\Encoding\Driver;
 use Soap\Engine\Engine;
 use Soap\Engine\LazyEngine;
@@ -15,32 +16,37 @@ final class DefaultEngineFactory
     public static function create(
         EngineOptions $options
     ): Engine {
-
-        $cache = $options->getCache();
-        $factory = static fn(): Engine => self::configureEngine($options);
-
-        return match (true) {
-            $cache->isSome() => new CachedEngine($cache->unwrap(), $options->getCacheConfig(), $factory),
-            default => new LazyEngine($factory),
-        };
+        return new LazyEngine(static fn (): Engine => self::configureEngine($options));
     }
 
     private static function configureEngine(EngineOptions $options): Engine
+    {
+        $driver = $options->getCache()->mapOrElse(
+            static fn (CacheItemPoolInterface $cache) => new CachedDriver(
+                $cache,
+                $options->getCacheConfig(),
+                static fn () => self::configureDriver($options),
+            ),
+            static fn () => self::configureDriver($options)
+        )->unwrap();
+
+        return new SimpleEngine(
+            $driver,
+            $options->getTransport()
+        );
+    }
+
+    private static function configureDriver(EngineOptions $options): Driver
     {
         $wsdl = (new Wsdl1Reader($options->getWsdlLoader()))(
             $options->getWsdl(),
             $options->getWsdlParserContext()
         );
 
-        $driver = Driver::createFromWsdl1(
+        return Driver::createFromWsdl1(
             $wsdl,
             $options->getWsdlServiceSelectionCriteria(),
             $options->getEncoderRegistry()
-        );
-
-        return new SimpleEngine(
-            $driver,
-            $options->getTransport()
         );
     }
 }

--- a/src/Phpro/SoapClient/Soap/EngineOptions.php
+++ b/src/Phpro/SoapClient/Soap/EngineOptions.php
@@ -130,7 +130,7 @@ final class EngineOptions
 
     public function getCacheConfig(): CacheConfig
     {
-        return $this->cacheConfig ?? new CacheConfig('soap-engine-'.md5($this->wsdl));
+        return $this->cacheConfig ?? new CacheConfig('soap-driver-'.md5($this->wsdl));
     }
 
     public function getWsdlServiceSelectionCriteria(): ServiceSelectionCriteria


### PR DESCRIPTION
Fixes issues like https://github.com/phpro/soap-client/discussions/570 where the transport is not serializable.