### PR TITLE
Fix xsd:language-like simple type generations.

### DIFF
--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -100,6 +100,12 @@ class Property
             return $this->type;
         }
 
+        if ($this->meta->isSimple()->unwrapOr(false)
+                && Normalizer::isKnownType($this->xsdType->getBaseType())
+        ) {
+            return $this->xsdType->getBaseType();
+        }
+
         if (!$this->namespace) {
             return '\\'.Normalizer::normalizeClassname($this->type);
         }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
@@ -3,10 +3,12 @@
 namespace PhproTest\SoapClient\Unit\CodeGenerator\Model;
 
 use Phpro\SoapClient\CodeGenerator\Model\Property;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Psl\Option\Option;
 use Soap\Engine\Metadata\Model\Property as EngineProperty;
+use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
 /**
@@ -56,5 +58,63 @@ class PropertyTest extends TestCase
         self::assertNotSame($xsdType, $property->getXsdType());
         self::assertSame('DateInterval', $property->getXsdType()->getName());
         self::assertSame('DateInterval', $property->getXsdType()->getBaseType());
+    }
+
+    #[Test]
+    #[DataProvider('provideTypes')]
+    public function it_can_figure_out_the_type(Property $property, string $expectedType): void
+    {
+        self::assertSame($expectedType, $property->getType());
+    }
+
+    public static function provideTypes()
+    {
+        yield 'known_simple_type' => [
+            Property::fromMetaData(
+                'MyApp',
+                new EngineProperty(
+                    'property',
+                    XsdType::create('string')
+                )
+            ),
+            'string'
+        ];
+        yield 'known_simple_base_type' => [
+            Property::fromMetaData(
+                'MyApp',
+                new EngineProperty(
+                    'property',
+                    XsdType::create('language')
+                        ->withXmlNamespace('http://www.w3.org/2001/XMLSchema')
+                        ->withXmlNamespaceName('xsd')
+                        ->withBaseType('string')
+                        ->withMemberTypes(['token'])
+                        ->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true))
+                )
+            ),
+            'string'
+        ];
+
+        yield 'root namespace' => [
+            Property::fromMetaData(
+                '',
+                new EngineProperty(
+                    'property',
+                    XsdType::create('MyType')
+                )
+            ),
+            '\\MyType'
+        ];
+
+        yield 'namespaced' => [
+            Property::fromMetaData(
+                'MyApp',
+                new EngineProperty(
+                    'property',
+                    XsdType::create('MyType')
+                )
+            ),
+            '\\MyApp\\MyType'
+        ];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/phpro/soap-client/issues/591

This enhances `xsd:language`-like type generations from

```php
    /**
     * @var array<int<0,max>, \MyApp\Token>
     */
    private array $elementfilterSprache;
```

to

```php
    /**
     * @var array<int<0,max>, string>
     */
    private array $elementfilterSprache;
```
