### PR TITLE
Update ClientConstructorAssembler to use type instead of phpdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 vendor
 composer.lock
 .phpunit.result.cache

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -287,7 +287,7 @@ class CalculatorClient
         $this->caller = $caller;
     }
 
-    public function add(Add $parameters) : AddResponse
+    public function add(Add $parameters): AddResponse
     {
         return ($this->caller)('Add', $parameters);
     }
@@ -319,7 +319,7 @@ use Phpro\SoapClient\Caller\EngineCaller;
 
 class CalculatorClientFactory
 {
-    public static function factory(string $wsdl) : CalculatorClient
+    public static function factory(string $wsdl): CalculatorClient
     {
         $engine = DefaultEngineFactory::create(
             ExtSoapOptions::defaults($wsdl, [])

--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,14 @@
         "guzzlehttp/guzzle": "^7.5.0",
         "nyholm/psr7": "^1.5",
         "php-http/vcr-plugin": "^1.2",
-        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpro/grumphp-shim": "^2.17",
-        "phpspec/phpspec": "~7.2 || ~8.0",
+        "phpspec/phpspec": "^8.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpstan/phpstan": "^2.1",
-        "phpunit/phpunit": "~12.4",
+        "phpunit/phpunit": "^12.4",
         "squizlabs/php_codesniffer": "^4.0",
-        "symfony/cache": "^6.4 || ^7.0"
+        "symfony/cache": "^7.0"
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
         "azjezz/psl": "^3.0 || ^4.0",
-        "laminas/laminas-code": "^4.14.0",
+        "laminas/laminas-code": "^4.17.0",
         "php-soap/cached-engine": "~0.3",
         "php-soap/engine": "^2.14.0",
         "php-soap/encoding": "~0.15",
@@ -33,7 +33,7 @@
         "php-http/vcr-plugin": "^1.2",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpro/grumphp-shim": "^2.17",
-        "phpspec/phpspec": "~7.2",
+        "phpspec/phpspec": "~7.2 || ~8.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "~12.4",

--- a/docs/cli/generate-classmap.md
+++ b/docs/cli/generate-classmap.md
@@ -50,7 +50,7 @@ use Soap\Encoding\ClassMap\ClassMap;
 class OrderClassMap
 {
 
-    public static function getCollection() : ClassMapCollection
+    public static function getCollection(): ClassMapCollection
     {
         return new ClassMapCollection(
             new ClassMap('http://namespace', 'CreateOrder', Type\Example1::class),

--- a/docs/cli/generate-clientfactory.md
+++ b/docs/cli/generate-clientfactory.md
@@ -53,7 +53,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class CalculatorClientFactory
 {
-    public static function factory(string $wsdl) : CalculatorClient
+    public static function factory(string $wsdl): CalculatorClient
     {
         $engine = DefaultEngineFactory::create(
             EngineOptions::defaults($wsdl)

--- a/docs/client.md
+++ b/docs/client.md
@@ -7,10 +7,7 @@ The first thing you need to do is creating your own client.
 ```php
 class YourClient
 {
-    /**
-     * @var Caller
-     */
-    private $caller;
+    private \Phpro\SoapClient\Caller\Caller $caller;
 
     public function __construct(\Phpro\SoapClient\Caller\Caller $caller)
     {
@@ -23,7 +20,7 @@ class YourClient
      * @return ResultInterface & HelloWorldResponse
      * @throws \Phpro\SoapClient\Exception\SoapException
      */
-    public function helloWorld(RequestInterface $request) : HelloWorldResponse
+    public function helloWorld(RequestInterface $request): HelloWorldResponse
     {
         $response = ($this->caller)('HelloWorld', $request);
 

--- a/docs/code-generation/assemblers.md
+++ b/docs/code-generation/assemblers.md
@@ -378,7 +378,7 @@ class MyType implements ResultProviderInterface
     /**
      * @return SomeClass|ResultInterface
      */
-    public function getResult() : \Phpro\SoapClient\Type\ResultInterface
+    public function getResult(): \Phpro\SoapClient\Type\ResultInterface
     {
         return $this->prop1;
     }
@@ -402,7 +402,7 @@ class MyType implements ResultProviderInterface
     /**
      * @return MixedResult
      */
-    public function getResult() : \Phpro\SoapClient\Type\ResultInterface
+    public function getResult(): \Phpro\SoapClient\Type\ResultInterface
     {
         return new MixedResult($this->prop1);
     }

--- a/docs/drivers/metadata.md
+++ b/docs/drivers/metadata.md
@@ -80,7 +80,7 @@ use Soap\WsdlReader\Metadata\Predicate\IsOfType;use Soap\Xml\Xmlns;
 
 final class MyDateReplacer implements TypeReplacer
 {
-    public function __invoke(XsdType $xsdType) : XsdType
+    public function __invoke(XsdType $xsdType): XsdType
     {
         $check = new IsOfType(Xmlns::xsd()->value(), 'date');
         if (!$check($xsdType)) {

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientConstructorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientConstructorAssembler.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Phpro\SoapClient\CodeGenerator\Assembler;

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientConstructorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientConstructorAssembler.php
@@ -1,19 +1,17 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phpro\SoapClient\CodeGenerator\Assembler;
 
-use Laminas\Code\Generator\ClassGenerator;
-use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\MethodGenerator;
 use Laminas\Code\Generator\ParameterGenerator;
 use Laminas\Code\Generator\PropertyGenerator;
+use Laminas\Code\Generator\TypeGenerator;
 use Phpro\SoapClient\Caller\Caller;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
-use Phpro\SoapClient\CodeGenerator\LaminasCodeFactory\DocBlockGeneratorFactory;
 use Phpro\SoapClient\Exception\AssemblerException;
-use function Psl\Type\non_empty_string;
 
 class ClientConstructorAssembler implements AssemblerInterface
 {
@@ -32,20 +30,14 @@ class ClientConstructorAssembler implements AssemblerInterface
 
         $class = $context->getClass();
         try {
-            $caller = $this->generateClassNameAndAddImport(Caller::class, $class);
-            $class->addPropertyFromGenerator(
-                (new PropertyGenerator('caller'))
-                    ->setVisibility(PropertyGenerator::VISIBILITY_PRIVATE)
-                    ->omitDefaultValue(true)
-                    ->setDocBlock((new DocBlockGenerator())
-                        ->setWordWrap(false)
-                        ->setTags([
-                            [
-                                'name'        => 'var',
-                                'description' => $caller,
-                            ],
-                        ])),
-            );
+            $property = (new PropertyGenerator('caller'))
+                ->setVisibility(PropertyGenerator::VISIBILITY_PRIVATE)
+                ->omitDefaultValue(true);
+
+            $property->setType(TypeGenerator::fromTypeString(Caller::class));
+
+            $class->addPropertyFromGenerator($property);
+
             $class->addMethodFromGenerator(
                 (new MethodGenerator('__construct'))
                     ->setParameter(new ParameterGenerator('caller', Caller::class))
@@ -57,21 +49,5 @@ class ClientConstructorAssembler implements AssemblerInterface
         }
 
         return true;
-    }
-
-    /**
-     * @param non-empty-string $fqcn
-     */
-    private function generateClassNameAndAddImport(string $fqcn, ClassGenerator $class): string
-    {
-        $fqcn = non_empty_string()->assert(ltrim($fqcn, '\\'));
-        $parts = explode('\\', $fqcn);
-        $className = array_pop($parts);
-
-        if (!\in_array($fqcn, $class->getUses(), true)) {
-            $class->addUse($fqcn);
-        }
-
-        return $className;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethodMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethodMap.php
@@ -42,7 +42,7 @@ class ClientMethodMap
     /**
      * @return ClientMethod[]
      */
-    public function getMethods() : array
+    public function getMethods(): array
     {
         return $this->methods;
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
@@ -56,14 +56,14 @@ use Soap\Encoding\ClassMap\ClassMap;
 
 class MyClassMap
 {
-    public static function types() : \Soap\Encoding\ClassMap\ClassMapCollection
+    public static function types(): \Soap\Encoding\ClassMap\ClassMapCollection
     {
         return new ClassMapCollection(
             new ClassMap('http://my-namespace.com', 'MyType', Type\MyType::class),
         );
     }
 
-    public static function enums() : \Soap\Encoding\ClassMap\ClassMapCollection
+    public static function enums(): \Soap\Encoding\ClassMap\ClassMapCollection
     {
         return new ClassMapCollection(
             new ClassMap('http://my-namespace.com', 'MyEnum', Type\MyEnum::class),

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientConstructorAssemblerTest.php
@@ -51,14 +51,9 @@ class ClientConstructorAssemblerTest extends TestCase
         $expected = <<<CODE
 namespace Vendor\MyNamespace;
 
-use Phpro\SoapClient\Caller\Caller;
-
 class MyClient
 {
-    /**
-     * @var Caller
-     */
-    private \$caller;
+    private \Phpro\SoapClient\Caller\Caller \$caller;
 
     public function __construct(\Phpro\SoapClient\Caller\Caller \$caller)
     {

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -128,7 +128,7 @@ class MyClient
      * @return ResultInterface & MyTypeNamespace\ReturnType
      * @throws SoapException
      */
-    public function functionName(\Vendor\MyTypeNamespace\ParamType \$param) : \Vendor\MyTypeNamespace\ReturnType
+    public function functionName(\Vendor\MyTypeNamespace\ParamType \$param): \Vendor\MyTypeNamespace\ReturnType
     {
         \$response = (\$this->caller)('functionName', \$param);
 
@@ -174,7 +174,7 @@ class MyClient
      * @return ResultInterface & MyTypeNamespace\ReturnType
      * @throws SoapException
      */
-    public function functionName(\Phpro\SoapClient\Type\MultiArgumentRequest \$multiArgumentRequest) : \Vendor\MyTypeNamespace\ReturnType
+    public function functionName(\Phpro\SoapClient\Type\MultiArgumentRequest \$multiArgumentRequest): \Vendor\MyTypeNamespace\ReturnType
     {
         \$response = (\$this->caller)('functionName', \$multiArgumentRequest);
 
@@ -211,7 +211,7 @@ class MyClient
      * @return ResultInterface & MyTypeNamespace\ReturnType
      * @throws SoapException
      */
-    public function functionName() : \Vendor\MyTypeNamespace\ReturnType
+    public function functionName(): \Vendor\MyTypeNamespace\ReturnType
     {
         \$response = (\$this->caller)('functionName', new MultiArgumentRequest([]));
 
@@ -262,7 +262,7 @@ class MyClient
      * @return ResultInterface & MyTypeNamespace\ReturnType
      * @throws SoapException
      */
-    public function function_name(\Vendor\MyTypeNamespace\ParamType \$param) : \Vendor\MyTypeNamespace\ReturnType
+    public function function_name(\Vendor\MyTypeNamespace\ParamType \$param): \Vendor\MyTypeNamespace\ReturnType
     {
         \$response = (\$this->caller)('Function_name', \$param);
 
@@ -331,7 +331,7 @@ class MyClient
      * @return ResultInterface & MyTypeNamespace\ReturnType
      * @throws SoapException
      */
-    public function function_name(\Phpro\SoapClient\Type\MultiArgumentRequest \$multiArgumentRequest) : \Vendor\MyTypeNamespace\ReturnType
+    public function function_name(\Phpro\SoapClient\Type\MultiArgumentRequest \$multiArgumentRequest): \Vendor\MyTypeNamespace\ReturnType
     {
         \$response = (\$this->caller)('Function_name', \$multiArgumentRequest);
 
@@ -382,7 +382,7 @@ class MyClient
      * @return ResultInterface & MixedResult<string>
      * @throws SoapException
      */
-    public function functionName() : \Phpro\SoapClient\Type\MixedResult
+    public function functionName(): \Phpro\SoapClient\Type\MixedResult
     {
         \$response = (\$this->caller)('functionName', new MultiArgumentRequest([]));
 
@@ -442,7 +442,7 @@ class MyClient
      * @return ResultInterface & MixedResult<string>
      * @throws SoapException
      */
-    public function functionName(\Phpro\SoapClient\Type\MultiArgumentRequest \$multiArgumentRequest) : \Phpro\SoapClient\Type\MixedResult
+    public function functionName(\Phpro\SoapClient\Type\MultiArgumentRequest \$multiArgumentRequest): \Phpro\SoapClient\Type\MixedResult
     {
         \$response = (\$this->caller)('functionName', \$multiArgumentRequest);
 
@@ -491,7 +491,7 @@ class MyClient
      * @return ResultInterface & MyTypeNamespace\ReturnType
      * @throws SoapException
      */
-    public function functionName() : \Vendor\MyTypeNamespace\ReturnType
+    public function functionName(): \Vendor\MyTypeNamespace\ReturnType
     {
         \$response = (\$this->caller)('functionName', new MultiArgumentRequest([]));
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -54,7 +54,7 @@ class MyType
      * @param string \$prop1
      * @return \$this
      */
-    public function setProp1(string \$prop1) : static
+    public function setProp1(string \$prop1): static
     {
         \$this->prop1 = \$prop1;
         return \$this;
@@ -83,7 +83,7 @@ class MyType
      * @param string \$prop1
      * @return \$this
      */
-    public function setProp1(\$prop1) : static
+    public function setProp1(\$prop1): static
     {
         \$this->prop1 = \$prop1;
         return \$this;
@@ -109,7 +109,7 @@ namespace MyNamespace;
 
 class MyType
 {
-    public function setProp1(string \$prop1) : static
+    public function setProp1(string \$prop1): static
     {
         \$this->prop1 = \$prop1;
         return \$this;
@@ -168,7 +168,7 @@ class MyType
      * @param \This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1
      * @return \$this
      */
-    public function setProp1(\This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1) : static
+    public function setProp1(\This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1): static
     {
         \$this->prop1 = \$prop1;
         return \$this;
@@ -206,7 +206,7 @@ class MyType
      * @param array<int<0,max>, string> \$prop1
      * @return \$this
      */
-    public function setProp1(array \$prop1) : static
+    public function setProp1(array \$prop1): static
     {
         \$this->prop1 = \$prop1;
         return \$this;

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -53,7 +53,7 @@ class MyType
     /**
      * @return string
      */
-    public function getProp1() : string
+    public function getProp1(): string
     {
         return \$this->prop1;
     }
@@ -80,7 +80,7 @@ class MyType
     /**
      * @return null | string
      */
-    public function getProp1() : ?string
+    public function getProp1(): ?string
     {
         return \$this->prop1;
     }
@@ -137,7 +137,7 @@ namespace MyNamespace;
 
 class MyType
 {
-    public function getProp2() : int
+    public function getProp2(): int
     {
         return \$this->prop2;
     }
@@ -166,7 +166,7 @@ class MyType
     /**
      * @return bool
      */
-    public function isProp3() : bool
+    public function isProp3(): bool
     {
         return \$this->prop3;
     }
@@ -195,7 +195,7 @@ class MyType
     /**
      * @return \\ns1\\MyResponse
      */
-    public function getProp4() : \\ns1\\MyResponse
+    public function getProp4(): \\ns1\\MyResponse
     {
         return \$this->prop4;
     }
@@ -223,7 +223,7 @@ class MyType
     /**
      * @return \This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap
      */
-    public function getProp1() : \This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap
+    public function getProp1(): \This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap
     {
         return \$this->prop1;
     }
@@ -259,7 +259,7 @@ class MyType
     /**
      * @return array<int<0,max>, string>
      */
-    public function getProp1() : array
+    public function getProp1(): array
     {
         return \$this->prop1;
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
@@ -55,7 +55,7 @@ class MyType
      * @param string \$prop1
      * @return static
      */
-    public function withProp1(string \$prop1) : static
+    public function withProp1(string \$prop1): static
     {
         \$new = clone \$this;
         \$new->prop1 = \$prop1;
@@ -87,7 +87,7 @@ class MyType
      * @param \This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1
      * @return static
      */
-    public function withProp1(\This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1) : static
+    public function withProp1(\This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1): static
     {
         \$new = clone \$this;
         \$new->prop1 = \$prop1;
@@ -114,7 +114,7 @@ namespace MyNamespace;
 
 class MyType
 {
-    public function withProp1(\This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1) : static
+    public function withProp1(\This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1): static
     {
         \$new = clone \$this;
         \$new->prop1 = \$prop1;
@@ -144,7 +144,7 @@ class MyType
      * @param string \$prop1
      * @return static
      */
-    public function withProp1(\$prop1) : static
+    public function withProp1(\$prop1): static
     {
         \$new = clone \$this;
         \$new->prop1 = \$prop1;
@@ -251,7 +251,7 @@ class MyType
      * @param array<int<0,max>, string> \$prop1
      * @return static
      */
-    public function withProp1(array \$prop1) : static
+    public function withProp1(array \$prop1): static
     {
         \$new = clone \$this;
         \$new->prop1 = \$prop1;

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
@@ -62,7 +62,7 @@ class MyType implements IteratorAggregate
      * @phpstan-return \ArrayIterator<int<0,1>, string>
      * @psalm-return \ArrayIterator<int<0,1>, string>
      */
-    public function getIterator() : \ArrayIterator
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator(\$this->prop1);
     }
@@ -101,7 +101,7 @@ class MyType implements IteratorAggregate
      * @phpstan-return \ArrayIterator<int<0,max>, string>
      * @psalm-return \ArrayIterator<int<0,max>, string>
      */
-    public function getIterator() : \ArrayIterator
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator(\$this->prop1);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
@@ -52,7 +52,7 @@ use JsonSerializable;
 
 class MyType implements JsonSerializable
 {
-    public function jsonSerialize() : array
+    public function jsonSerialize(): array
     {
         return [
             'prop1' => \$this->prop1,

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
@@ -56,7 +56,7 @@ class MyType implements ResultProviderInterface
     /**
      * @return \MyNamespace\SomeClass|ResultInterface
      */
-    public function getResult() : \Phpro\SoapClient\Type\ResultInterface
+    public function getResult(): \Phpro\SoapClient\Type\ResultInterface
     {
         return \$this->prop1;
     }
@@ -86,7 +86,7 @@ class MyType implements ResultProviderInterface
     /**
      * @return MixedResult
      */
-    public function getResult() : \Phpro\SoapClient\Type\ResultInterface
+    public function getResult(): \Phpro\SoapClient\Type\ResultInterface
     {
         return new MixedResult(\$this->prop1);
     }
@@ -116,7 +116,7 @@ class MyType implements ResultProviderInterface
     /**
      * @return MixedResult
      */
-    public function getResult() : \Phpro\SoapClient\Type\ResultInterface
+    public function getResult(): \Phpro\SoapClient\Type\ResultInterface
     {
         return new MixedResult(\$this->prop1);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
@@ -54,7 +54,7 @@ class MyType
     /**
      * @param string \$prop1
      */
-    public function setProp1(string \$prop1) : void
+    public function setProp1(string \$prop1): void
     {
         \$this->prop1 = \$prop1;
     }
@@ -79,7 +79,7 @@ namespace MyNamespace;
 
 class MyType
 {
-    public function setProp1(string \$prop1) : void
+    public function setProp1(string \$prop1): void
     {
         \$this->prop1 = \$prop1;
     }
@@ -106,7 +106,7 @@ class MyType
     /**
      * @param string \$prop1
      */
-    public function setProp1(\$prop1) : void
+    public function setProp1(\$prop1): void
     {
         \$this->prop1 = \$prop1;
     }
@@ -134,7 +134,7 @@ class MyType
     /**
      * @param \This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1
      */
-    public function setProp1(\This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1) : void
+    public function setProp1(\This\Is\My\Very\Very\Long\Namespace\And\Class\Name\That\Should\Not\Never\Ever\Wrap \$prop1): void
     {
         \$this->prop1 = \$prop1;
     }
@@ -170,7 +170,7 @@ class MyType
     /**
      * @param array<int<0,max>, string> \$prop1
      */
-    public function setProp1(array \$prop1) : void
+    public function setProp1(array \$prop1): void
     {
         \$this->prop1 = \$prop1;
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
@@ -36,7 +36,7 @@ class MyclientFactory
      *
      * @param non-empty-string \$wsdl
      */
-    public static function factory(string \$wsdl) : \App\Client\Myclient
+    public static function factory(string \$wsdl): \App\Client\Myclient
     {
         \$engine = DefaultEngineFactory::create(
             EngineOptions::defaults(\$wsdl)


### PR DESCRIPTION
This pr changes the output generated by `ClientConstructorAssembler` from:

```php
use Phpro\SoapClient\Caller\Caller;
    
class MyClient
{
    /**
     * @var Caller
     */
    private $caller;

    public function __construct(\Phpro\SoapClient\Caller\Caller $caller)
    {
```

to:

```php
class MyClient
{
    private \Phpro\SoapClient\Caller\Caller $caller;

    public function __construct(\Phpro\SoapClient\Caller\Caller $caller)
    {
```

Also upgrade `laminas/laminas-code` to latest version since GrumPHP didn't let me commit due to changes in [laminas/laminas-code/pull/208](https://github.com/laminas/laminas-code/pull/208) 

### why this change

I'm using phpstan with `tomasvotruba/type-coverage` plugin, and the only missing type in my codebase is this `Caller` interface, it works the same and the type is already validated in the constructor, so It shouldn't break anything.