### PR TITLE
Make it possible to configure a mapping of type namespaces based on xmlns

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,151 @@
+# V4 to V5
+
+## Configuration overhaul
+
+The configuration system has been significantly reworked.
+The `Config` class no longer implements `ConfigInterface` (which has been removed) and uses new value objects for configuring destinations.
+
+### New value objects
+
+Individual string-based configuration (name, namespace, destination) has been replaced by dedicated value objects:
+
+- **`Destination`**: Combines a `path` and `namespace` into a single object.
+- **`ClientConfig`**: Wraps a client name and `Destination`.
+- **`ClassMapConfig`**: Wraps a classmap name and `Destination`.
+- **`TypeNamespaceMap`**: Replaces the old `setTypeNamespace()` / `setTypeDestination()` combination.
+
+### Migration
+
+**Before (v4):**
+
+```php
+use Phpro\SoapClient\CodeGenerator\Config\Config;
+
+return Config::create()
+    ->setEngine($engine = DefaultEngineFactory::create(
+        EngineOptions::defaults('your.wsdl')
+    ))
+    ->setTypeDestination('src/Type')
+    ->setTypeNamespace('App\\Type')
+    ->setClientName('MyClient')
+    ->setClientNamespace('App')
+    ->setClientDestination('src')
+    ->setClassMapName('MyClassmap')
+    ->setClassMapNamespace('App')
+    ->setClassMapDestination('src');
+```
+
+**After (v5):**
+
+```php
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Config;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+
+return Config::create()
+    ->setEngine($engine = DefaultEngineFactory::create(
+        EngineOptions::defaults('your.wsdl')
+    ))
+    ->setTypeNamespaceMap(
+        TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
+    )
+    ->setClient(new ClientConfig('MyClient', new Destination('src', 'App')))
+    ->setClassMap(new ClassMapConfig('MyClassmap', new Destination('src', 'App')));
+```
+
+### Removed methods on `Config`
+
+| Removed method | Replacement |
+|---|---|
+| `setTypeDestination()` | `setTypeNamespaceMap(TypeNamespaceMap::create(new Destination(...)))` |
+| `setTypeNamespace()` | (included in `Destination`) |
+| `getTypeDestination()` | `getTypeNamespaceMap()` |
+| `getTypeNamespace()` | (included in `TypeNamespaceMap`) |
+| `setClientName()` | `setClient(new ClientConfig(...))` |
+| `setClientNamespace()` | (included in `ClientConfig`) |
+| `setClientDestination()` | (included in `ClientConfig`) |
+| `getClientName()` | `getClient()->name` |
+| `getClientNamespace()` | `getClient()->destination->namespace` |
+| `getClientDestination()` | `getClient()->destination->path` |
+| `setClassMapName()` | `setClassMap(new ClassMapConfig(...))` |
+| `setClassMapNamespace()` | (included in `ClassMapConfig`) |
+| `setClassMapDestination()` | (included in `ClassMapConfig`) |
+| `getClassMapName()` | `getClassMap()->name` |
+| `getClassMapNamespace()` | `getClassMap()->destination->namespace` |
+| `getClassMapDestination()` | `getClassMap()->destination->path` |
+
+### `ConfigInterface` removed
+
+The `ConfigInterface` has been removed entirely. If you had a custom configuration class implementing `ConfigInterface`, you must now use the `Config` class directly.
+
+## TypeNamespaceMap: XML namespace mapping and strategies
+
+The `TypeNamespaceMap` allows you to map XML namespaces (xmlns) to specific PHP namespace destinations.
+This is useful when a WSDL defines types across multiple XML namespaces and you want to organize them into separate PHP directories/namespaces.
+
+### Explicit mappings
+
+```php
+TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
+    ->withMapping('http://www.opengis.net/gml/3.2', new Destination('src/Type/Gml', 'App\\Type\\Gml'))
+    ->withMapping('http://xoev.de/schemata/xzufi/2_2_0', new Destination('src/Type/Xzufi', 'App\\Type\\Xzufi'))
+```
+
+### Strategy-based resolution
+
+Instead of manually mapping every xmlns, you can use a strategy to automatically resolve destinations.
+A built-in `PrefixBasedTypeNamespaceStrategy` derives a sub-namespace from the XML namespace prefix:
+
+```php
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
+
+TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
+    ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+```
+
+With this strategy, a type in the `gml` xmlns prefix is automatically placed in `src/Type/Gml` with namespace `App\Type\Gml`.
+
+Explicit `withMapping()` entries always take precedence over the strategy. You can combine both:
+
+```php
+TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
+    ->withMapping('http://special.example.com', new Destination('src/Type/Special', 'App\\Type\\Special'))
+    ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+```
+
+You can also implement a custom strategy via `TypeNamespaceMapStrategyInterface` or pass any callable.
+
+### Duplicate type strategies are now namespace-aware
+
+The `IntersectDuplicateTypesStrategy` and `RemoveDuplicateTypesStrategy` now use a factory pattern (`create()`) that accepts the `TypeNamespaceMap`. When types map to different PHP namespaces, they are not considered duplicates.
+
+## Interactive config generator improvements
+
+The `generate:config` command now attempts to load the WSDL and detect XML namespaces automatically.
+Detected namespaces are included as commented-out `withMapping()` suggestions and a commented-out `withStrategy()` line in the generated configuration file.
+If you want to have this mapping in your configuration, you can start out fresh by running:
+
+```
+./vendor/bin/soap-client generate:config --config=config/soap-client.php
+```
+
+## Regenerate classes
+
+After upgrading, regenerate all your classes:
+
+```
+./vendor/bin/soap-client generate:client --config=config/soap-client.php
+./vendor/bin/soap-client generate:classmap --config=config/soap-client.php
+./vendor/bin/soap-client generate:types --config=config/soap-client.php
+./vendor/bin/soap-client generate:clientfactory --config=config/soap-client.php
+```
+
+**Note:** The generated code may have changed for your project due to the namespace-aware type generation. Validate that you are still using the correct methods in your implementation.
+
+---
+
 # V3 to V4
 
 **NOTE:** We now require a `psr/cache-implementation` so that the engine (and WSDL parsing) can be cached. Some examples are: `symfony/cache` or `cache/*-adapter`.

--- a/docs/code-generation/configuration.md
+++ b/docs/code-generation/configuration.md
@@ -13,6 +13,7 @@ use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
 use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 
@@ -28,9 +29,11 @@ return Config::create()
     ))
     ->setTypeNamespaceMap(
         TypeNamespaceMap::create(new Destination('SoapTypes', 'src/SoapTypes'))
-            // You can add specific XML xmlns -> PHP namespace mappings here:
-            // If no mapping is found, the default destination + namespace will be used.
+            // You can add explicit XML xmlns -> PHP namespace mappings here:
             ->withMapping('http://www.xmlns.mapping', new Destination('src/Type/OtherDir', 'App\\Type\\OtherDir'))
+            // Or use a strategy to automatically resolve destinations from xmlns prefixes:
+            // This strategy will only be called for XML namespaces that don't have an explicit mapping configured.
+            ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
     )
     ->setClient(new ClientConfig('MySoapClient', new Destination('SoapClient', 'src/SoapClient')))
     ->setClassMap(new ClassMapConfig('AcmeClassmap', new Destination('Acme\\Classmap', 'src/acme/classmap')))
@@ -112,7 +115,39 @@ DefaultEngineFactory::create(
 
 Use `setTypeNamespaceMap(TypeNamespaceMap::create($namespace, $destination))` to configure the namespace and destination for generated types.
 
-You can also add specific XML namespace to PHP namespace mappings by using the `withMapping($xmlNamespace, Destination)` method on the created TypeNamespaceMap instance.
+You can add specific XML namespace to PHP namespace mappings by using the `withMapping($xmlNamespace, Destination)` method on the created TypeNamespaceMap instance.
+
+Alternatively, you can use `withStrategy()` to automatically resolve destinations based on the xmlns prefix.
+A strategy will only be called for XML namespaces that don't have an explicit mapping configured.
+A built-in `PrefixBasedTypeNamespaceStrategy` is provided that derives a sub-namespace from the XML namespace prefix:
+
+```php
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
+
+TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
+    ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+```
+
+With this strategy, a type in the `gml` xmlns prefix would automatically be placed in `src/Type/Gml` with namespace `App\Type\Gml`.
+
+Explicit `withMapping()` entries always take precedence over the strategy.
+You can also provide your own strategy by implementing `TypeNamespaceMapStrategyInterface` or passing any callable:
+
+```php
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\TypeNamespaceMapStrategyInterface;
+
+final readonly class MyCustomStrategy implements TypeNamespaceMapStrategyInterface
+{
+    public function __invoke(string $xmlns, string $xmlNamespaceName, Destination $fallback): Destination
+    {
+        // Your custom resolution logic here
+        return $fallback;
+    }
+}
+```
 
 **Client Configuration**
 

--- a/docs/code-generation/configuration.md
+++ b/docs/code-generation/configuration.md
@@ -179,12 +179,20 @@ Examples:
 ```php
 use Phpro\SoapClient\CodeGenerator\Config\Config;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\IntersectDuplicateTypesStrategy;
+use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\RemoveDuplicateTypesStrategy;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\TypeReplacer\TypeReplacers;
 
 Config::create()
-    ->setDuplicateTypeIntersectStrategy(new IntersectDuplicateTypesStrategy())
+    // Use the factory method - this is namespace-aware when TypeNamespaceMap is configured
+    ->setDuplicateTypeIntersectStrategy(IntersectDuplicateTypesStrategy::create())
+    // Or use the remove strategy instead:
+    // ->setDuplicateTypeIntersectStrategy(RemoveDuplicateTypesStrategy::create())
     ->setTypeReplacementStrategy(TypeReplacers::defaults()->add(new MyDateReplacer()));
 ```
+
+The duplicate type strategies use a factory pattern (`create()`) that returns a closure.
+This closure receives the `TypeNamespaceMap` from the configuration, enabling namespace-aware duplicate detection.
+When types map to different PHP namespaces, they are not considered duplicates.
 
 **Enumeration options**
 

--- a/docs/code-generation/configuration.md
+++ b/docs/code-generation/configuration.md
@@ -8,7 +8,11 @@ The code generation commands require a configuration file to determine how the S
 
 use Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Rules;
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 
@@ -22,14 +26,14 @@ return Config::create()
                     ->addBackedEnumClassMapCollection(SomeClassmap::enums())
             )
     ))
-    ->setTypeDestination('src/SoapTypes')
-    ->setTypeNamespace('SoapTypes')
-    ->setClientDestination('src/SoapClient')
-    ->setClientNamespace('SoapClient')
-    ->setClientName('MySoapClient')
-    ->setClassMapNamespace('Acme\\Classmap')
-    ->setClassMapDestination('src/acme/classmap')
-    ->setClassMapName('AcmeClassmap')
+    ->setTypeNamespaceMap(
+        TypeNamespaceMap::create(new Destination('SoapTypes', 'src/SoapTypes'))
+            // You can add specific XML xmlns -> PHP namespace mappings here:
+            // If no mapping is found, the default destination + namespace will be used.
+            ->withMapping('http://www.xmlns.mapping', new Destination('src/Type/OtherDir', 'App\\Type\\OtherDir'))
+    )
+    ->setClient(new ClientConfig('MySoapClient', new Destination('SoapClient', 'src/SoapClient')))
+    ->setClassMap(new ClassMapConfig('AcmeClassmap', new Destination('Acme\\Classmap', 'src/acme/classmap')))
     ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
     ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler(
         new Assembler\ImmutableSetterAssemblerOptions()
@@ -104,48 +108,19 @@ DefaultEngineFactory::create(
 );
 ```
 
-**type destination**
+**Type Namespace Map**
 
-String - REQUIRED
+Use `setTypeNamespaceMap(TypeNamespaceMap::create($namespace, $destination))` to configure the namespace and destination for generated types.
 
-The destination of the generated PHP classes. 
+You can also add specific XML namespace to PHP namespace mappings by using the `withMapping($xmlNamespace, Destination)` method on the created TypeNamespaceMap instance.
 
-**client destination**
+**Client Configuration**
 
-String - REQUIRED
+Use `setClient(new ClientConfig($name, $destination))` to configure the generated client class.
 
-The destination of the generated soap client. 
+**Classmap Configuration**
 
-**type namespace**
-
-String - OPTIONAL
-
-The namespace of the PHP Classes you want to generate.
-
-
-**client namespace**
-
-String - OPTIONAL
-
-The namespace of the generated client.
-
-**client name**
-
-String - OPTIONAL
-
-The class name of the client, defaults to 'Client'.
-
-**classmap name**
-
-Name of the classmap class
-
-**classmap destination**
-
-The location of a directory the classmap should be generated in.
-
-**classmap namespace**
-
-Name for the classmap
+Use `setClassMap(new ClassMapConfig($name, $destination))` to configure the classmap.
 
 **rules**
 
@@ -154,7 +129,7 @@ RuleInterface - OPTIONAL
 You can specify how you want to generate your code.
 More information about the topic is available in the [rules](rules.md) and [assemblers](assemblers.md) section.
 
-The pre-defined rules are override-able by calling `setRuleSet` on the constucted object.
+The pre-defined rules are override-able by calling `setRuleSet` on the constructed object.
 
 For example, to make all your properties protected:
 ```php

--- a/docs/drivers/metadata.md
+++ b/docs/drivers/metadata.md
@@ -14,16 +14,14 @@ Enabled by default when using `Config::create()`.
 
 This duplicate types strategy will merge all duplicate types into one big type which contains all properties.
 
-
 ```php
 use Phpro\SoapClient\CodeGenerator\Config\Config;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\IntersectDuplicateTypesStrategy;
-use Phpro\SoapClient\Soap\Metadata\MetadataOptions;
 
 return Config::create()
     //...
     ->setDuplicateTypeIntersectStrategy(
-        new IntersectDuplicateTypesStrategy()
+        IntersectDuplicateTypesStrategy::create()
     )
     // ...
 ```
@@ -32,20 +30,49 @@ return Config::create()
 
 This duplicate types strategy will remove all duplicate types it finds.
 
-You can overwrite the strategy on the `DefaultEngineFactory` object inside the client factory:
-
 ```php
 use Phpro\SoapClient\CodeGenerator\Config\Config;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\RemoveDuplicateTypesStrategy;
-use Phpro\SoapClient\Soap\Metadata\MetadataOptions;
 
 return Config::create()
     //...
     ->setDuplicateTypeIntersectStrategy(
-        new RemoveDuplicateTypesStrategy()
+        RemoveDuplicateTypesStrategy::create()
     )
     // ...
 ```
+
+**Namespace-aware duplicate detection**
+
+The duplicate type strategies are namespace-aware when used with `TypeNamespaceMap`.
+When you configure multiple XML namespaces to map to different PHP namespaces,
+types with the same name in different XML namespaces will NOT be considered duplicates
+because they will be generated into separate PHP namespaces.
+
+For example, if you have `AccidentItem` in both `http://ns-a.com` and `http://ns-b.com`,
+and you map these to `App\Type\A` and `App\Type\B` respectively,
+the strategies will treat them as separate types (`App\Type\A\AccidentItem` and `App\Type\B\AccidentItem`).
+
+```php
+use Phpro\SoapClient\CodeGenerator\Config\Config;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\IntersectDuplicateTypesStrategy;
+
+return Config::create()
+    ->setTypeNamespaceMap(
+        TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
+            ->withMapping('http://ns-a.com', new Destination('src/Type/A', 'App\\Type\\A'))
+            ->withMapping('http://ns-b.com', new Destination('src/Type/B', 'App\\Type\\B'))
+    )
+    ->setDuplicateTypeIntersectStrategy(
+        IntersectDuplicateTypesStrategy::create()
+    )
+    // ...
+```
+
+The `create()` factory method returns a closure that receives the `TypeNamespaceMap` from the configuration,
+enabling the strategy to determine target PHP namespaces for each type.
 
 ### Type replacements
 

--- a/spec/Phpro/SoapClient/CodeGenerator/ClassMapGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/ClassMapGeneratorSpec.php
@@ -3,6 +3,9 @@
 namespace spec\Phpro\SoapClient\CodeGenerator;
 
 use Phpro\SoapClient\CodeGenerator\ClassMapGenerator;
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Context\FileContext;
 use Phpro\SoapClient\CodeGenerator\GeneratorInterface;
@@ -11,6 +14,7 @@ use Phpro\SoapClient\CodeGenerator\Rules\RuleSetInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Laminas\Code\Generator\FileGenerator;
+use Soap\Engine\Metadata\Collection\TypeCollection;
 
 /**
  * Class ClassMapGeneratorSpec
@@ -22,7 +26,8 @@ class ClassMapGeneratorSpec extends ObjectBehavior
 {
     function let(RuleSetInterface $ruleSet)
     {
-        $this->beConstructedWith($ruleSet, 'ClassMap', 'App\\Mynamespace');
+        $classMapConfig = new ClassMapConfig('ClassMap', new Destination('/app', 'App\\Mynamespace'));
+        $this->beConstructedWith($ruleSet, $classMapConfig);
     }
     
     function it_is_initializable()
@@ -35,11 +40,14 @@ class ClassMapGeneratorSpec extends ObjectBehavior
         $this->shouldImplement(GeneratorInterface::class);
     }
 
-    function it_generates_classmaps(RuleSetInterface $ruleSet, FileGenerator $file, TypeMap $typeMap)
+    function it_generates_classmaps(RuleSetInterface $ruleSet, FileGenerator $file)
     {
         $ruleSet->applyRules(Argument::type(ClassMapContext::class))->shouldBeCalled();
         $ruleSet->applyRules(Argument::type(FileContext::class))->shouldBeCalled();
         $file->generate()->willReturn('code');
-        $this->generate($file, $typeMap)->shouldReturn('code');
+        $this->generate($file, TypeMap::fromMetadata(
+            TypeNamespaceMap::create(new Destination('/app', 'App\\Mynamespace')),
+            new TypeCollection(),
+        ))->shouldReturn('code');
     }
 }

--- a/spec/Phpro/SoapClient/CodeGenerator/ClientGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/ClientGeneratorSpec.php
@@ -5,6 +5,9 @@ namespace spec\Phpro\SoapClient\CodeGenerator;
 use Laminas\Code\Generator\Exception\ClassNotFoundException;
 use Phpro\SoapClient\CodeGenerator\ClassMapGenerator;
 use Phpro\SoapClient\CodeGenerator\ClientGenerator;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 use Phpro\SoapClient\CodeGenerator\Context\FileContext;
@@ -46,13 +49,14 @@ class ClientGeneratorSpec extends ObjectBehavior
         $this->shouldImplement(GeneratorInterface::class);
     }
 
-    function it_generates_clients(RuleSetInterface $ruleSet, FileGenerator $file, Client $client, ClientMethodMap $map, ClassGenerator $class)
+    function it_generates_clients(RuleSetInterface $ruleSet, FileGenerator $file, ClassGenerator $class)
     {
+        $typeNamespaceMap = TypeNamespaceMap::create(new Destination('/app', ''));
         $method = new ClientMethod(
             'Test',
-            [new Parameter('parameters', 'Test', '', XsdType::create('Test'))],
-            ReturnType::fromMetaData('', XsdType::create('TestResponse')),
-            '',
+            [new Parameter('parameters', 'Test', $typeNamespaceMap, XsdType::create('Test'))],
+            ReturnType::fromMetaData($typeNamespaceMap, XsdType::create('TestResponse')),
+            $typeNamespaceMap,
             new MethodMeta()
         );
         $ruleSet->applyRules(Argument::type(ClientMethodContext::class))->shouldBeCalled();
@@ -63,33 +67,35 @@ class ClientGeneratorSpec extends ObjectBehavior
         $file->getClass()->willThrow(new ClassNotFoundException('No class is set'));
         $file->setClass(Argument::type(ClassGenerator::class))->shouldBeCalled();
 
-        $client->getMethodMap()->willReturn($map);
-        $map->getMethods()->willReturn([$method]);
-        $client->getNamespace()->willReturn('MyNamespace');
-        $client->getName()->willReturn('MyClient');
+        $client = new Client(
+            new ClientConfig('MyClient', new Destination('', 'MyNamespace')),
+            new ClientMethodMap([$method])
+        );
         $this->generate($file, $client)->shouldReturn('code');
     }
 
-    private function it_generates_clients_for_file_without_classes(RuleSetInterface $ruleSet, FileGenerator $file, Client $client, ClientMethodMap $map, ClassGenerator $class)
+    function it_generates_clients_for_file_without_classes(RuleSetInterface $ruleSet, FileGenerator $file, ClassGenerator $class)
     {
+        $typeNamespaceMap = TypeNamespaceMap::create(new Destination('/app', ''));
         $method = new ClientMethod(
             'Test',
-            [new Parameter('parameters', 'Test', '', XsdType::create('Test'))],
-            ReturnType::fromMetaData('', XsdType::create('TestResponse')),
-            '',
+            [new Parameter('parameters', 'Test', $typeNamespaceMap, XsdType::create('Test'))],
+            ReturnType::fromMetaData($typeNamespaceMap, XsdType::create('TestResponse')),
+            $typeNamespaceMap,
             new MethodMeta()
         );
 
         $ruleSet->applyRules(Argument::type(ClientMethodContext::class))->shouldBeCalled();
+        $ruleSet->applyRules(Argument::type(ClientContext::class))->shouldBeCalled();
+        $ruleSet->applyRules(Argument::type(FileContext::class))->shouldBeCalled();
         $file->generate()->willReturn('code');
 
         $file->getClass()->willReturn($class);
         $file->setClass($class)->shouldBeCalled();
-
-        $client->getMethodMap()->willReturn($map);
-        $map->getMethods()->willReturn([$method]);
-        $client->getNamespace()->willReturn('MyNamespace');
-        $client->getName()->willReturn('MyClient');
+        $client = new Client(
+            new ClientConfig('MyClient', new Destination('', 'MyNamespace')),
+            new ClientMethodMap([$method])
+        );
         $this->generate($file, $client)->shouldReturn('code');
     }
 }

--- a/spec/Phpro/SoapClient/CodeGenerator/Config/ConfigSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Config/ConfigSpec.php
@@ -2,11 +2,13 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Config;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
-use Phpro\SoapClient\CodeGenerator\Config\ConfigInterface;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSet;
 use Phpro\SoapClient\Exception\InvalidArgumentException;
-use Phpro\SoapClient\Util\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Soap\Engine\Engine;
 
@@ -34,9 +36,9 @@ class ConfigSpec extends ObjectBehavior
         $this->shouldThrow(InvalidArgumentException::class)->duringGetEngine();
     }
 
-    function it_requires_a_typedestination()
+    function it_requires_a_type_namespace_map()
     {
-        $this->shouldThrow(InvalidArgumentException::class)->duringGetTypeDestination();
+        $this->shouldThrow(InvalidArgumentException::class)->duringGetTypeNamespaceMap();
     }
 
     function it_has_a_ruleset()
@@ -45,38 +47,37 @@ class ConfigSpec extends ObjectBehavior
         $this->getRuleSet()->shouldBe($value);
     }
 
-    public function it_has_a_type_destination()
+    public function it_has_a_type_namespace_map()
     {
-        $this->setTypeDestination($value = 'src/type');
-        $this->getTypeDestination()->shouldBe($value);
+        $destination = new Destination('src/type', 'TypeNamespace');
+        $value = TypeNamespaceMap::create($destination);
+        $this->setTypeNamespaceMap($value);
+        $this->getTypeNamespaceMap()->shouldBe($value);
     }
 
-    public function it_has_a_client_destination()
+    public function it_has_a_client_config()
     {
-        $this->setClientDestination($value = 'src/client');
-        $this->getClientDestination()->shouldBe($value);
+        $destination = new Destination('src/client', 'ClientNamespace');
+        $value = new ClientConfig('ClientName', $destination);
+        $this->setClient($value);
+        $this->getClient()->shouldBe($value);
     }
 
-    public function it_has_a_type_namespace()
+    public function it_requires_a_client_config()
     {
-        $this->setTypeNamespace($value = 'TypeNamespace');
-        $this->getTypeNamespace()->shouldBe($value);
+        $this->shouldThrow(InvalidArgumentException::class)->duringGetClient();
     }
 
-    public function it_has_a_client_namespace()
+    public function it_has_a_classmap_config()
     {
-        $this->setClientNamespace($value = 'ClientNamespace');
-        $this->getClientNamespace()->shouldBe($value);
+        $destination = new Destination('src/classmap', 'ClassMapNamespace');
+        $value = new ClassMapConfig('ClassMapName', $destination);
+        $this->setClassMap($value);
+        $this->getClassMap()->shouldBe($value);
     }
 
-    public function it_requires_a_client_namespace()
+    public function it_requires_a_classmap_config()
     {
-        $this->shouldThrow(InvalidArgumentException::class)->duringGetClientNamespace();
-    }
-
-    public function it_has_a_client_name()
-    {
-        $this->setClientName($value = 'ClientName');
-        $this->getClientName()->shouldBe($value);
+        $this->shouldThrow(InvalidArgumentException::class)->duringGetClassMap();
     }
 }

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClassMapContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClassMapContextSpec.php
@@ -2,11 +2,13 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Laminas\Code\Generator\FileGenerator;
 
 /**
@@ -17,16 +19,25 @@ use Laminas\Code\Generator\FileGenerator;
  */
 class ClassMapContextSpec extends ObjectBehavior
 {
-    function let(FileGenerator $fileGenerator, TypeMap $typeMap)
+    private TypeMap $typeMap;
+
+    function let(FileGenerator $fileGenerator)
     {
-        $this->beConstructedWith($fileGenerator, $typeMap, 'ClassMap', 'App\\Mynamespace');
+        $typeDestination = new Destination('src/type', 'App\\Mynamespace');
+        $namespaceMap = TypeNamespaceMap::create($typeDestination);
+        $this->typeMap = new TypeMap($namespaceMap, []);
+
+        $classMapDestination = new Destination('src/classmap', 'App\\Mynamespace');
+        $classMapConfig = new ClassMapConfig('ClassMap', $classMapDestination);
+
+        $this->beConstructedWith($fileGenerator, $this->typeMap, $classMapConfig);
     }
 
     function it_is_initializable()
     {
         $this->shouldHaveType(ClassMapContext::class);
     }
-    
+
     function it_is_a_context()
     {
         $this->shouldImplement(ContextInterface::class);
@@ -37,8 +48,8 @@ class ClassMapContextSpec extends ObjectBehavior
         $this->getFile()->shouldReturn($fileGenerator);
     }
 
-    function it_has_a_typemap(TypeMap $typeMap)
+    function it_has_a_typemap()
     {
-        $this->getTypeMap()->shouldReturn($typeMap);
+        $this->getTypeMap()->shouldReturn($this->typeMap);
     }
 }

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClientContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClientContextSpec.php
@@ -3,21 +3,24 @@
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
 use Laminas\Code\Generator\ClassGenerator;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
-use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use PhpSpec\ObjectBehavior;
 
 /**
- * Class TypeContextSpec
+ * Class ClientContextSpec
  *
  * @package spec\Phpro\SoapClient\CodeGenerator\Context
- * @mixin TypeContext
+ * @mixin ClientContext
  */
 class ClientContextSpec extends ObjectBehavior
 {
     function let(ClassGenerator $class)
     {
-        $this->beConstructedWith($class, 'MyClient', 'App\Client');
+        $destination = new Destination('src/client', 'App\Client');
+        $clientConfig = new ClientConfig('MyClient', $destination);
+        $this->beConstructedWith($class, $clientConfig);
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContextSpec.php
@@ -3,13 +3,14 @@
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
 use Laminas\Code\Generator\ClassGenerator;
-use Phpro\SoapClient\CodeGenerator\Config\Config;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Phpro\SoapClient\CodeGenerator\Context\ClientFactoryContext;
 use Laminas\Code\Generator\FileGenerator;
 
@@ -20,12 +21,18 @@ class ClientFactoryContextSpec extends ObjectBehavior
 {
     function let()
     {
-        $clientContext = new ClientContext(new ClassGenerator(), 'Myclient', 'App\\Client');
+        $clientDestination = new Destination('src/client', 'App\\Client');
+        $clientConfig = new ClientConfig('Myclient', $clientDestination);
+        $clientContext = new ClientContext(new ClassGenerator(), $clientConfig);
+
+        $classMapDestination = new Destination('src/classmap', 'App\\Classmap');
+        $typeDestination = new Destination('src/type', 'ns');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($typeDestination);
+        $classMapConfig = new ClassMapConfig('Myclassmap', $classMapDestination);
         $classMapContext = new ClassMapContext(
             new FileGenerator(),
-            new TypeMap('ns', []),
-            'Myclassmap',
-            'App\\Classmap'
+            new TypeMap($namespaceMap, []),
+            $classMapConfig
         );
         $this->beConstructedWith($clientContext, $classMapContext);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContextSpec.php
@@ -2,24 +2,41 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
-use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
+use Phpro\SoapClient\CodeGenerator\Model\ReturnType;
 use PhpSpec\ObjectBehavior;
 use Laminas\Code\Generator\ClassGenerator;
+use Soap\Engine\Metadata\Model\MethodMeta;
+use Soap\Engine\Metadata\Model\XsdType;
 
 /**
  * Class ClientMethodContextSpec
  *
  * @package spec\Phpro\SoapClient\CodeGenerator\Context
- * @mixin TypeContext
+ * @mixin ClientMethodContext
  */
 class ClientMethodContextSpec extends ObjectBehavior
 {
-    function let(ClassGenerator $class, ClientMethod $method)
+    private ClientMethod $method;
+
+    function let(ClassGenerator $class)
     {
-        $this->beConstructedWith($class, $method);
+        $destination = new Destination('src/type', 'ParamNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+
+        $this->method = new ClientMethod(
+            'testMethod',
+            [],
+            ReturnType::fromMetaData($namespaceMap, XsdType::create('CreditResponse')),
+            $namespaceMap,
+            new MethodMeta()
+        );
+
+        $this->beConstructedWith($class, $this->method);
     }
 
     function it_is_initializable()
@@ -37,8 +54,8 @@ class ClientMethodContextSpec extends ObjectBehavior
         $this->getClass()->shouldReturn($class);
     }
 
-    function it_has_a_method(ClientMethod $method)
+    function it_has_a_method()
     {
-        $this->getMethod()->shouldReturn($method);
+        $this->getMethod()->shouldReturn($this->method);
     }
 }

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ConfigContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ConfigContextSpec.php
@@ -2,9 +2,11 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
 
 /**
@@ -22,10 +24,23 @@ class ConfigContextSpec extends ObjectBehavior
         $this->shouldImplement(ContextInterface::class);
     }
 
-    function it_adds_setters()
+    function it_has_type_namespace_fallback()
     {
-        $this->addSetter('setTest', 'test\'run');
-        $this->getSetters()->shouldBeArray();
-        $this->getSetters()['setTest']->shouldBe('test\'run');
+        $this->setTypeDestination($destination = new Destination('src/type', 'App\\Type'));
+        $this->getTypeDestination()->shouldBe($destination);
+    }
+
+    function it_has_client_config()
+    {
+        $clientConfig = new ClientConfig('MyClient', new Destination('src/client', 'App\\Client'));
+        $this->setClientConfig($clientConfig);
+        $this->getClientConfig()->shouldBe($clientConfig);
+    }
+
+    function it_has_classmap_config()
+    {
+        $classMapConfig = new ClassMapConfig('MyClassmap', new Destination('src/classmap', 'App\\Classmap'));
+        $this->setClassMapConfig($classMapConfig);
+        $this->getClassMapConfig()->shouldBe($classMapConfig);
     }
 }

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/PropertyContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/PropertyContextSpec.php
@@ -2,13 +2,15 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Laminas\Code\Generator\ClassGenerator;
+use Soap\Engine\Metadata\Model\XsdType;
 
 /**
  * Class PropertyContextSpec
@@ -18,11 +20,26 @@ use Laminas\Code\Generator\ClassGenerator;
  */
 class PropertyContextSpec extends ObjectBehavior
 {
-    function let(ClassGenerator $class, Type $type, Property $property)
+    private Type $type;
+    private Property $property;
+
+    function let(ClassGenerator $class)
     {
-        $this->beConstructedWith($class, $type, $property);
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+
+        $this->property = new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
+        $this->type = new Type(
+            $namespaceMap,
+            'MyType',
+            'MyType',
+            [$this->property],
+            XsdType::create('MyType')
+        );
+
+        $this->beConstructedWith($class, $this->type, $this->property);
     }
-    
+
     function it_is_initializable()
     {
         $this->shouldHaveType(PropertyContext::class);
@@ -32,19 +49,19 @@ class PropertyContextSpec extends ObjectBehavior
     {
         $this->shouldImplement(ContextInterface::class);
     }
-    
+
     function it_has_a_class_generator(ClassGenerator $class)
     {
         $this->getClass()->shouldReturn($class);
     }
-    
-    function it_has_a_type(Type $type)
+
+    function it_has_a_type()
     {
-        $this->getType()->shouldReturn($type);
+        $this->getType()->shouldReturn($this->type);
     }
-    
-    function it_has_a_property(Property $property)
+
+    function it_has_a_property()
     {
-        $this->getProperty()->shouldReturn($property);
+        $this->getProperty()->shouldReturn($this->property);
     }
 }

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/TypeContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/TypeContextSpec.php
@@ -2,12 +2,14 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Laminas\Code\Generator\ClassGenerator;
+use Soap\Engine\Metadata\Model\XsdType;
 
 /**
  * Class TypeContextSpec
@@ -17,9 +19,20 @@ use Laminas\Code\Generator\ClassGenerator;
  */
 class TypeContextSpec extends ObjectBehavior
 {
-    function let(ClassGenerator $class, Type $type)
+    private Type $type;
+
+    function let(ClassGenerator $class)
     {
-        $this->beConstructedWith($class, $type);
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $this->type = new Type(
+            $namespaceMap,
+            'MyType',
+            'MyType',
+            [],
+            XsdType::create('MyType')
+        );
+        $this->beConstructedWith($class, $this->type);
     }
 
     function it_is_initializable()
@@ -37,8 +50,8 @@ class TypeContextSpec extends ObjectBehavior
         $this->getClass()->shouldReturn($class);
     }
 
-    function it_has_a_type(Type $type)
+    function it_has_a_type()
     {
-        $this->getType()->shouldReturn($type);
+        $this->getType()->shouldReturn($this->type);
     }
 }

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ClientMethodSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ClientMethodSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
 use Phpro\SoapClient\CodeGenerator\Model\ReturnType;
 use PhpSpec\ObjectBehavior;
@@ -18,11 +20,13 @@ class ClientMethodSpec extends ObjectBehavior
 {
     function let()
     {
+        $destination = new Destination('src/type', 'ParamNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
         $this->beConstructedWith(
             'testMethod',
             [],
-            ReturnType::fromMetaData('ParamNamespace', XsdType::create('CreditResponse')),
-            'ParamNamespace',
+            ReturnType::fromMetaData($namespaceMap, XsdType::create('CreditResponse')),
+            $namespaceMap,
             new MethodMeta()
         );
     }
@@ -49,14 +53,11 @@ class ClientMethodSpec extends ObjectBehavior
 
     function is_has_a_return_type()
     {
+        $destination = new Destination('src/type', 'ParamNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
         $this->getReturnType()->shouldBeLike(
-            ReturnType::fromMetaData('ParamNamespace', XsdType::create('CreditResponse'))
+            ReturnType::fromMetaData($namespaceMap, XsdType::create('CreditResponse'))
         );
-    }
-
-    function it_has_a_parameter_namespace()
-    {
-        $this->getParameterNamespace()->shouldBe('ParamNamespace');
     }
 
     public function it_has_type_meta(): void

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ClientSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ClientSpec.php
@@ -2,22 +2,26 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Model\Client;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethodMap;
-use Phpro\SoapClient\CodeGenerator\Model\Property;
 use PhpSpec\ObjectBehavior;
 
 /**
  * Class ClientSpec
  *
  * @package spec\Phpro\SoapClient\CodeGenerator\Model
- * @mixin Property
+ * @mixin Client
  */
 class ClientSpec extends ObjectBehavior
 {
-    function let(ClientMethodMap $methods)
+    function let()
     {
-        $this->beConstructedWith('MyClient', 'MyNamespace', $methods);
+        $destination = new Destination('src/client', 'MyNamespace');
+        $clientConfig = new ClientConfig('MyClient', $destination);
+        $methods = new ClientMethodMap([]);
+        $this->beConstructedWith($clientConfig, $methods);
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ParameterSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ParameterSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Model\Parameter;
 use PhpSpec\ObjectBehavior;
 use Soap\Engine\Metadata\Model\TypeMeta;
@@ -17,7 +19,9 @@ class ParameterSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('MyParameter', 'MyParameterType', 'MyNamespace', XsdType::create('MyParameter'));
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $this->beConstructedWith('MyParameter', 'MyParameterType', $namespaceMap, XsdType::create('MyParameter'));
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/PropertySpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/PropertySpec.php
@@ -2,9 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
@@ -18,7 +19,9 @@ class PropertySpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('name', 'Type', 'My\Namespace', XsdType::create('Type'));
+        $destination = new Destination('src/type', 'My\Namespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $this->beConstructedWith('name', 'Type', $namespaceMap, 'My\Namespace', XsdType::create('Type'));
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ReturnTypeSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ReturnTypeSpec.php
@@ -2,9 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Model\ReturnType;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
@@ -18,7 +19,9 @@ class ReturnTypeSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('Type', 'My\Namespace', XsdType::create('Type'));
+        $destination = new Destination('src/type', 'My\Namespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $this->beConstructedWith('Type', $namespaceMap, XsdType::create('Type'));
     }
 
     function it_is_initializable()
@@ -33,9 +36,11 @@ class ReturnTypeSpec extends ObjectBehavior
 
     function it_can_fall_back_to_mixed_on_unkown_extension_of_simple_type()
     {
+        $destination = new Destination('src/type', 'My\Namespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
         $this->beConstructedWith(
             'Type',
-            'My\Namespace',
+            $namespaceMap,
             XsdType::create('Type')
                 ->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true))
         );
@@ -45,9 +50,11 @@ class ReturnTypeSpec extends ObjectBehavior
 
     function it_can_fall_back_to_simple_type()
     {
+        $destination = new Destination('src/type', 'My\Namespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
         $this->beConstructedWith(
             'Type',
-            'My\Namespace',
+            $namespaceMap,
             XsdType::create('Type')
                 ->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true)->withExtends([
                     'isSimple' => true,
@@ -66,10 +73,12 @@ class ReturnTypeSpec extends ObjectBehavior
 
     public function it_falls_back_to_complex_type_if_its_an_element_referencing_this_type(): void
     {
+        $destination = new Destination('src/type', 'My\Namespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
         $this->beConstructedThrough(
             'fromMetaData',
             [
-                'My\Namespace',
+                $namespaceMap,
                 XsdType::create('ElementType')
                     ->withXmlTypeName('ComplexType')
             ]

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/TypeMapSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/TypeMapSpec.php
@@ -2,12 +2,12 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
 /**
@@ -20,9 +20,11 @@ class TypeMapSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith($namespace = 'MyNamespace', [
-            new Type($namespace, 'type1', 'type1', [
-                new Property('prop1', 'string', $namespace, XsdType::create('string'))
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $this->beConstructedWith($namespaceMap, [
+            new Type($namespaceMap, 'type1', 'type1', [
+                new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))
             ], XsdType::create('MyType'))
         ]);
     }
@@ -30,11 +32,6 @@ class TypeMapSpec extends ObjectBehavior
     function it_is_initializable()
     {
         $this->shouldHaveType(TypeMap::class);
-    }
-
-    function it_has_a_namespace()
-    {
-        $this->getNamespace()->shouldReturn('MyNamespace');
     }
 
     function it_has_types()

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/TypeSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/TypeSpec.php
@@ -2,11 +2,12 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
@@ -20,11 +21,13 @@ class TypeSpec extends ObjectBehavior
 {
     function let()
     {
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
         $this->beConstructedWith(
-            $namespace = 'MyNamespace',
+            $namespaceMap,
             'myType',
             'MyType',
-            [new Property('prop1', 'string', $namespace, XsdType::create('string'))],
+            [new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))],
             XsdType::create('MyType')
         );
     }
@@ -60,21 +63,25 @@ class TypeSpec extends ObjectBehavior
 
     function it_should_not_replace_underscores_in_paths()
     {
-        $this->beConstructedWith('MyNamespace', 'my_type_3_2', Normalizer::normalizeClassname('my_type_3_2'), ['prop1' => 'string'], XsdType::create('MyType'));
-        $this->getFileInfo('my/some_dir')->getPathname()->shouldReturn('my/some_dir/MyType32.php');
+        $destination = new Destination('my/some_dir', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $this->beConstructedWith($namespaceMap, 'my_type_3_2', Normalizer::normalizeClassname('my_type_3_2'), ['prop1' => 'string'], XsdType::create('MyType'));
+        $this->getFileInfo()->getPathname()->shouldReturn('my/some_dir/MyType32.php');
     }
 
     function it_should_prefix_reserved_keywords()
     {
+        $destination = new Destination('my/some_dir', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
         $this->beConstructedWith(
-            $namespace = 'MyNamespace',
+            $namespaceMap,
             'Final',
             Normalizer::normalizeClassname('Final'),
-            [new Property('xor', 'string', $namespace, XsdType::create('string'))],
+            [new Property('xor', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))],
             XsdType::create('MyType')
         );
 
-        $this->getFileInfo('my/some_dir')->getPathname()->shouldReturn('my/some_dir/FinalType.php');
+        $this->getFileInfo()->getPathname()->shouldReturn('my/some_dir/FinalType.php');
         $this->getName()->shouldReturn('FinalType');
         $this->getProperties()[0]->getName()->shouldReturn('xor');
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRuleSpec.php
@@ -2,12 +2,13 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
+use Laminas\Code\Generator\ClassGenerator;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
-use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
 use Phpro\SoapClient\CodeGenerator\Model\ReturnType;
-use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
 use Phpro\SoapClient\CodeGenerator\Rules\ClientMethodMatchesRule;
 use PhpSpec\ObjectBehavior;
@@ -43,43 +44,53 @@ class ClientMethodMatchesRuleSpec extends ObjectBehavior
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_to_client_method_context(RuleInterface $subRule, ClientMethodContext $context)
+    function it_can_apply_to_client_method_context(RuleInterface $subRule)
     {
-        $context->getMethod()->willReturn(new ClientMethod(
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $method = new ClientMethod(
             'myClientMethod',
             [],
-            ReturnType::fromMetaData('', XsdType::create('string')),
-            '',
+            ReturnType::fromMetaData($namespaceMap, XsdType::create('string')),
+            $namespaceMap,
             new MethodMeta()
-        ));
+        );
+        $context = new ClientMethodContext(new ClassGenerator(), $method);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_not_apply_on_unmatched_regex(RuleInterface $subRule, ClientMethodContext $context)
+    function it_can_not_apply_on_unmatched_regex(RuleInterface $subRule)
     {
-        $context->getMethod()->willReturn(new ClientMethod(
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $method = new ClientMethod(
             'myInvalidClientMethod',
             [],
-            ReturnType::fromMetaData('', XsdType::create('string')),
-            '',
+            ReturnType::fromMetaData($namespaceMap, XsdType::create('string')),
+            $namespaceMap,
             new MethodMeta()
-        ));
+        );
+        $context = new ClientMethodContext(new ClassGenerator(), $method);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_not_apply_if_subrule_does_not_apply(RuleInterface $subRule, ClientMethodContext $context)
+    function it_can_not_apply_if_subrule_does_not_apply(RuleInterface $subRule)
     {
-        $context->getMethod()->willReturn(new ClientMethod(
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $method = new ClientMethod(
             'myClientMethod',
             [],
-            ReturnType::fromMetaData('', XsdType::create('string')),
-            '',
+            ReturnType::fromMetaData($namespaceMap, XsdType::create('string')),
+            $namespaceMap,
             new MethodMeta()
-        ));
-        
+        );
+        $context = new ClientMethodContext(new ClassGenerator(), $method);
+
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRuleSpec.php
@@ -56,30 +56,47 @@ class IsAbstractTypeRuleSpec extends ObjectBehavior
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_to_type_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
+    function it_can_apply_to_property_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($namespaceMap, 'MyAbstract', 'MyAbstract', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
+    function it_can_not_apply_on_invalid_type(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'NotAbstract', 'NotAbstract', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'NotAbstract', 'NotAbstract', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRuleSpec.php
@@ -59,30 +59,47 @@ class IsExtendingTypeRuleSpec extends ObjectBehavior
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_to_type_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', 'MyExtending', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'MyExtending', 'MyExtending', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
+    function it_can_apply_to_property_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', 'MyExtending', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($namespaceMap, 'MyExtending', 'MyExtending', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
+    function it_can_not_apply_on_invalid_type(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'NotExtending', 'NotExtending', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'NotExtending', 'NotExtending', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'MyExtending', 'MyExtending', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'MyExtending', 'MyExtending', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRuleSpec.php
@@ -54,30 +54,47 @@ class IsRequestRuleSpec extends ObjectBehavior
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_to_type_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', 'RequestType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'RequestType', 'RequestType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
+    function it_can_apply_to_property_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', 'RequestType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($namespaceMap, 'RequestType', 'RequestType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
+    function it_can_not_apply_on_invalid_type(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'RequestType', 'RequestType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'RequestType', 'RequestType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsResultRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsResultRuleSpec.php
@@ -54,30 +54,47 @@ class IsResultRuleSpec extends ObjectBehavior
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_to_type_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', 'ResultType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'ResultType', 'ResultType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_apply_to_property_context(RuleInterface $subRule, PropertyContext $context)
+    function it_can_apply_to_property_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', 'ResultType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($namespaceMap, 'ResultType', 'ResultType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_not_apply_on_invalid_type(RuleInterface $subRule, TypeContext $context)
+    function it_can_not_apply_on_invalid_type(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'ResultType', 'ResultType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'ResultType', 'ResultType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/PropertynameMatchesRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/PropertynameMatchesRuleSpec.php
@@ -2,16 +2,16 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
+use Laminas\Code\Generator\ClassGenerator;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
-use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
 use Phpro\SoapClient\CodeGenerator\Rules\PropertynameMatchesRule;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
 /**
@@ -43,23 +43,38 @@ class PropertynameMatchesRuleSpec extends ObjectBehavior
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_to_property_context( RuleInterface $subRule, PropertyContext $context)
+    function it_can_apply_to_property_context(RuleInterface $subRule)
     {
-        $context->getProperty()->willReturn(new Property('myProperty', 'string', 'ns1', XsdType::create('string')));
+        $destination = new Destination('src/type', 'ns1');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $property = new Property('myProperty', 'string', $namespaceMap, 'ns1', XsdType::create('string'));
+        $type = new Type($namespaceMap, 'MyType', 'MyType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new ClassGenerator(), $type, $property);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_not_apply_on_invalid_regex(RuleInterface $subRule, PropertyContext $context)
+    function it_can_not_apply_on_invalid_regex(RuleInterface $subRule)
     {
-        $context->getProperty()->willReturn(new Property('InvalidTypeName', 'string', 'ns1', XsdType::create('string')));
+        $destination = new Destination('src/type', 'ns1');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $property = new Property('InvalidTypeName', 'string', $namespaceMap, 'ns1', XsdType::create('string'));
+        $type = new Type($namespaceMap, 'MyType', 'MyType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new ClassGenerator(), $type, $property);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, PropertyContext $context)
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule)
     {
-        $context->getProperty()->willReturn(new Property('MyProperty', 'string', 'ns1', XsdType::create('string')));
+        $destination = new Destination('src/type', 'ns1');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $property = new Property('MyProperty', 'string', $namespaceMap, 'ns1', XsdType::create('string'));
+        $type = new Type($namespaceMap, 'MyType', 'MyType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new ClassGenerator(), $type, $property);
+
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRuleSpec.php
@@ -46,50 +46,79 @@ class TypeMapRuleSpec extends ObjectBehavior
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_to_type_context(RuleInterface $rule, TypeContext $context)
+    function it_can_apply_to_type_context(RuleInterface $rule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', 'SomeType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'SomeType', 'SomeType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $rule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_apply_to_property_context(RuleInterface $rule, PropertyContext $context)
+    function it_can_apply_to_property_context(RuleInterface $rule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', 'SomeType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($namespaceMap, 'SomeType', 'SomeType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+
         $rule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_apply_the_default_assembler_to_unknown_types(RuleInterface $defaultRule, TypeContext $context)
+    function it_can_apply_the_default_assembler_to_unknown_types(RuleInterface $defaultRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'UnknownType', 'UnknownType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'UnknownType', 'UnknownType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $defaultRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_not_apply_to_knwon_types_with_no_rule(TypeContext $context)
+    function it_can_not_apply_to_knwon_types_with_no_rule()
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'NullType', 'NullType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'NullType', 'NullType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_not_apply_if_rule_does_not_apply(RuleInterface $rule, TypeContext $context)
+    function it_can_not_apply_if_rule_does_not_apply(RuleInterface $rule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', 'SomeType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'SomeType', 'SomeType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $rule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_applies_a_specified_rule_to_known_types(RuleInterface $rule, TypeContext $context)
+    function it_applies_a_specified_rule_to_known_types(RuleInterface $rule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'SomeType', 'SomeType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'SomeType', 'SomeType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $rule->apply($context)->shouldBeCalled();
         $this->apply($context);
     }
 
-    function it_applies_the_default_rule_to_unknown_types(RuleInterface $defaultRule, TypeContext $context)
+    function it_applies_the_default_rule_to_unknown_types(RuleInterface $defaultRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'UnknownType', 'UnknownType', [], XsdType::create('MyType')));
+        $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
+        $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'UnknownType', 'UnknownType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+
         $defaultRule->apply($context)->shouldBeCalled();
         $this->apply($context);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/TypenameMatchesRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/TypenameMatchesRuleSpec.php
@@ -2,15 +2,17 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
+use Laminas\Code\Generator\ClassGenerator;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
+use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
 use Phpro\SoapClient\CodeGenerator\Rules\TypenameMatchesRule;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
 /**
@@ -42,30 +44,47 @@ class TypenameMatchesRuleSpec extends ObjectBehavior
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_to_type_context(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_to_type_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'TypeName', 'TypeName', [], XsdType::create('MyType')));
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'TypeName', 'TypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_apply_to_property_context( RuleInterface $subRule, PropertyContext $context)
+    function it_can_apply_to_property_context(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'TypeName', 'TypeName', [], XsdType::create('MyType')));
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $property = new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($namespaceMap, 'TypeName', 'TypeName', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new ClassGenerator(), $type, $property);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
     }
 
-    function it_can_not_apply_on_invalid_regex(RuleInterface $subRule, TypeContext $context)
+    function it_can_not_apply_on_invalid_regex(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType')));
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
     }
 
-    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule, TypeContext $context)
+    function it_can_apply_if_subrule_does_not_apply(RuleInterface $subRule)
     {
-        $context->getType()->willReturn(new Type('MyNamespace', 'TypeName', 'TypeName', [], XsdType::create('MyType')));
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
+        $type = new Type($namespaceMap, 'TypeName', 'TypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new ClassGenerator(), $type);
+
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/TypeGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/TypeGeneratorSpec.php
@@ -3,6 +3,8 @@
 namespace spec\Phpro\SoapClient\CodeGenerator;
 
 use Laminas\Code\Generator\Exception\ClassNotFoundException;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\FileContext;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
@@ -16,7 +18,6 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\FileGenerator;
-use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
 /**
@@ -45,11 +46,13 @@ class TypeGeneratorSpec extends ObjectBehavior
 
     function it_generates_types(RuleSetInterface $ruleSet, FileGenerator $file, ClassGenerator $class)
     {
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
         $type = new Type(
-            $namespace = 'MyNamespace',
+            $namespaceMap,
             'MyType',
             'MyType',
-            [new Property('prop1', 'string', $namespace, XsdType::create('string'))],
+            [new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))],
             XsdType::create('MyType')
         );
         $property = $type->getProperties()[0];
@@ -70,11 +73,13 @@ class TypeGeneratorSpec extends ObjectBehavior
 
     function it_generates_types_for_file_without_classes(RuleSetInterface $ruleSet, FileGenerator $file, ClassGenerator $class)
     {
+        $destination = new Destination('src/type', 'MyNamespace');
+        $namespaceMap = TypeNamespaceMap::create($destination);
         $type = new Type(
-            $namespace = 'MyNamespace',
+            $namespaceMap,
             'MyType',
             'MyType',
-            [new Property('prop1', 'string', $namespace, XsdType::create('string'))],
+            [new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))],
             XsdType::create('MyType')
         );
         $property = $type->getProperties()[0];

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClassMapAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClassMapAssembler.php
@@ -42,8 +42,6 @@ class ClassMapAssembler implements AssemblerInterface
         $file->setClass($class);
         $file->setNamespace($context->getNamespace());
         $typeMap = $context->getTypeMap();
-        $typeNamespace = $typeMap->getNamespace();
-        $file->setUse($typeNamespace, preg_match('/\\\\Type$/', $typeNamespace) ? null : 'Type');
 
         try {
             $file->setUse(ClassMapCollection::class);
@@ -117,7 +115,7 @@ class ClassMapAssembler implements AssemblerInterface
                 $indentation,
                 $type->getXsdType()->getXmlNamespace(),
                 $type->getXsdType()->getName(),
-                'Type\\'.$type->getName()
+                '\\' . $type->getFullName(),
             );
         }
 

--- a/src/Phpro/SoapClient/CodeGenerator/ClassMapGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClassMapGenerator.php
@@ -2,9 +2,9 @@
 
 namespace Phpro\SoapClient\CodeGenerator;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Context\FileContext;
-use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSetInterface;
 use Laminas\Code\Generator\FileGenerator;
@@ -14,33 +14,10 @@ use Laminas\Code\Generator\FileGenerator;
  */
 class ClassMapGenerator implements GeneratorInterface
 {
-    /**
-     * @var RuleSetInterface
-     */
-    private $ruleSet;
-
-    /**
-     * @var string
-     */
-    private $name;
-
-    /**
-     * @var string
-     */
-    private $namespace;
-
-    /**
-     * TypeGenerator constructor.
-     *
-     * @param RuleSetInterface $ruleSet
-     * @param string           $name
-     * @param string           $namespace
-     */
-    public function __construct(RuleSetInterface $ruleSet, string $name, string $namespace)
-    {
-        $this->ruleSet = $ruleSet;
-        $this->name = $name;
-        $this->namespace = $namespace;
+    public function __construct(
+        private RuleSetInterface $ruleSet,
+        private ClassMapConfig $classMap
+    ) {
     }
 
     /**
@@ -51,7 +28,7 @@ class ClassMapGenerator implements GeneratorInterface
      */
     public function generate(FileGenerator $file, $typeMap): string
     {
-        $this->ruleSet->applyRules(new ClassMapContext($file, $typeMap, $this->name, $this->namespace));
+        $this->ruleSet->applyRules(new ClassMapContext($file, $typeMap, $this->classMap));
         $this->ruleSet->applyRules(new FileContext($file));
 
         return $file->generate();

--- a/src/Phpro/SoapClient/CodeGenerator/ClientGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClientGenerator.php
@@ -50,7 +50,7 @@ class ClientGenerator implements GeneratorInterface
         $class->setNamespaceName($client->getNamespace());
         $class->setName($client->getName());
 
-        $this->ruleSet->applyRules(new ClientContext($class, $client->getName(), $client->getNamespace()));
+        $this->ruleSet->applyRules(new ClientContext($class, $client->config()));
 
         $methods = $client->getMethodMap();
         foreach ($methods->getMethods() as $method) {

--- a/src/Phpro/SoapClient/CodeGenerator/Config/ClassMapConfig.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/ClassMapConfig.php
@@ -18,7 +18,7 @@ final readonly class ClassMapConfig
      */
     public function path(): string
     {
-        return $this->destination->path . '/' . $this->name . '.php';
+        return rtrim($this->destination->path, '/') . '/' . $this->name . '.php';
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Config/ClassMapConfig.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/ClassMapConfig.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Config;
+
+final readonly class ClassMapConfig
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        public string $name,
+        public Destination $destination,
+    ) {
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function path(): string
+    {
+        return $this->destination->path . '/' . $this->name . '.php';
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function fqcn(): string
+    {
+        return $this->destination->namespace . '\\' . $this->name;
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Config/ClientConfig.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/ClientConfig.php
@@ -18,7 +18,7 @@ final readonly class ClientConfig
      */
     public function path(): string
     {
-        return $this->destination->path . '/' . $this->name . '.php';
+        return rtrim($this->destination->path, '/') . '/' . $this->name . '.php';
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Config/ClientConfig.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/ClientConfig.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Config;
+
+final readonly class ClientConfig
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        public string $name,
+        public Destination $destination,
+    ) {
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function path(): string
+    {
+        return $this->destination->path . '/' . $this->name . '.php';
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function fqcn(): string
+    {
+        return $this->destination->namespace . '\\' . $this->name;
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
@@ -2,12 +2,12 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Config;
 
+use Closure;
 use Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSet;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSetInterface;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\InvalidArgumentException;
 use Phpro\SoapClient\Soap\Metadata\Detector\LocalEnumDetector;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\IntersectDuplicateTypesStrategy;
@@ -28,62 +28,23 @@ use Soap\Engine\Metadata\Metadata;
 
 final class Config
 {
-    /**
-     * @var string
-     */
-    protected $clientName = 'Client';
+    protected ?ClientConfig $client = null;
+
+    protected ?TypeNamespaceMap $typeNamespaceMap = null;
+    protected ?Engine $engine = null;
 
     /**
-     * @var string
+     * @var TypesManipulatorInterface|Closure(?TypeNamespaceMap): TypesManipulatorInterface
      */
-    protected $typeNamespace = '';
-
-    /**
-     * @var string
-     */
-    protected $clientNamespace = '';
-
-    /**
-     * @var Engine|null
-     */
-    protected $engine = null;
-
-    /**
-     * @var string
-     */
-    protected $clientDestination = '';
-
-    /**
-     * @var string
-     */
-    protected $typeDestination = '';
-
-    protected TypesManipulatorInterface $duplicateTypeIntersectStrategy;
+    protected TypesManipulatorInterface|Closure $duplicateTypeIntersectStrategy;
 
     protected TypeReplacer $typeReplacementStrategy;
 
     protected ?MetadataOptions $metadataOptions = null;
 
-    /**
-     * @var RuleSetInterface
-     */
-    protected $ruleSet;
+    protected RuleSetInterface $ruleSet;
 
-    /**
-     * @var string
-     */
-    protected $classMapName;
-
-    /**
-     * @var string
-     */
-    protected $classMapNamespace;
-
-    /**
-     * @var string
-     */
-    protected $classMapDestination;
-
+    protected ?ClassMapConfig $classMap = null;
     protected EnumerationGenerationStrategy $enumerationGenerationStrategy;
 
     public function __construct()
@@ -93,7 +54,7 @@ final class Config
         // Working with duplicate types is hard (see FAQ).
         // Therefore, we decided to combine all duplicate types into 1 big intersected type by default instead.
         // The resulting type will always be usable, but might contain some additional empty properties.
-        $this->duplicateTypeIntersectStrategy = new IntersectDuplicateTypesStrategy();
+        $this->duplicateTypeIntersectStrategy = IntersectDuplicateTypesStrategy::create();
 
         // By default, we only generate global enumerations to avoid naming conflicts.
         $this->enumerationGenerationStrategy = EnumerationGenerationStrategy::default();
@@ -106,37 +67,27 @@ final class Config
         ]);
     }
 
-    /**
-     * @return Config
-     */
     public static function create(): self
     {
         return new static();
     }
 
-    /**
-     * @return string
-     */
-    public function getTypeNamespace(): string
+    public function getTypeNamespaceMap(): TypeNamespaceMap
     {
-        return $this->typeNamespace;
+        if (!$this->typeNamespaceMap) {
+            throw InvalidArgumentException::typeNamespaceMapIsMissing();
+        }
+
+        return $this->typeNamespaceMap;
     }
 
-    /**
-     * @param non-empty-string $namespace
-     *
-     * @return Config
-     */
-    public function setTypeNamespace($namespace): self
+    public function setTypeNamespaceMap(TypeNamespaceMap $namespaceMap): self
     {
-        $this->typeNamespace = Normalizer::normalizeNamespace($namespace);
+        $this->typeNamespaceMap = $namespaceMap;
 
         return $this;
     }
 
-    /**
-     * @return Engine
-     */
     public function getEngine(): Engine
     {
         if (!$this->engine instanceof Engine) {
@@ -145,11 +96,6 @@ final class Config
         return $this->engine;
     }
 
-    /**
-     * @param Engine $engine
-     *
-     * @return Config
-     */
     public function setEngine(Engine $engine): self
     {
         $this->engine = $engine;
@@ -157,19 +103,11 @@ final class Config
         return $this;
     }
 
-    /**
-     * @return RuleSetInterface
-     */
     public function getRuleSet(): RuleSetInterface
     {
         return $this->ruleSet;
     }
 
-    /**
-     * @param RuleSetInterface $ruleSet
-     *
-     * @return Config
-     */
     public function setRuleSet(RuleSetInterface $ruleSet): self
     {
         $this->ruleSet = $ruleSet;
@@ -177,11 +115,6 @@ final class Config
         return $this;
     }
 
-    /**
-     * @param RuleInterface $rule
-     *
-     * @return Config
-     */
     public function addRule(RuleInterface $rule): self
     {
         $this->ruleSet->addRule($rule);
@@ -189,90 +122,18 @@ final class Config
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getClientName(): string
+    public function getClient(): ClientConfig
     {
-        return $this->clientName;
-    }
-
-    /**
-     * @param string $clientName
-     * @return $this
-     */
-    public function setClientName($clientName): self
-    {
-        $this->clientName = $clientName;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getClientNamespace(): string
-    {
-        if (!$this->clientNamespace) {
-            throw InvalidArgumentException::clientNamespaceIsMissing();
+        if (!$this->client) {
+            throw InvalidArgumentException::clientIsMissing();
         }
 
-        return $this->clientNamespace;
+        return $this->client;
     }
 
-    /**
-     * @param string $clientNamespace
-     * @return Config
-     */
-    public function setClientNamespace($clientNamespace): self
+    public function setClient(ClientConfig $client): self
     {
-        $this->clientNamespace = $clientNamespace;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getClientDestination(): string
-    {
-        if (!$this->clientDestination) {
-            throw InvalidArgumentException::clientDestinationIsMissing();
-        }
-
-        return $this->clientDestination;
-    }
-
-    /**
-     * @param string $clientDestination
-     * @return Config
-     */
-    public function setClientDestination($clientDestination): self
-    {
-        $this->clientDestination = $clientDestination;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTypeDestination(): string
-    {
-        if (!$this->typeDestination) {
-            throw InvalidArgumentException::typeDestinationIsMissing();
-        }
-
-        return $this->typeDestination;
-    }
-
-    /**
-     * @param string $typeDestination
-     * @return Config
-     */
-    public function setTypeDestination($typeDestination): self
-    {
-        $this->typeDestination = $typeDestination;
+        $this->client = $client;
 
         return $this;
     }
@@ -295,7 +156,7 @@ final class Config
             ->withTypesManipulator(
                 new TypesManipulatorChain(
                     new AppendTypesManipulator($appendTypes),
-                    $this->duplicateTypeIntersectStrategy,
+                    $this->resolveDuplicateTypeStrategy(),
                     new ReplaceTypesManipulator($typeReplacementStrategy),
                 )
             )->withMethodsManipulator(
@@ -320,7 +181,10 @@ final class Config
         return $this;
     }
 
-    public function setDuplicateTypeIntersectStrategy(TypesManipulatorInterface $duplicateTypeIntersectStrategy): self
+    /**
+     * @param TypesManipulatorInterface|Closure(?TypeNamespaceMap): TypesManipulatorInterface $duplicateTypeIntersectStrategy
+     */
+    public function setDuplicateTypeIntersectStrategy(TypesManipulatorInterface|Closure $duplicateTypeIntersectStrategy): self
     {
         $this->duplicateTypeIntersectStrategy = $duplicateTypeIntersectStrategy;
 
@@ -334,71 +198,18 @@ final class Config
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getClassMapName(): string
+    public function getClassMap(): ClassMapConfig
     {
-        if (!$this->classMapName) {
-            throw InvalidArgumentException::classmapNameMissing();
+        if (!$this->classMap) {
+            throw InvalidArgumentException::classmapMissing();
         }
 
-        return $this->classMapName;
+        return $this->classMap;
     }
 
-    /**
-     * @return string
-     */
-    public function getClassMapNamespace(): string
+    public function setClassMap(ClassMapConfig $classMap): self
     {
-        if (!$this->classMapNamespace) {
-            throw InvalidArgumentException::classmapNamespaceMissing();
-        }
-
-        return $this->classMapNamespace;
-    }
-
-    /**
-     * @return string
-     */
-    public function getClassMapDestination(): string
-    {
-        if (!$this->classMapDestination) {
-            throw InvalidArgumentException::classmapDestinationMissing();
-        }
-
-        return $this->classMapDestination;
-    }
-
-    /**
-     * @param string $classMapName
-     * @return Config
-     */
-    public function setClassMapName(string $classMapName): self
-    {
-        $this->classMapName = $classMapName;
-
-        return $this;
-    }
-
-    /**
-     * @param string $classMapNamespace
-     * @return Config
-     */
-    public function setClassMapNamespace(string $classMapNamespace): self
-    {
-        $this->classMapNamespace = $classMapNamespace;
-
-        return $this;
-    }
-
-    /**
-     * @param string $classMapDestination
-     * @return Config
-     */
-    public function setClassMapDestination(string $classMapDestination): self
-    {
-        $this->classMapDestination = $classMapDestination;
+        $this->classMap = $classMap;
 
         return $this;
     }
@@ -413,5 +224,14 @@ final class Config
     public function getEnumerationGenerationStrategy(): EnumerationGenerationStrategy
     {
         return $this->enumerationGenerationStrategy;
+    }
+
+    private function resolveDuplicateTypeStrategy(): TypesManipulatorInterface
+    {
+        if ($this->duplicateTypeIntersectStrategy instanceof Closure) {
+            return ($this->duplicateTypeIntersectStrategy)($this->typeNamespaceMap);
+        }
+
+        return $this->duplicateTypeIntersectStrategy;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
@@ -182,10 +182,15 @@ final class Config
     }
 
     /**
-     * @param TypesManipulatorInterface|Closure(?TypeNamespaceMap): TypesManipulatorInterface $duplicateTypeIntersectStrategy
+     *
+     * @param (
+     *  TypesManipulatorInterface|
+     *  Closure(?TypeNamespaceMap): TypesManipulatorInterface
+     * ) $duplicateTypeIntersectStrategy
      */
-    public function setDuplicateTypeIntersectStrategy(TypesManipulatorInterface|Closure $duplicateTypeIntersectStrategy): self
-    {
+    public function setDuplicateTypeIntersectStrategy(
+        TypesManipulatorInterface|Closure $duplicateTypeIntersectStrategy
+    ): self {
         $this->duplicateTypeIntersectStrategy = $duplicateTypeIntersectStrategy;
 
         return $this;

--- a/src/Phpro/SoapClient/CodeGenerator/Config/Destination.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/Destination.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Config;
+
+final readonly class Destination
+{
+    /**
+     * @param non-empty-string $path
+     * @param non-empty-string $namespace
+     */
+    public function __construct(
+        public string $path,
+        public string $namespace,
+    ) {
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Config/TypeNamespaceMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/TypeNamespaceMap.php
@@ -4,21 +4,26 @@ namespace Phpro\SoapClient\CodeGenerator\Config;
 
 use Soap\Engine\Metadata\Model\XsdType;
 
+/**
+ * @psalm-type Strategy = \Closure(string $xmlns, Destination $fallback): Destination
+ */
 final readonly class TypeNamespaceMap
 {
     /**
      * @param Destination $fallback
      * @param array<non-empty-string, Destination> $map
+     * @param Strategy|null $strategy
      */
     public function __construct(
         private Destination $fallback,
-        private array $map,
+        private array $map = [],
+        private ?\Closure $strategy = null,
     ) {
     }
 
     public static function create(Destination $fallback): self
     {
-        return new self($fallback, []);
+        return new self($fallback);
     }
 
     public function withMapping(string $xmlns, Destination $destination): self
@@ -29,6 +34,22 @@ final readonly class TypeNamespaceMap
         return new self($this->fallback, $newMap);
     }
 
+    /**
+     * Add a strategy to determine the destination for a given xmlns.
+     * The strategy is a callable that takes the xmlns and the fallback destination as arguments
+     * and returns a "calculated" destination.
+     *
+     * If the xmlns exists in the map, the strategy will not be called.
+     * If the xmlns does not exist in the map,
+     * the strategy will be called with the xmlns and the fallback destination as arguments.
+     *
+     * @param Strategy|null $strategy
+     */
+    public function withStrategy(?\Closure $strategy): self
+    {
+        return new self($this->fallback, $this->map, $strategy);
+    }
+
     public function detectDestinationForType(XsdType $type): Destination
     {
         $xmlns = $type->getXmlNamespace(); // TODO : Is this the correct one?
@@ -36,6 +57,11 @@ final readonly class TypeNamespaceMap
             return $this->map[$xmlns];
         }
 
-        return $this->fallback;
+        $fallback = $this->fallback;
+        if ($this->strategy !== null) {
+            $fallback = ($this->strategy)($xmlns, $fallback);
+        }
+
+        return $fallback;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Config/TypeNamespaceMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/TypeNamespaceMap.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Config;
+
+use Soap\Engine\Metadata\Model\XsdType;
+
+final readonly class TypeNamespaceMap
+{
+    /**
+     * @param Destination $fallback
+     * @param array<non-empty-string, Destination> $map
+     */
+    public function __construct(
+        private Destination $fallback,
+        private array $map,
+    ) {
+    }
+
+    public static function create(Destination $fallback): self
+    {
+        return new self($fallback, []);
+    }
+
+    public function withMapping(string $xmlns, Destination $destination): self
+    {
+        $newMap = $this->map;
+        $newMap[$xmlns] = $destination;
+
+        return new self($this->fallback, $newMap);
+    }
+
+    public function detectDestinationForType(XsdType $type): Destination
+    {
+        $xmlns = $type->getXmlNamespace(); // TODO : Is this the correct one?
+        if ($xmlns && array_key_exists($xmlns, $this->map)) {
+            return $this->map[$xmlns];
+        }
+
+        return $this->fallback;
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Config/TypeNamespaceMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/TypeNamespaceMap.php
@@ -2,19 +2,20 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Config;
 
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\TypeNamespaceMapStrategyInterface;
 use Soap\Engine\Metadata\Model\XsdType;
 
 /**
- * @psalm-type Strategy = \Closure(string $xmlns, Destination $fallback): Destination
+ * @psalm-import-type StrategyCallable from TypeNamespaceMapStrategyInterface
  */
 final readonly class TypeNamespaceMap
 {
     /**
      * @param Destination $fallback
      * @param array<non-empty-string, Destination> $map
-     * @param Strategy|null $strategy
+     * @param (\Closure&StrategyCallable)|null $strategy
      */
-    public function __construct(
+    private function __construct(
         private Destination $fallback,
         private array $map = [],
         private ?\Closure $strategy = null,
@@ -43,23 +44,27 @@ final readonly class TypeNamespaceMap
      * If the xmlns does not exist in the map,
      * the strategy will be called with the xmlns and the fallback destination as arguments.
      *
-     * @param Strategy|null $strategy
+     * @param StrategyCallable|null $strategy
      */
-    public function withStrategy(?\Closure $strategy): self
+    public function withStrategy(?callable $strategy): self
     {
-        return new self($this->fallback, $this->map, $strategy);
+        return new self(
+            $this->fallback,
+            $this->map,
+            ($strategy ? $strategy(...) : null),
+        );
     }
 
     public function detectDestinationForType(XsdType $type): Destination
     {
-        $xmlns = $type->getXmlNamespace(); // TODO : Is this the correct one?
+        $xmlns = $type->getXmlNamespace();
         if ($xmlns && array_key_exists($xmlns, $this->map)) {
             return $this->map[$xmlns];
         }
 
         $fallback = $this->fallback;
         if ($this->strategy !== null) {
-            $fallback = ($this->strategy)($xmlns, $fallback);
+            $fallback = ($this->strategy)($xmlns, $type->getXmlNamespaceName(), $fallback);
         }
 
         return $fallback;

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -44,7 +44,7 @@ EOENGINE;
      */
     private function generateSetter(string $name, string $value, FileGenerator $file): string
     {
-        return sprintf("%s->%s('%s')".GeneratorInterface::EOL, $file->getIndentation(), $name, $value);
+        return sprintf("%s->%s(%s)".GeneratorInterface::EOL, $file->getIndentation(), $name, $value);
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -8,6 +8,8 @@ use Phpro\SoapClient\CodeGenerator\Config\Config;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Laminas\Code\Generator\FileGenerator;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Phpro\SoapClient\Soap\EngineOptions;
@@ -41,14 +43,44 @@ EOENGINE;
 
     /**
      * Generate code for TypeNamespaceMap configuration
+     *
+     * @param array<string, string> $detectedXmlNamespaces
      */
-    private function generateTypeNamespaceMapCode(Destination $fallback): string
-    {
-        return sprintf(
+    private function generateTypeNamespaceMapCode(
+        Destination $fallback,
+        array $detectedXmlNamespaces,
+        string $indentation
+    ): string {
+        $createCall = sprintf(
             'TypeNamespaceMap::create(new Destination(%s, %s))',
             var_export($fallback->path, true),
             var_export($fallback->namespace, true)
         );
+
+        $lines = [];
+        $lines[] = GeneratorInterface::EOL . $indentation . $indentation . $createCall;
+        foreach ($detectedXmlNamespaces as $xmlns => $prefix) {
+            $segment = Normalizer::normalizeNamespaceSegment($prefix);
+            $suggestedPath = $fallback->path . ($segment !== null ? '/' . $segment : '');
+            $suggestedNamespace = $fallback->namespace . ($segment !== null ? '\\' . $segment : '');
+
+            $lines[] = sprintf(
+                '%s%s// ->withMapping(%s, new Destination(%s, %s))',
+                $indentation,
+                $indentation,
+                var_export($xmlns, true),
+                var_export($suggestedPath, true),
+                var_export($suggestedNamespace, true)
+            );
+        }
+
+        $lines[] = sprintf(
+            '%s%s// ->withStrategy(new PrefixBasedTypeNamespaceStrategy())',
+            $indentation,
+            $indentation
+        );
+
+        return implode(GeneratorInterface::EOL, $lines) . GeneratorInterface::EOL . $indentation;
     }
 
     /**
@@ -115,10 +147,12 @@ EOENGINE;
 
         // Generate TypeNamespaceMap setter
         if ($typeDestination = $context->getTypeDestination()) {
+            $file->setUse(PrefixBasedTypeNamespaceStrategy::class);
+            $detectedXmlNamespaces = $context->getDetectedXmlNamespaces();
             $body .= sprintf(
                 "%s->setTypeNamespaceMap(%s)".GeneratorInterface::EOL,
                 $file->getIndentation(),
-                $this->generateTypeNamespaceMapCode($typeDestination)
+                $this->generateTypeNamespaceMapCode($typeDestination, $detectedXmlNamespaces, $file->getIndentation())
             );
         }
 

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -2,10 +2,13 @@
 
 namespace Phpro\SoapClient\CodeGenerator;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
 use Laminas\Code\Generator\FileGenerator;
-use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Phpro\SoapClient\Soap\EngineOptions;
 
@@ -37,14 +40,41 @@ RULESET;
 EOENGINE;
 
     /**
-     * @param string $name
-     * @param string $value
-     * @param FileGenerator $file
-     * @return string
+     * Generate code for TypeNamespaceMap configuration
      */
-    private function generateSetter(string $name, string $value, FileGenerator $file): string
+    private function generateTypeNamespaceMapCode(Destination $fallback): string
     {
-        return sprintf("%s->%s(%s)".GeneratorInterface::EOL, $file->getIndentation(), $name, $value);
+        return sprintf(
+            'TypeNamespaceMap::create(new Destination(%s, %s))',
+            var_export($fallback->path, true),
+            var_export($fallback->namespace, true)
+        );
+    }
+
+    /**
+     * Generate code for ClientConfig configuration
+     */
+    private function generateClientConfigCode(ClientConfig $config): string
+    {
+        return sprintf(
+            'new ClientConfig(%s, new Destination(%s, %s))',
+            var_export($config->name, true),
+            var_export($config->destination->path, true),
+            var_export($config->destination->namespace, true)
+        );
+    }
+
+    /**
+     * Generate code for ClassMapConfig configuration
+     */
+    private function generateClassMapConfigCode(ClassMapConfig $config): string
+    {
+        return sprintf(
+            'new ClassMapConfig(%s, new Destination(%s, %s))',
+            var_export($config->name, true),
+            var_export($config->destination->path, true),
+            var_export($config->destination->namespace, true)
+        );
     }
 
     /**
@@ -73,13 +103,41 @@ EOENGINE;
         $body = self::BODY;
         $file->setUse('Phpro\\SoapClient\\CodeGenerator\\Assembler');
         $file->setUse('Phpro\\SoapClient\\CodeGenerator\\Rules');
+        $file->setUse(ClassMapConfig::class);
+        $file->setUse(ClientConfig::class);
         $file->setUse(Config::class);
+        $file->setUse(Destination::class);
+        $file->setUse(TypeNamespaceMap::class);
         $file->setUse(EngineOptions::class);
         $file->setUse(DefaultEngineFactory::class);
 
         $body .= $this->parseEngine($file, $context->getWsdl());
-        foreach ($context->getSetters() as $name => $value) {
-            $body .= $this->generateSetter($name, $value, $file);
+
+        // Generate TypeNamespaceMap setter
+        if ($typeDestination = $context->getTypeDestination()) {
+            $body .= sprintf(
+                "%s->setTypeNamespaceMap(%s)".GeneratorInterface::EOL,
+                $file->getIndentation(),
+                $this->generateTypeNamespaceMapCode($typeDestination)
+            );
+        }
+
+        // Generate Client setter
+        if ($clientConfig = $context->getClientConfig()) {
+            $body .= sprintf(
+                "%s->setClient(%s)".GeneratorInterface::EOL,
+                $file->getIndentation(),
+                $this->generateClientConfigCode($clientConfig)
+            );
+        }
+
+        // Generate ClassMap setter
+        if ($classMapConfig = $context->getClassMapConfig()) {
+            $body .= sprintf(
+                "%s->setClassMap(%s)".GeneratorInterface::EOL,
+                $file->getIndentation(),
+                $this->generateClassMapConfigCode($classMapConfig)
+            );
         }
 
         $body .= $this->parseIndentedRuleSet($file, $this->generateGetterSetterRuleSet($context));

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClassMapContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClassMapContext.php
@@ -2,82 +2,43 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use Laminas\Code\Generator\FileGenerator;
 
-/**
- * Class ClassMapContext
- *
- * @package Phpro\SoapClient\CodeGenerator\Context
- */
-class ClassMapContext implements ContextInterface
+final readonly class ClassMapContext implements ContextInterface
 {
-    /**
-     * @var FileGenerator
-     */
-    private $file;
-
-    /**
-     * @var TypeMap
-     */
-    private $typeMap;
-
-    /**
-     * @var string
-     */
-    private $name;
-
-    /**
-     * @var string
-     */
-    private $namespace;
-
-    /**
-     * TypeContext constructor.
-     *
-     * @param FileGenerator $file
-     * @param TypeMap       $typeMap
-     * @param string        $name
-     * @param string        $namespace
-     */
-    public function __construct(FileGenerator $file, TypeMap $typeMap, string $name, string $namespace)
-    {
-        $this->file = $file;
-        $this->typeMap = $typeMap;
-        $this->name = $name;
-        $this->namespace = $namespace;
+    public function __construct(
+        private FileGenerator $file,
+        private TypeMap $typeMap,
+        private ClassMapConfig $classMap
+    ) {
     }
 
-    /**
-     * @return FileGenerator
-     */
     public function getFile(): FileGenerator
     {
         return $this->file;
     }
 
-    /**
-     * @return TypeMap
-     */
     public function getTypeMap(): TypeMap
     {
         return $this->typeMap;
     }
 
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function getName(): string
     {
-        return $this->name;
+        return $this->classMap->name;
     }
 
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function getNamespace(): string
     {
-        return $this->namespace;
+        return $this->classMap->destination->namespace;
     }
 
     /**
@@ -85,6 +46,6 @@ class ClassMapContext implements ContextInterface
      */
     public function getFqcn(): string
     {
-        return $this->namespace.'\\'.$this->name;
+        return $this->classMap->fqcn();
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClientContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClientContext.php
@@ -3,56 +3,30 @@
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
 use Laminas\Code\Generator\ClassGenerator;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 
-/**
- * Class ClientContext
- *
- * @package Phpro\SoapClient\CodeGenerator\Context
- */
-class ClientContext implements ContextInterface
+final readonly class ClientContext implements ContextInterface
 {
-    /**
-     * @var string
-     */
-    private $name;
-
-    /**
-     * @var string
-     */
-    private $namespace;
-
-    /**
-     * @var ClassGenerator
-     */
-    private $class;
-
-    /**
-     * PropertyContext constructor.
-     *
-     * @param string $name
-     * @param string $namespace
-     */
-    public function __construct(ClassGenerator $class, string $name, string $namespace)
-    {
-        $this->class = $class;
-        $this->name = $name;
-        $this->namespace = $namespace;
+    public function __construct(
+        private ClassGenerator $class,
+        private ClientConfig $clientConfig
+    ) {
     }
 
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function getName(): string
     {
-        return $this->name;
+        return $this->clientConfig->name;
     }
 
     /**
-     * @return string
+     * @return non-empty-string
      */
     public function getNamespace(): string
     {
-        return $this->namespace;
+        return $this->clientConfig->destination->namespace;
     }
 
     /**
@@ -60,7 +34,7 @@ class ClientContext implements ContextInterface
      */
     public function getFqcn(): string
     {
-        return $this->namespace.'\\'.$this->name;
+        return $this->clientConfig->fqcn();
     }
 
     public function getClass(): ClassGenerator

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContext.php
@@ -2,41 +2,41 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
-class ClientFactoryContext implements ContextInterface
+final readonly class ClientFactoryContext implements ContextInterface
 {
-    /**
-     * @var ClassMapContext
-     */
-    private $classMapContext;
-
-    /**
-     * @var ClientContext
-     */
-    private $clientContext;
-
     public function __construct(
-        ClientContext $clientContext,
-        ClassMapContext $classMapContext
+        private ClientContext $clientContext,
+        private ClassMapContext $classMapContext
     ) {
-        $this->classMapContext = $classMapContext;
-        $this->clientContext = $clientContext;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getClientName(): string
     {
         return $this->clientContext->getName();
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getClientNamespace(): string
     {
         return $this->clientContext->getNamespace();
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getClassmapName(): string
     {
         return $this->classMapContext->getName();
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getClassmapNamespace(): string
     {
         return $this->classMapContext->getNamespace();

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContext.php
@@ -5,41 +5,19 @@ namespace Phpro\SoapClient\CodeGenerator\Context;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
 use Laminas\Code\Generator\ClassGenerator;
 
-class ClientMethodContext implements ContextInterface
+final readonly class ClientMethodContext implements ContextInterface
 {
-    /**
-     * @var ClassGenerator
-     */
-    private $class;
-
-    /**
-     * @var ClientMethod
-     */
-    private $method;
-
-    /**
-     * PropertyContext constructor.
-     *
-     * @param ClassGenerator $class
-     * @param ClientMethod $method
-     */
-    public function __construct(ClassGenerator $class, ClientMethod $method)
-    {
-        $this->class = $class;
-        $this->method = $method;
+    public function __construct(
+        private ClassGenerator $class,
+        private ClientMethod $method
+    ) {
     }
 
-    /**
-     * @return ClassGenerator
-     */
     public function getClass(): ClassGenerator
     {
         return $this->class;
     }
 
-    /**
-     * @return ClientMethod
-     */
     public function getMethod(): ClientMethod
     {
         return $this->method;

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
@@ -2,31 +2,17 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+
 final class ConfigContext implements ContextInterface
 {
-    /**
-     * @var array<string, string>
-     */
-    private array $setters = [];
-
     private string $wsdl = '';
-
     private bool $generateDocblocks = true;
-
-    public function addSetter(string $name, string $value): self
-    {
-        $this->setters[$name] = $value;
-
-        return $this;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function getSetters(): array
-    {
-        return $this->setters;
-    }
+    private ?Destination $typeDestination = null;
+    private ?ClientConfig $clientConfig = null;
+    private ?ClassMapConfig $classMapConfig = null;
 
     public function getWsdl(): string
     {
@@ -50,5 +36,41 @@ final class ConfigContext implements ContextInterface
     public function isGenerateDocblocks(): bool
     {
         return $this->generateDocblocks;
+    }
+
+    public function getTypeDestination(): ?Destination
+    {
+        return $this->typeDestination;
+    }
+
+    public function setTypeDestination(Destination $typeDestination): self
+    {
+        $this->typeDestination = $typeDestination;
+
+        return $this;
+    }
+
+    public function getClientConfig(): ?ClientConfig
+    {
+        return $this->clientConfig;
+    }
+
+    public function setClientConfig(ClientConfig $clientConfig): self
+    {
+        $this->clientConfig = $clientConfig;
+
+        return $this;
+    }
+
+    public function getClassMapConfig(): ?ClassMapConfig
+    {
+        return $this->classMapConfig;
+    }
+
+    public function setClassMapConfig(ClassMapConfig $classMapConfig): self
+    {
+        $this->classMapConfig = $classMapConfig;
+
+        return $this;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
@@ -2,14 +2,14 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Context;
 
-class ConfigContext implements ContextInterface
+final class ConfigContext implements ContextInterface
 {
-    private $setters = [];
-
     /**
-     * @var string
+     * @var array<string, string>
      */
-    private $wsdl;
+    private array $setters = [];
+
+    private string $wsdl = '';
 
     private bool $generateDocblocks = true;
 
@@ -21,25 +21,18 @@ class ConfigContext implements ContextInterface
     }
 
     /**
-     * @return array
+     * @return array<string, string>
      */
     public function getSetters(): array
     {
         return $this->setters;
     }
 
-    /**
-     * @return string
-     */
     public function getWsdl(): string
     {
         return $this->wsdl;
     }
 
-    /**
-     * @param string $wsdl
-     * @return ConfigContext
-     */
     public function setWsdl(string $wsdl): self
     {
         $this->wsdl = $wsdl;

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ConfigContext.php
@@ -13,6 +13,8 @@ final class ConfigContext implements ContextInterface
     private ?Destination $typeDestination = null;
     private ?ClientConfig $clientConfig = null;
     private ?ClassMapConfig $classMapConfig = null;
+    /** @var array<string, string> */
+    private array $detectedXmlNamespaces = [];
 
     public function getWsdl(): string
     {
@@ -70,6 +72,20 @@ final class ConfigContext implements ContextInterface
     public function setClassMapConfig(ClassMapConfig $classMapConfig): self
     {
         $this->classMapConfig = $classMapConfig;
+
+        return $this;
+    }
+
+    /** @return array<string, string> */
+    public function getDetectedXmlNamespaces(): array
+    {
+        return $this->detectedXmlNamespaces;
+    }
+
+    /** @param array<string, string> $xmlNamespaces */
+    public function setDetectedXmlNamespaces(array $xmlNamespaces): self
+    {
+        $this->detectedXmlNamespaces = $xmlNamespaces;
 
         return $this;
     }

--- a/src/Phpro/SoapClient/CodeGenerator/Context/FileContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/FileContext.php
@@ -6,18 +6,13 @@ namespace Phpro\SoapClient\CodeGenerator\Context;
 
 use Laminas\Code\Generator\FileGenerator;
 
-class FileContext implements ContextInterface
+final readonly class FileContext implements ContextInterface
 {
-    private $fileGenerator;
-
-    public function __construct(FileGenerator $fileGenerator)
-    {
-        $this->fileGenerator = $fileGenerator;
+    public function __construct(
+        private FileGenerator $fileGenerator
+    ) {
     }
 
-    /**
-     * @return FileGenerator
-     */
     public function getFileGenerator(): FileGenerator
     {
         return $this->fileGenerator;

--- a/src/Phpro/SoapClient/CodeGenerator/Context/PropertyContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/PropertyContext.php
@@ -6,61 +6,25 @@ use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Laminas\Code\Generator\ClassGenerator;
 
-/**
- * Class PropertyContext
- *
- * @package Phpro\SoapClient\CodeGenerator\Context
- */
-class PropertyContext implements ContextInterface
+final readonly class PropertyContext implements ContextInterface
 {
-    /**
-     * @var ClassGenerator
-     */
-    private $class;
-
-    /**
-     * @var Type
-     */
-    private $type;
-
-    /**
-     * @var Property
-     */
-    private $property;
-
-    /**
-     * PropertyContext constructor.
-     *
-     * @param ClassGenerator $class
-     * @param Type           $type
-     * @param Property       $property
-     */
-    public function __construct(ClassGenerator $class, Type $type, Property $property)
-    {
-        $this->class = $class;
-        $this->type = $type;
-        $this->property = $property;
+    public function __construct(
+        private ClassGenerator $class,
+        private Type $type,
+        private Property $property
+    ) {
     }
 
-    /**
-     * @return ClassGenerator
-     */
     public function getClass(): ClassGenerator
     {
         return $this->class;
     }
 
-    /**
-     * @return Type
-     */
     public function getType(): Type
     {
         return $this->type;
     }
 
-    /**
-     * @return Property
-     */
     public function getProperty(): Property
     {
         return $this->property;

--- a/src/Phpro/SoapClient/CodeGenerator/Context/TypeContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/TypeContext.php
@@ -5,46 +5,19 @@ namespace Phpro\SoapClient\CodeGenerator\Context;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Laminas\Code\Generator\ClassGenerator;
 
-/**
- * Class TypeContext
- *
- * @package Phpro\SoapClient\CodeGenerator\Context
- */
-class TypeContext implements ContextInterface
+final readonly class TypeContext implements ContextInterface
 {
-    /**
-     * @var ClassGenerator
-     */
-    private $class;
-
-    /**
-     * @var Type
-     */
-    private $type;
-
-    /**
-     * PropertyContext constructor.
-     *
-     * @param ClassGenerator $class
-     * @param Type           $type
-     */
-    public function __construct(ClassGenerator $class, Type $type)
-    {
-        $this->class = $class;
-        $this->type = $type;
+    public function __construct(
+        private ClassGenerator $class,
+        private Type $type
+    ) {
     }
 
-    /**
-     * @return ClassGenerator
-     */
     public function getClass(): ClassGenerator
     {
         return $this->class;
     }
 
-    /**
-     * @return Type
-     */
     public function getType(): Type
     {
         return $this->type;

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Client.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Client.php
@@ -2,67 +2,39 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 
-/**
- * Class Client
- *
- * @package Phpro\SoapClient\CodeGenerator\Model
- */
-class Client
+final readonly class Client
 {
-    /**
-     * @var ClientMethodMap
-     */
-    private $methodMap;
+    public function __construct(
+        private ClientConfig $clientConfig,
+        private ClientMethodMap $methods
+    ) {
+    }
 
-    /**
-     * @var non-empty-string
-     */
-    private $namespace;
-
-    /**
-     * @var non-empty-string
-     */
-    private $name;
-
-    /**
-     * TypeModel constructor.
-     *
-     * @param non-empty-string $name
-     * @param non-empty-string $namespace
-     * @param ClientMethodMap $methods
-     * @internal param string $xsdName
-     * @internal param Property[] $properties
-     */
-    public function __construct(string $name, string $namespace, ClientMethodMap $methods)
+    public function config(): ClientConfig
     {
-        $this->name = $name;
-        $this->namespace = Normalizer::normalizeNamespace($namespace);
-        $this->methodMap = $methods;
+        return $this->clientConfig;
     }
 
     /**
      * @return non-empty-string
      */
-    public function getNamespace()
+    public function getNamespace(): string
     {
-        return $this->namespace;
+        return $this->clientConfig->destination->namespace;
     }
 
     /**
      * @return non-empty-string
      */
-    public function getName()
+    public function getName(): string
     {
-        return $this->name;
+        return $this->clientConfig->name;
     }
 
-    /**
-     * @return ClientMethodMap
-     */
-    public function getMethodMap()
+    public function getMethodMap(): ClientMethodMap
     {
-        return $this->methodMap;
+        return $this->methods;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethod.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethod.php
@@ -2,85 +2,50 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Soap\Engine\Metadata\Model\Method as MetadataMethod;
 use Soap\Engine\Metadata\Model\MethodMeta;
 use Soap\Engine\Metadata\Model\Parameter as MetadataParameter;
 use Soap\WsdlReader\Metadata\Predicate\IsConsideredScalarType;
 use function Psl\Type\non_empty_string;
 
-/**
- * Class ClientMethod
- *
- * @package Phpro\SoapClient\CodeGenerator\Model
- */
-class ClientMethod
+final readonly class ClientMethod
 {
-    /**
-     * @var Parameter[]
-     */
-    private array $parameters;
-
-    /**
-     * @var non-empty-string
-     */
-    private string $methodName;
-
-    private ReturnType $returnType;
-
-    /**
-     * @var string
-     */
-    private string $parameterNamespace;
-
-    private MethodMeta $meta;
-
     /**
      * @internal - Use ClientMethod::fromMetadata instead
      *
-     * TypeModel constructor.
-     *
-     * @param non-empty-string $name
-     * @param array $params
-     * @param string $parameterNamespace
+     * @param non-empty-string $methodName
+     * @param array<array-key, Parameter> $parameters
      */
     public function __construct(
-        string $name,
-        array $params,
-        ReturnType $returnType,
-        string $parameterNamespace,
-        MethodMeta $meta
+        private string $methodName,
+        private array $parameters,
+        private ReturnType $returnType,
+        private TypeNamespaceMap $typeNamespaceMap,
+        private MethodMeta $meta
     ) {
-        $this->parameterNamespace = $parameterNamespace;
-        $this->methodName = $name;
-        $this->parameters = $params;
-        $this->returnType = $returnType;
-        $this->meta = $meta;
     }
 
-    /**
-     * @param non-empty-string $parameterNamespace
-     */
     public static function fromMetadata(
-        string $parameterNamespace,
+        TypeNamespaceMap $typeNamespaceMap,
         MetadataMethod $method
     ): self {
         return new self(
             non_empty_string()->assert($method->getName()),
             array_map(
-                function (MetadataParameter $parameter) use ($parameterNamespace) {
-                    return Parameter::fromMetadata($parameterNamespace, $parameter);
+                function (MetadataParameter $parameter) use ($typeNamespaceMap) {
+                    return Parameter::fromMetadata($typeNamespaceMap, $parameter);
                 },
                 iterator_to_array($method->getParameters())
             ),
-            ReturnType::fromMetaData($parameterNamespace, $method->getReturnType()),
-            Normalizer::normalizeNamespace($parameterNamespace),
+            ReturnType::fromMetaData($typeNamespaceMap, $method->getReturnType()),
+            $typeNamespaceMap,
             $method->getMeta()
         );
     }
 
     /**
-     * @return array|Parameter[]
+     * @return array<array-key, Parameter>
      */
     public function getParameters(): array
     {
@@ -100,12 +65,9 @@ class ClientMethod
         return $this->methodName;
     }
 
-    /**
-     * @return string
-     */
-    public function getParameterNamespace(): string
+    public function getTypeNamespaceMap(): TypeNamespaceMap
     {
-        return $this->parameterNamespace;
+        return $this->typeNamespaceMap;
     }
 
     public function getReturnType(): ReturnType

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethodMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethodMap.php
@@ -2,45 +2,33 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Soap\Engine\Metadata\Collection\MethodCollection;
 use Soap\Engine\Metadata\Model\Method;
 
-/**
- * Class ClientMethodMap
- *
- * @package Phpro\SoapClient\CodeGenerator\Model
- */
-class ClientMethodMap
+final readonly class ClientMethodMap
 {
-    /**
-     * @var ClientMethod[]
-     */
-    private $methods;
-
     /**
      * @internal - Use ClientMethodMap::fromMetadata instead
      *
-     * ClientMethodMap constructor.
-     *
-     * @param array|ClientMethod[] $methods
+     * @param array<array-key, ClientMethod> $methods
      */
-    public function __construct(array $methods)
-    {
-        $this->methods = $methods;
+    public function __construct(
+        private array $methods
+    ) {
     }
 
-    /**
-     * @param non-empty-string $parameterNamespace
-     */
-    public static function fromMetadata(string $parameterNamespace, MethodCollection $collection): self
-    {
-        return new self($collection->map(function (Method $method) use ($parameterNamespace) {
-            return ClientMethod::fromMetadata($parameterNamespace, $method);
+    public static function fromMetadata(
+        TypeNamespaceMap $typeNamespaces,
+        MethodCollection $collection
+    ): self {
+        return new self($collection->map(function (Method $method) use ($typeNamespaces) {
+            return ClientMethod::fromMetadata($typeNamespaces, $method);
         }));
     }
 
     /**
-     * @return ClientMethod[]
+     * @return array<array-key, ClientMethod>
      */
     public function getMethods(): array
     {

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Parameter.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Parameter.php
@@ -2,6 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\TypeNameCalculator;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Soap\Engine\Metadata\Model\Parameter as MetadataParameter;
@@ -9,25 +10,8 @@ use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 use function Psl\Type\non_empty_string;
 
-class Parameter
+final readonly class Parameter
 {
-    /**
-     * @var non-empty-string
-     */
-    private string $name;
-
-    /**
-     * @var non-empty-string
-     */
-    private string $type;
-
-    /**
-     * @var non-empty-string
-     */
-    private string $namespace;
-
-    private XsdType $xsdType;
-
     private TypeMeta $meta;
 
     /**
@@ -37,21 +21,17 @@ class Parameter
      *
      * @param non-empty-string $name
      * @param non-empty-string $type
-     * @param non-empty-string $namespace
      */
-    public function __construct(string $name, string $type, string $namespace, XsdType $xsdType)
-    {
-        $this->name = $name;
-        $this->type = $type;
-        $this->namespace = $namespace;
-        $this->xsdType = $xsdType;
+    public function __construct(
+        private string $name,
+        private string $type,
+        private TypeNamespaceMap $namespaces,
+        private XsdType $xsdType
+    ) {
         $this->meta = $xsdType->getMeta();
     }
 
-    /**
-     * @param non-empty-string $parameterNamespace
-     */
-    public static function fromMetadata(string $parameterNamespace, MetadataParameter $parameter): Parameter
+    public static function fromMetadata(TypeNamespaceMap $typeNamespaceMap, MetadataParameter $parameter): Parameter
     {
         $type = $parameter->getType();
         $typeName = (new TypeNameCalculator())($type);
@@ -59,7 +39,7 @@ class Parameter
         return new self(
             Normalizer::normalizeProperty(non_empty_string()->assert($parameter->getName())),
             Normalizer::normalizeDataType(non_empty_string()->assert($typeName)),
-            Normalizer::normalizeNamespace($parameterNamespace),
+            $typeNamespaceMap,
             $type
         );
     }
@@ -81,12 +61,15 @@ class Parameter
             return $this->type;
         }
 
-        return '\\'.$this->namespace.'\\'.Normalizer::normalizeClassname($this->type);
+        return '\\'.$this->getNamespace().'\\'.Normalizer::normalizeClassname($this->type);
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getNamespace(): string
     {
-        return $this->namespace;
+        return $this->namespaces->detectDestinationForType($this->xsdType)->namespace;
     }
 
     public function getXsdType(): XsdType

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -23,7 +23,6 @@ final class Property
      *
      * @param non-empty-string $name
      * @param non-empty-string $type
-     * @param non-empty-string $namespace
      */
     public function __construct(
         private readonly string $name,
@@ -84,7 +83,11 @@ final class Property
             return $this->xsdType->getBaseType();
         }
 
-        return '\\'.$this->namespace.'\\'.Normalizer::normalizeClassname($this->type);
+        $normalized = Normalizer::normalizeClassname($this->type);
+
+        return $this->namespace !== ''
+            ? '\\'.$this->namespace.'\\'.$normalized
+            : '\\'.$normalized;
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -2,6 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\TypeNameCalculator;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\MetaTypeEnhancer;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\TypeEnhancer;
@@ -11,30 +12,8 @@ use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 use function Psl\Type\non_empty_string;
 
-/**
- * Class Property
- *
- * @package Phpro\SoapClient\CodeGenerator\Model
- */
-class Property
+final class Property
 {
-    /**
-     * @var non-empty-string
-     */
-    private $name;
-
-    /**
-     * @var non-empty-string
-     */
-    private $type;
-
-    /**
-     * @var string
-     */
-    private $namespace;
-
-    private XsdType $xsdType;
-
     private TypeMeta $meta;
 
     private TypeEnhancer $typeEnhancer;
@@ -42,30 +21,27 @@ class Property
     /**
      * @internal
      *
-     * Property constructor.
-     *
      * @param non-empty-string $name
      * @param non-empty-string $type
-     * @param string $namespace
+     * @param non-empty-string $namespace
      */
-    public function __construct(string $name, string $type, string $namespace, XsdType $xsdType)
-    {
-        $this->name = $name;
-        $this->type = $type;
-        $this->namespace = $namespace;
-        $this->xsdType = $xsdType;
+    public function __construct(
+        private readonly string $name,
+        private readonly string $type,
+        private readonly TypeNamespaceMap $namespaces,
+        private readonly string $namespace,
+        private readonly XsdType $xsdType
+    ) {
         $this->meta = $xsdType->getMeta();
         $this->typeEnhancer = new MetaTypeEnhancer($this->meta);
     }
 
-    /**
-     * @param non-empty-string $namespace
-     */
-    public static function fromMetaData(string $namespace, MetadataProperty $property): self
+    public static function fromMetaData(TypeNamespaceMap $namespaces, MetadataProperty $property): self
     {
         $type = $property->getType();
         $typeName = $type->getName();
         $calculatedTypeName = Normalizer::normalizeDataType((new TypeNameCalculator())($type));
+        $namespace = $namespaces->detectDestinationForType($type)->namespace;
 
         // This makes it possible to set FQCN as type names in the metadata through TypeReplacers.
         if (Normalizer::isConsideredExistingThirdPartyClass($typeName)) {
@@ -78,6 +54,7 @@ class Property
         return new self(
             Normalizer::normalizeProperty(non_empty_string()->assert($property->getName())),
             non_empty_string()->assert($calculatedTypeName),
+            $namespaces,
             Normalizer::normalizeNamespace($namespace),
             $type
         );
@@ -105,10 +82,6 @@ class Property
                 && Normalizer::isKnownType($this->xsdType->getBaseType())
         ) {
             return $this->xsdType->getBaseType();
-        }
-
-        if (!$this->namespace) {
-            return '\\'.Normalizer::normalizeClassname($this->type);
         }
 
         return '\\'.$this->namespace.'\\'.Normalizer::normalizeClassname($this->type);
@@ -154,6 +127,11 @@ class Property
     public function getMeta(): TypeMeta
     {
         return $this->meta;
+    }
+
+    public function getNamespaces(): TypeNamespaceMap
+    {
+        return $this->namespaces;
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\TypeNameCalculator;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Soap\Engine\Metadata\Model\TypeMeta;
@@ -10,42 +11,24 @@ use Soap\Engine\Metadata\Model\XsdType;
 use Soap\WsdlReader\Metadata\Predicate\IsConsideredScalarType;
 use function Psl\Type\non_empty_string;
 
-final class ReturnType
+final readonly class ReturnType
 {
-    /**
-     * @var non-empty-string
-     */
-    private string $type;
-
-    /**
-     * @var non-empty-string
-     */
-    private string $namespace;
-
-    private XsdType $xsdType;
-
     private TypeMeta $meta;
 
     /**
      * @internal - Use ReturnType::fromMetaData instead
      *
-     * Property constructor.
-     *
      * @param non-empty-string $type
-     * @param non-empty-string $namespace
      */
-    public function __construct(string $type, string $namespace, XsdType $xsdType)
-    {
-        $this->type = $type;
-        $this->namespace = $namespace;
-        $this->xsdType = $xsdType;
+    public function __construct(
+        private string $type,
+        private TypeNamespaceMap $namespaces,
+        private XsdType $xsdType
+    ) {
         $this->meta = $xsdType->getMeta();
     }
 
-    /**
-     * @param non-empty-string $namespace
-     */
-    public static function fromMetaData(string $namespace, XsdType $returnType): self
+    public static function fromMetaData(TypeNamespaceMap $namespaces, XsdType $returnType): self
     {
         // Element types that are referencing complex types, should result in the complexType according to ext-soap:
         $returnType = $returnType->copy($returnType->getXmlTypeName() ?: $returnType->getName());
@@ -54,7 +37,7 @@ final class ReturnType
 
         return new self(
             Normalizer::normalizeDataType(non_empty_string()->assert($typeName)),
-            Normalizer::normalizeNamespace($namespace),
+            $namespaces,
             $returnType
         );
     }
@@ -74,7 +57,15 @@ final class ReturnType
                 ->unwrapOr('mixed');
         }
 
-        return '\\'.$this->namespace.'\\'.Normalizer::normalizeClassname($this->type);
+        return '\\'.$this->getNamespace().'\\'.Normalizer::normalizeClassname($this->type);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function getNamespace(): string
+    {
+        return $this->namespaces->detectDestinationForType($this->xsdType)->namespace;
     }
 
     public function getXsdType(): XsdType

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
@@ -2,6 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Soap\Engine\Metadata\Model\Property as MetadataProperty;
 use Soap\Engine\Metadata\Model\Type as MetadataType;
@@ -10,72 +11,39 @@ use Soap\Engine\Metadata\Model\XsdType;
 use SplFileInfo;
 use function Psl\Type\non_empty_string;
 
-/**
- * Class Type
- *
- * @package Phpro\SoapClient\CodeGenerator\Model
- */
-class Type
+final readonly class Type
 {
-    /**
-     * @var non-empty-string
-     */
-    private $namespace;
-
-    /**
-     * @var non-empty-string
-     */
-    private $xsdName;
-
-    /**
-     * @var non-empty-string
-     */
-    private $name;
-
-    /**
-     * @var array
-     */
-    private $properties = [];
-
-    private XsdType $xsdType;
-
     private TypeMeta $meta;
 
     /**
      * @internal - Use Type::fromMetadata instead
      *
-     * TypeModel constructor.
-     *
-     * @param non-empty-string     $namespace
-     * @param non-empty-string     $xsdName
-     * @param non-empty-string     $name
-     * @param Property[] $properties
+     * @param non-empty-string $xsdName
+     * @param non-empty-string $name
+     * @param array<array-key, Property> $properties
      */
-    public function __construct(string $namespace, string $xsdName, string $name, array $properties, XsdType $xsdType)
-    {
-        $this->namespace = $namespace;
-        $this->xsdName = $xsdName;
-        $this->name = $name;
-        $this->properties = $properties;
-        $this->xsdType = $xsdType;
+    public function __construct(
+        private TypeNamespaceMap $namespaces,
+        private string $xsdName,
+        private string $name,
+        private array $properties,
+        private XsdType $xsdType
+    ) {
         $this->meta = $xsdType->getMeta();
     }
 
-    /**
-     * @param non-empty-string $namespace
-     */
-    public static function fromMetadata(string $namespace, MetadataType $type): self
+    public static function fromMetadata(TypeNamespaceMap $namespaces, MetadataType $type): self
     {
         $xsdName = non_empty_string()->assert($type->getName());
 
         return new self(
-            Normalizer::normalizeNamespace($namespace),
+            $namespaces,
             $xsdName,
             Normalizer::normalizeClassname($xsdName),
             array_map(
-                function (MetadataProperty $property) use ($namespace) {
+                function (MetadataProperty $property) use ($namespaces) {
                     return Property::fromMetaData(
-                        $namespace,
+                        $namespaces,
                         $property
                     );
                 },
@@ -90,7 +58,7 @@ class Type
      */
     public function getNamespace(): string
     {
-        return $this->namespace;
+        return $this->namespaces->detectDestinationForType($this->xsdType)->namespace;
     }
 
     /**
@@ -109,15 +77,11 @@ class Type
         return $this->xsdName;
     }
 
-    /**
-     * @param non-empty-string $destination
-     *
-     * @return SplFileInfo
-     */
-    public function getFileInfo(string $destination): SplFileInfo
+    public function getFileInfo(): SplFileInfo
     {
+        $destination = $this->namespaces->detectDestinationForType($this->xsdType);
         $name = Normalizer::normalizeClassname($this->getName());
-        $path = rtrim($destination, '/\\').'/'.$name.'.php';
+        $path = rtrim($destination->path, '/\\').'/'.$name.'.php';
 
         return new SplFileInfo($path);
     }
@@ -133,7 +97,7 @@ class Type
     }
 
     /**
-     * @return Property[]
+     * @return array<array-key, Property>
      */
     public function getProperties(): array
     {

--- a/src/Phpro/SoapClient/CodeGenerator/Model/TypeMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/TypeMap.php
@@ -2,65 +2,41 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Soap\Engine\Metadata\Collection\TypeCollection;
 use Soap\Engine\Metadata\Model\Type as MetadataType;
 
-/**
- * Class TypeMap
- *
- * @package Phpro\SoapClient\CodeGenerator\Model
- */
-class TypeMap
+final readonly class TypeMap
 {
-
-    /**
-     * @var array|Type[]
-     */
-    private $types;
-
-    /**
-     * @var non-empty-string
-     */
-    private $namespace;
 
     /**
      * @internal - Use TypeMap::fromMetadata instead
      *
-     * TypeMap constructor.
-     *
-     * @param non-empty-string $namespace
-     * @param array|Type[] $types
+     * @param array<array-key, Type> $types
      */
-    public function __construct(string $namespace, array $types)
-    {
-        $this->namespace = Normalizer::normalizeNamespace($namespace);
-        $this->types = $types;
+    public function __construct(
+        private TypeNamespaceMap $namespaces,
+        private array $types
+    ) {
     }
 
-    /**
-     * @param non-empty-string $namespace
-     */
-    public static function fromMetadata(string $namespace, TypeCollection $types): self
+    public static function fromMetadata(TypeNamespaceMap $namespaces, TypeCollection $types): self
     {
         return new self(
-            $namespace,
-            $types->map(function (MetadataType $type) use ($namespace) {
-                return Type::fromMetadata($namespace, $type);
+            $namespaces,
+            $types->map(function (MetadataType $type) use ($namespaces) {
+                return Type::fromMetadata($namespaces, $type);
             })
         );
     }
 
-    /**
-     * @return string
-     */
-    public function getNamespace(): string
+    public function getNamespaces(): TypeNamespaceMap
     {
-        return $this->namespace;
+        return $this->namespaces;
     }
 
     /**
-     * @return array|Type[]
+     * @return array<array-key, Type>
      */
     public function getTypes(): array
     {

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/AssembleRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/AssembleRule.php
@@ -5,11 +5,6 @@ namespace Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 
-/**
- * Class AssembleRule
- *
- * @package Phpro\SoapClient\CodeGenerator\Rules
- */
 class AssembleRule implements RuleInterface
 {
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRule.php
@@ -5,11 +5,6 @@ namespace Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 
-/**
- * Class ClientMethodMatchesRule
- *
- * @package Phpro\SoapClient\CodeGenerator\Rules
- */
 class ClientMethodMatchesRule implements RuleInterface
 {
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/MultiRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/MultiRule.php
@@ -4,11 +4,6 @@ namespace Phpro\SoapClient\CodeGenerator\Rules;
 
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 
-/**
- * Class MultiRule
- *
- * @package Phpro\SoapClient\CodeGenerator\Rules
- */
 class MultiRule implements RuleInterface
 {
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/PropertynameMatchesRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/PropertynameMatchesRule.php
@@ -5,11 +5,6 @@ namespace Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 
-/**
- * Class PropertynameMatchesRule
- *
- * @package Phpro\SoapClient\CodeGenerator\Rules
- */
 class PropertynameMatchesRule implements RuleInterface
 {
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/RuleInterface.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/RuleInterface.php
@@ -4,22 +4,9 @@ namespace Phpro\SoapClient\CodeGenerator\Rules;
 
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 
-/**
- * Interface RuleInterface
- *
- * @package Phpro\SoapClient\CodeGenerator\Rules
- */
 interface RuleInterface
 {
-    /**
-     * @param ContextInterface $context
-     *
-     * @return bool
-     */
     public function appliesToContext(ContextInterface $context): bool;
 
-    /**
-     * @param ContextInterface $context
-     */
     public function apply(ContextInterface $context);
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/RuleSet.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/RuleSet.php
@@ -4,11 +4,6 @@ namespace Phpro\SoapClient\CodeGenerator\Rules;
 
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 
-/**
- * Class RuleSet
- *
- * @package Phpro\SoapClient\CodeGenerator\Rules
- */
 class RuleSet implements RuleSetInterface
 {
 

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/RuleSetInterface.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/RuleSetInterface.php
@@ -4,15 +4,7 @@ namespace Phpro\SoapClient\CodeGenerator\Rules;
 
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 
-/**
- * Interface RuleSetInterface
- *
- * @package Phpro\SoapClient\CodeGenerator\Rules
- */
 interface RuleSetInterface
 {
-    /**
-     * @param ContextInterface $context
-     */
     public function applyRules(ContextInterface $context);
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRule.php
@@ -6,11 +6,6 @@ use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 
-/**
- * Class TypeMapRule
- *
- * @package Phpro\SoapClient\CodeGenerator\Rules
- */
 class TypeMapRule implements RuleInterface
 {
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/TypenameMatchesRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/TypenameMatchesRule.php
@@ -6,11 +6,6 @@ use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 
-/**
- * Class TypenameMatchingAssembleRule
- *
- * @package Phpro\SoapClient\CodeGenerator\Rules
- */
 class TypenameMatchesRule implements RuleInterface
 {
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/TypeNamespaceMap/Strategy/PrefixBasedTypeNamespaceStrategy.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeNamespaceMap/Strategy/PrefixBasedTypeNamespaceStrategy.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy;
+
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+
+final readonly class PrefixBasedTypeNamespaceStrategy implements TypeNamespaceMapStrategyInterface
+{
+    public function __invoke(string $xmlns, string $xmlNamespaceName, Destination $fallback): Destination
+    {
+        $segment = Normalizer::normalizeNamespaceSegment($xmlNamespaceName);
+        if ($segment === null) {
+            return $fallback;
+        }
+
+        return new Destination(
+            $fallback->path . '/' . $segment,
+            $fallback->namespace . '\\' . $segment
+        );
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/TypeNamespaceMap/Strategy/TypeNamespaceMapStrategyInterface.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeNamespaceMap/Strategy/TypeNamespaceMapStrategyInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy;
+
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+
+/**
+ * @psalm-type StrategyCallable = callable(string $xmlns, string $xmlNamespaceName, Destination $fallback): Destination
+ */
+interface TypeNamespaceMapStrategyInterface
+{
+    public function __invoke(string $xmlns, string $xmlNamespaceName, Destination $fallback): Destination;
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Util/Normalizer.php
@@ -239,6 +239,21 @@ class Normalizer
         return $normalized;
     }
 
+    public static function normalizeNamespaceSegment(string $segment): ?string
+    {
+        if ($segment === '') {
+            return null;
+        }
+
+        $normalized = self::normalizeClassname($segment);
+
+        if (preg_match('/^[0-9]/', $normalized)) {
+            $normalized = 'Ns' . $normalized;
+        }
+
+        return $normalized;
+    }
+
     /**
      * @param non-empty-string $type
      *

--- a/src/Phpro/SoapClient/Console/Application.php
+++ b/src/Phpro/SoapClient/Console/Application.php
@@ -20,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class Application extends SymfonyApplication
 {
     const APP_NAME = 'SoapClient';
-    const APP_VERSION = '2.0.0';
+    const APP_VERSION = '5.0.0';
 
     /**
      * Set up application:

--- a/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
@@ -14,42 +14,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Laminas\Code\Generator\FileGenerator;
 use function Psl\Type\instance_of;
-use function Psl\Type\non_empty_string;
 
-/**
- * Class GenerateTypesCommand
- *
- * @package Phpro\SoapClient\Console\Command
- */
 class GenerateClassmapCommand extends Command
 {
-
     const COMMAND_NAME = 'generate:classmap';
 
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * @var OutputInterface
-     */
-    private $output;
-
-    /**
-     * GenerateClassmapCommand constructor.
-     *
-     * @param Filesystem $filesystem
-     */
-    public function __construct(Filesystem $filesystem)
-    {
+    public function __construct(
+        private Filesystem $filesystem
+    ) {
         parent::__construct();
-        $this->filesystem = $filesystem;
     }
 
-    /**
-     * Configure the command.
-     */
     protected function configure(): void
     {
         $this
@@ -64,12 +39,10 @@ class GenerateClassmapCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
      * @throws \Phpro\SoapClient\Exception\InvalidArgumentException
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->output = $output;
         $io = new SymfonyStyle($input, $output);
 
         $config = $this->getConfigHelper()->load($input);
@@ -78,69 +51,25 @@ class GenerateClassmapCommand extends Command
         $config->setDuplicateTypeIntersectStrategy(new TypesManipulatorChain());
 
         $typeMap = TypeMap::fromMetadata(
-            non_empty_string()->assert($config->getTypeNamespace()),
+            $config->getTypeNamespaceMap(),
             $config->getManipulatedMetadata()->getTypes(),
         );
 
         $generator = new ClassMapGenerator(
             $config->getRuleSet(),
-            $config->getClassMapName(),
-            $config->getClassMapNamespace()
+            $config->getClassMap(),
         );
-        $path = $config->getClassMapDestination().DIRECTORY_SEPARATOR.$config->getClassMapName().'.php';
-        $this->handleClassmap($generator, $typeMap, $path);
+        $path = $config->getClassMap()->path();
+        $this->filesystem->putFileContents(
+            $path,
+            $generator->generate(new FileGenerator(), $typeMap)
+        );
 
         $io->success('Generated classmap at ' . $path);
 
-        return 0;
+        return self::SUCCESS;
     }
 
-
-    /**
-     * Generates one type class
-     *
-     * @param FileGenerator $file
-     * @param ClassMapGenerator $generator
-     * @param TypeMap $typeMap
-     * @param string $path
-     */
-    protected function generateClassmap(
-        FileGenerator $file,
-        ClassMapGenerator $generator,
-        TypeMap $typeMap,
-        string $path
-    ) {
-        $code = $generator->generate($file, $typeMap);
-        $this->filesystem->putFileContents($path, $code);
-    }
-
-    /**
-     * Try to create a class for a type.
-     *
-     * @param ClassMapGenerator $generator
-     * @param TypeMap           $typeMap
-     * @param string            $path
-     *
-     * @return bool
-     */
-    protected function handleClassmap(ClassMapGenerator $generator, TypeMap $typeMap, string $path): bool
-    {
-        // Try to create a new class:
-        try {
-            $file = new FileGenerator();
-            $this->generateClassmap($file, $generator, $typeMap, $path);
-        } catch (\Exception $e) {
-            $this->output->writeln('<fg=red>'.$e->getMessage().'</fg=red>');
-
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Function for added type hint
-     */
     public function getConfigHelper(): ConfigHelper
     {
         return instance_of(ConfigHelper::class)->assert($this->getHelper('config'));

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
@@ -3,12 +3,9 @@
 namespace Phpro\SoapClient\Console\Command;
 
 use Phpro\SoapClient\CodeGenerator\ClientGenerator;
-use Phpro\SoapClient\CodeGenerator\GeneratorInterface;
 use Phpro\SoapClient\CodeGenerator\Model\Client;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethodMap;
 use Phpro\SoapClient\Console\Helper\ConfigHelper;
-use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorChain;
-use Phpro\SoapClient\Soap\Metadata\MetadataFactory;
 use Phpro\SoapClient\Util\Filesystem;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,40 +14,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Laminas\Code\Generator\FileGenerator;
 use function Psl\Type\instance_of;
-use function Psl\Type\non_empty_string;
 
-/**
- * Class GenerateClientCommand
- *
- * @package Phpro\SoapClient\Console\Command
- */
 class GenerateClientCommand extends Command
 {
-
     const COMMAND_NAME = 'generate:client';
 
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * @var OutputInterface
-     */
-    private $output;
-
-    /**
-     * @param Filesystem $filesystem
-     */
-    public function __construct(Filesystem $filesystem)
-    {
+    public function __construct(
+        private Filesystem $filesystem
+    ) {
         parent::__construct();
-        $this->filesystem = $filesystem;
     }
 
-    /**
-     * Configure the command.
-     */
     protected function configure(): void
     {
         $this
@@ -64,81 +38,35 @@ class GenerateClientCommand extends Command
             );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->output = $output;
         $io = new SymfonyStyle($input, $output);
 
         $config = $this->getConfigHelper()->load($input);
 
-        $destination = $config->getClientDestination().'/'.$config->getClientName().'.php';
+        $clientConfig = $config->getClient();
+        $destination = $clientConfig->path();
         $methodMap = ClientMethodMap::fromMetadata(
-            non_empty_string()->assert($config->getTypeNamespace()),
+            $config->getTypeNamespaceMap(),
             $config->getManipulatedMetadata()->getMethods(),
         );
 
-        $client = new Client(
-            non_empty_string()->assert($config->getClientName()),
-            non_empty_string()->coerce($config->getClientNamespace()),
-            $methodMap
-        );
+        $client = new Client($clientConfig, $methodMap);
         $generator = new ClientGenerator($config->getRuleSet());
-        $fileGenerator = new FileGenerator();
-        $this->generateClient(
-            $fileGenerator,
-            $generator,
-            $client,
-            $destination
+
+        $this->filesystem->putFileContents(
+            $destination,
+            $generator->generate(
+                new FileGenerator(),
+                $client,
+            )
         );
 
         $io->success('Generated client at ' . $destination);
 
-        return 0;
+        return self::SUCCESS;
     }
 
-    /**
-     * Generates one type class
-     *
-     * @param FileGenerator $file
-     * @param GeneratorInterface $generator
-     * @param Client $client
-     * @param string $path
-     */
-    protected function generateClient(FileGenerator $file, GeneratorInterface $generator, Client $client, string $path)
-    {
-        $code = $generator->generate($file, $client);
-        $this->filesystem->putFileContents($path, $code);
-    }
-
-    /**
-     * Try to create a class for a type.
-     *
-     * @param ClientGenerator $generator
-     * @param Client $client
-     * @param string $path
-     * @return bool
-     */
-    protected function handleClient(ClientGenerator $generator, Client $client, string $path): bool
-    {
-        // Try to create a blanco class:
-        try {
-            $file = new FileGenerator();
-            $this->generateClient($file, $generator, $client, $path);
-        } catch (\Exception $e) {
-            $this->output->writeln('<fg=red>'.$e->getMessage().'</fg=red>');
-
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Function for added type hint
-     */
     public function getConfigHelper(): ConfigHelper
     {
         return instance_of(ConfigHelper::class)->assert($this->getHelper('config'));

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
@@ -22,24 +22,12 @@ class GenerateClientFactoryCommand extends Command
 {
     const COMMAND_NAME = 'generate:clientfactory';
 
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * GenerateClientBuilderCommand constructor.
-     * @param Filesystem $filesystem
-     */
-    public function __construct(Filesystem $filesystem)
-    {
-        $this->filesystem = $filesystem;
+    public function __construct(
+        private Filesystem $filesystem
+    ) {
         parent::__construct();
     }
 
-    /**
-     * Configure the command.
-     */
     protected function configure(): void
     {
         $this
@@ -53,37 +41,29 @@ class GenerateClientFactoryCommand extends Command
             );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $config = $this->getConfigHelper()->load($input);
         $classmapContext = new ClassMapContext(
             new FileGenerator(),
-            new TypeMap('not-used', []),
-            $config->getClassMapName(),
-            $config->getClassMapNamespace()
+            new TypeMap($config->getTypeNamespaceMap(), []),
+            $config->getClassMap(),
         );
         $clientContext = new ClientContext(
             new ClassGenerator(),
-            $config->getClientName(),
-            $config->getClientNamespace()
+            $config->getClient(),
         );
         $context = new ClientFactoryContext($clientContext, $classmapContext);
         $generator = new ClientFactoryGenerator();
-        $dest = $config->getClientDestination().DIRECTORY_SEPARATOR.$config->getClientName().'Factory.php';
+        $dest = $config->getClient()->destination->path.DIRECTORY_SEPARATOR.$config->getClient()->name.'Factory.php';
         $this->filesystem->putFileContents($dest, $generator->generate(new FileGenerator(), $context));
 
         $io->success('Generated client factory at ' . $dest);
 
-        return 0;
+        return self::SUCCESS;
     }
 
-    /**
-     * Function for added type hint
-     */
     public function getConfigHelper(): ConfigHelper
     {
         return instance_of(ConfigHelper::class)->assert($this->getHelper('config'));

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -2,8 +2,13 @@
 
 namespace Phpro\SoapClient\Console\Command;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\ConfigGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Console\Validator\NotBlankValidator;
 use Phpro\SoapClient\Util\Filesystem;
 use Symfony\Component\Console\Command\Command;
@@ -17,18 +22,9 @@ class GenerateConfigCommand extends Command
 {
     const COMMAND_NAME = 'generate:config';
 
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * GenerateConfigCommand constructor.
-     * @param Filesystem $filesystem
-     */
-    public function __construct(Filesystem $filesystem)
-    {
-        $this->filesystem = $filesystem;
+    public function __construct(
+        private Filesystem $filesystem
+    ) {
         parent::__construct();
     }
 
@@ -68,38 +64,39 @@ class GenerateConfigCommand extends Command
             $required
         );
         $baseDir = $io->ask('Directory where the client should be generated in', null, $required);
-        $namespace = $io->ask('Namespace for your client', null, $required);
+        $namespace = Normalizer::normalizeNamespace($io->ask('Namespace for your client', null, $required));
 
-        // Type
-        $context->addSetter('setTypeDestination', $baseDir.DIRECTORY_SEPARATOR.'Type');
-        $context->addSetter('setTypeNamespace', $namespace.'\\Type');
+        $context->addSetter('setTypeNamespaceMap', sprintf(
+            '%s::create(new %s(%s, %s))',
+            '\\' . TypeNamespaceMap::class,
+            '\\' . Destination::class,
+            var_export($baseDir . DIRECTORY_SEPARATOR . 'Type', true),
+            var_export($namespace . '\\Type', true)
+        ));
 
-        // Client
-        $this->addNonEmptySetter($context, 'setClientDestination', $baseDir);
-        $this->addNonEmptySetter($context, 'setClientName', $name.'Client');
-        $this->addNonEmptySetter($context, 'setClientNamespace', $namespace);
+        $context->addSetter('setClient', sprintf(
+            'new %s(%s, new %s(%s, %s))',
+            '\\' . ClientConfig::class,
+            var_export($name.'Client', true),
+            '\\' . Destination::class,
+            var_export($baseDir, true),
+            var_export($namespace, true)
+        ));
 
-        // Classmap
-        $this->addNonEmptySetter($context, 'setClassMapDestination', $baseDir);
-        $this->addNonEmptySetter($context, 'setClassMapName', $name.'Classmap');
-        $this->addNonEmptySetter($context, 'setClassMapNamespace', $namespace);
+        $context->addSetter('setClassMap', sprintf(
+            'new %s(%s, new %s(%s, %s))',
+            '\\' . ClassMapConfig::class,
+            var_export($name.'Classmap', true),
+            '\\' . Destination::class,
+            var_export($baseDir, true),
+            var_export($namespace, true)
+        ));
 
         // Create the config
         $generator = new ConfigGenerator();
         $this->filesystem->putFileContents($destination, $generator->generate(new FileGenerator(), $context));
         $io->success('Config has been written to ' . $destination);
 
-        return 0;
-    }
-
-    private function addNonEmptySetter(ConfigContext $context, string $key, string $value)
-    {
-        if ($value === '') {
-            return;
-        }
-        if (preg_match('/namespace$/i', $key)) {
-            $value = str_replace('/', '\\\\', $value);
-        }
-        $context->addSetter($key, $value);
+        return self::SUCCESS;
     }
 }

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -5,7 +5,6 @@ namespace Phpro\SoapClient\Console\Command;
 use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\ConfigGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
@@ -66,31 +65,16 @@ class GenerateConfigCommand extends Command
         $baseDir = $io->ask('Directory where the client should be generated in', null, $required);
         $namespace = Normalizer::normalizeNamespace($io->ask('Namespace for your client', null, $required));
 
-        $context->addSetter('setTypeNamespaceMap', sprintf(
-            '%s::create(new %s(%s, %s))',
-            '\\' . TypeNamespaceMap::class,
-            '\\' . Destination::class,
-            var_export($baseDir . DIRECTORY_SEPARATOR . 'Type', true),
-            var_export($namespace . '\\Type', true)
-        ));
+        // Create configuration objects
+        $typeDestination = new Destination($baseDir . DIRECTORY_SEPARATOR . 'Type', $namespace . '\\Type');
+        $context->setTypeDestination($typeDestination);
 
-        $context->addSetter('setClient', sprintf(
-            'new %s(%s, new %s(%s, %s))',
-            '\\' . ClientConfig::class,
-            var_export($name.'Client', true),
-            '\\' . Destination::class,
-            var_export($baseDir, true),
-            var_export($namespace, true)
-        ));
+        $clientDestination = new Destination($baseDir, $namespace);
+        $clientConfig = new ClientConfig($name . 'Client', $clientDestination);
+        $context->setClientConfig($clientConfig);
 
-        $context->addSetter('setClassMap', sprintf(
-            'new %s(%s, new %s(%s, %s))',
-            '\\' . ClassMapConfig::class,
-            var_export($name.'Classmap', true),
-            '\\' . Destination::class,
-            var_export($baseDir, true),
-            var_export($namespace, true)
-        ));
+        $classMapConfig = new ClassMapConfig($name . 'Classmap', $clientDestination);
+        $context->setClassMapConfig($classMapConfig);
 
         // Create the config
         $generator = new ConfigGenerator();

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -9,7 +9,10 @@ use Phpro\SoapClient\CodeGenerator\ConfigGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Console\Validator\NotBlankValidator;
+use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Util\Filesystem;
+use Soap\WsdlReader\Model\Wsdl1;
+use Soap\WsdlReader\Wsdl1Reader;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -55,7 +58,18 @@ class GenerateConfigCommand extends Command
             );
         }
 
-        $context->setWsdl($io->ask('Wsdl location (URL or path to file)', null, $required));
+        $wsdlUri = $io->ask('Wsdl location (URL or path to file)', null, $required);
+        $context->setWsdl($wsdlUri);
+
+        $io->warning('Attempting to load WSDL... (this might take a while)');
+        $wsdl = $this->loadWsdl($wsdlUri);
+
+        if (!$wsdl) {
+            $io->warning('Could not load the provided WSDL with default engine options.');
+            $io->info('Continuing generating configuration...');
+        }
+
+        $context->setDetectedXmlNamespaces($wsdl?->namespaces->namespaceToNameMap ?? []);
         $context->setGenerateDocblocks($io->confirm('Should methods be generated with docblocks?', true));
         $name = $io->ask(
             'Generic name used to name this client (Results in <name>Client <name>Classmap etc.)',
@@ -81,6 +95,27 @@ class GenerateConfigCommand extends Command
         $this->filesystem->putFileContents($destination, $generator->generate(new FileGenerator(), $context));
         $io->success('Config has been written to ' . $destination);
 
+        if (!$wsdl) {
+            $io->warning(
+                'The WSDL could not be loaded with default options.' .
+                'You may need to configure custom engine options or verify the WSDL file manually before continuing.'
+            );
+
+            return self::FAILURE;
+        }
+
         return self::SUCCESS;
+    }
+
+    private function loadWsdl(string $wsdl): ?Wsdl1
+    {
+        try {
+            $options = EngineOptions::defaults($wsdl);
+            $loader = $options->getWsdlLoader();
+
+            return (new Wsdl1Reader($loader))($wsdl);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 }

--- a/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
@@ -9,7 +9,6 @@ use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use Phpro\SoapClient\CodeGenerator\TypeGenerator;
 use Phpro\SoapClient\Console\Helper\ConfigHelper;
-use Phpro\SoapClient\Soap\Metadata\MetadataFactory;
 use Phpro\SoapClient\Util\Filesystem;
 use Soap\WsdlReader\Metadata\Predicate\IsConsideredScalarType;
 use SplFileInfo;
@@ -20,40 +19,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Laminas\Code\Generator\FileGenerator;
 use function Psl\Type\instance_of;
-use function Psl\Type\non_empty_string;
 
-/**
- * Class GenerateTypesCommand
- *
- * @package Phpro\SoapClient\Console\Command
- */
 class GenerateTypesCommand extends Command
 {
-
     const COMMAND_NAME = 'generate:types';
 
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
+    private OutputInterface $output;
 
-    /**
-     * @var OutputInterface
-     */
-    private $output;
-
-    /**
-     * @param Filesystem $filesystem
-     */
-    public function __construct(Filesystem $filesystem)
-    {
-        parent::__construct(null);
-        $this->filesystem = $filesystem;
-    }
-
-    /**
-     * Configure the command.
-     */
     protected function configure(): void
     {
         $this
@@ -67,9 +39,12 @@ class GenerateTypesCommand extends Command
             );
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    public function __construct(
+        private Filesystem $filesystem
+    ) {
+        parent::__construct();
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
@@ -77,13 +52,12 @@ class GenerateTypesCommand extends Command
 
         $config = $this->getConfigHelper()->load($input);
         $typeMap = TypeMap::fromMetadata(
-            non_empty_string()->assert($config->getTypeNamespace()),
+            $config->getTypeNamespaceMap(),
             $config->getManipulatedMetadata()->getTypes(),
         );
 
-        $typesDestination = non_empty_string()->assert($config->getTypeDestination());
         foreach ($typeMap->getTypes() as $type) {
-            $fileInfo = $type->getFileInfo($typesDestination);
+            $fileInfo = $type->getFileInfo();
             if ($this->handleType($config, $type, $fileInfo)) {
                 $this->output->writeln(
                     sprintf('Generated class %s to %s', $type->getFullName(), $fileInfo->getPathname())
@@ -93,7 +67,7 @@ class GenerateTypesCommand extends Command
 
         $io->success('All SOAP types generated');
 
-        return 0;
+        return self::SUCCESS;
     }
 
     /**
@@ -110,9 +84,6 @@ class GenerateTypesCommand extends Command
         };
     }
 
-    /**
-     * Try to create a class for a type.
-     */
     protected function handleType(Config $config, Type $type, SplFileInfo $fileInfo): bool
     {
         $generator = $this->detectCodeGeneratorForType($config, $type);
@@ -130,8 +101,8 @@ class GenerateTypesCommand extends Command
 
         // Try to create a blanco class:
         try {
-            $file = new FileGenerator();
-            $this->generateType($file, $generator, $type, $fileInfo);
+            $code = $generator->generate(new FileGenerator(), $type);
+            $this->filesystem->putFileContents($fileInfo->getPathname(), $code);
         } catch (\Exception $e) {
             $this->output->writeln('<fg=red>Error generating '.$type->getFullName().':'.$e->getMessage().'</fg=red>');
             if ($this->output->isVeryVerbose()) {
@@ -144,22 +115,6 @@ class GenerateTypesCommand extends Command
         return true;
     }
 
-    /**
-     * @param GeneratorInterface<Type> $generator
-     */
-    protected function generateType(
-        FileGenerator $file,
-        GeneratorInterface $generator,
-        Type $type,
-        SplFileInfo $fileInfo
-    ): void {
-        $code = $generator->generate($file, $type);
-        $this->filesystem->putFileContents($fileInfo->getPathname(), $code);
-    }
-
-    /**
-     * Function for added type hint
-     */
     public function getConfigHelper(): ConfigHelper
     {
         return instance_of(ConfigHelper::class)->assert($this->getHelper('config'));

--- a/src/Phpro/SoapClient/Console/Command/WizardCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/WizardCommand.php
@@ -14,9 +14,6 @@ class WizardCommand extends Command
 {
     const COMMAND_NAME = 'wizard';
 
-    /**
-     * Configure the command.
-     */
     protected function configure(): void
     {
         $this
@@ -50,6 +47,6 @@ class WizardCommand extends Command
             }
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/Phpro/SoapClient/Exception/InvalidArgumentException.php
+++ b/src/Phpro/SoapClient/Exception/InvalidArgumentException.php
@@ -2,8 +2,6 @@
 
 namespace Phpro\SoapClient\Exception;
 
-use Throwable;
-
 /**
  * Class InvalidArgumentException
  *
@@ -16,48 +14,23 @@ final class InvalidArgumentException extends \InvalidArgumentException
         return new static('You did not configure a soap engine');
     }
 
-    public static function destinationConfigurationIsMissing(): self
-    {
-        return new static('You did not configure a destination.');
-    }
-
     public static function invalidConfigFile(): self
     {
         return new static('You have to provide a code-generator config file which returns a Config class instance.');
     }
 
-    public static function clientNamespaceIsMissing(): self
+    public static function clientIsMissing(): self
     {
-        return new static('You did not configure a client namespace.');
+        return new static('You did not configure a client.');
     }
 
-    public static function typeNamespaceIsMissing(): self
+    public static function typeNamespaceMapIsMissing(): self
     {
-        return new static('You did not configure a type namespace.');
+        return new static('You did not configure a namespace mapping for the types.');
     }
 
-    public static function clientDestinationIsMissing(): self
+    public static function classmapMissing(): self
     {
-        return new static('You did not configure a client destination.');
-    }
-
-    public static function typeDestinationIsMissing(): self
-    {
-        return new static('You did not configure a type destination.');
-    }
-
-    public static function classmapNameMissing(): self
-    {
-        return new static('You did not configure a classmap name.');
-    }
-
-    public static function classmapNamespaceMissing(): self
-    {
-        return new static('You did not configure a classmap namespace.');
-    }
-
-    public static function classmapDestinationMissing(): self
-    {
-        return new static('You did not configure a classmap destination.');
+        return new static('You did not configure a classmap.');
     }
 }

--- a/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/DuplicateTypesKey.php
+++ b/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/DuplicateTypesKey.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes;
+
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Soap\Engine\Metadata\Model\Type;
+use function Psl\Type\non_empty_string;
+
+final class DuplicateTypesKey
+{
+    /**
+     * Generates a unique key for grouping/detecting duplicate types.
+     * When namespace map is provided, types in different target PHP namespaces
+     * are NOT considered duplicates (they produce different keys).
+     */
+    public static function forType(Type $type, ?TypeNamespaceMap $namespaceMap): string
+    {
+        $normalizedName = Normalizer::normalizeClassname(non_empty_string()->assert($type->getName()));
+
+        if ($namespaceMap === null) {
+            return $normalizedName;
+        }
+
+        $destination = $namespaceMap->detectDestinationForType($type->getXsdType());
+
+        return $destination->namespace . '\\' . $normalizedName;
+    }
+}

--- a/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes;
 
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Closure;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorInterface;
 use Soap\Engine\Metadata\Collection\PropertyCollection;
 use Soap\Engine\Metadata\Collection\TypeCollection;
@@ -15,26 +16,40 @@ use function Psl\Iter\contains;
 use function Psl\Iter\first;
 use function Psl\Iter\reduce;
 use function Psl\Type\instance_of;
-use function Psl\Type\non_empty_string;
 use function Psl\Vec\flat_map;
 use function Psl\Vec\map;
 use function Psl\Vec\values;
 
 final class IntersectDuplicateTypesStrategy implements TypesManipulatorInterface
 {
+    public function __construct(
+        private ?TypeNamespaceMap $namespaceMap = null
+    ) {
+    }
+
+    /**
+     * Factory that returns a closure - Config will call it with the namespace map.
+     *
+     * @return Closure(?TypeNamespaceMap): self
+     */
+    public static function create(): Closure
+    {
+        return static fn (?TypeNamespaceMap $map) => new self($map);
+    }
+
     public function __invoke(TypeCollection $allTypes): TypeCollection
     {
         return new TypeCollection(...array_values($allTypes->reduce(
             function (array $result, Type $type) use ($allTypes): array {
-                $name = Normalizer::normalizeClassname(non_empty_string()->assert($type->getName()));
-                if (array_key_exists($name, $result)) {
+                $key = DuplicateTypesKey::forType($type, $this->namespaceMap);
+                if (array_key_exists($key, $result)) {
                     return $result;
                 }
 
                 return array_merge(
                     $result,
                     [
-                        $name => $this->intersectTypes($this->fetchAllTypesNormalizedByName($allTypes, $name))
+                        $key => $this->intersectTypes($this->fetchAllTypesWithSameKey($allTypes, $key))
                     ]
                 );
             },
@@ -54,11 +69,9 @@ final class IntersectDuplicateTypesStrategy implements TypesManipulatorInterface
         );
     }
 
-    private function fetchAllTypesNormalizedByName(TypeCollection $types, string $name): TypeCollection
+    private function fetchAllTypesWithSameKey(TypeCollection $types, string $key): TypeCollection
     {
-        return $types->filter(static function (Type $type) use ($name): bool {
-            return Normalizer::normalizeClassname(non_empty_string()->assert($type->getName())) === $name;
-        });
+        return $types->filter(fn (Type $type): bool => DuplicateTypesKey::forType($type, $this->namespaceMap) === $key);
     }
 
     private function uniqueProperties(PropertyCollection ...$types): PropertyCollection

--- a/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
@@ -4,25 +4,49 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes;
 
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
-use Phpro\SoapClient\Soap\Metadata\Detector\DuplicateTypeNamesDetector;
+use Closure;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorInterface;
 use Soap\Engine\Metadata\Collection\TypeCollection;
 use Soap\Engine\Metadata\Model\Type;
-use function Psl\Type\non_empty_string;
 
 final class RemoveDuplicateTypesStrategy implements TypesManipulatorInterface
 {
+    public function __construct(
+        private ?TypeNamespaceMap $namespaceMap = null
+    ) {
+    }
+
+    /**
+     * Factory that returns a closure - Config will call it with the namespace map.
+     *
+     * @return Closure(?TypeNamespaceMap): self
+     */
+    public static function create(): Closure
+    {
+        return static fn (?TypeNamespaceMap $map) => new self($map);
+    }
+
     public function __invoke(TypeCollection $types): TypeCollection
     {
-        $duplicateNames = (new DuplicateTypeNamesDetector())($types);
+        $duplicateKeys = $this->detectDuplicateKeys($types);
 
-        return $types->filter(static function (Type $type) use ($duplicateNames): bool {
-            return !in_array(
-                Normalizer::normalizeClassname(non_empty_string()->assert($type->getName())),
-                $duplicateNames,
-                true
-            );
-        });
+        return $types->filter(
+            fn (Type $type): bool => !in_array(DuplicateTypesKey::forType($type, $this->namespaceMap), $duplicateKeys, true)
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function detectDuplicateKeys(TypeCollection $types): array
+    {
+        $keyCounts = [];
+        foreach ($types as $type) {
+            $key = DuplicateTypesKey::forType($type, $this->namespaceMap);
+            $keyCounts[$key] = ($keyCounts[$key] ?? 0) + 1;
+        }
+
+        return array_keys(array_filter($keyCounts, static fn (int $count): bool => $count > 1));
     }
 }

--- a/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
@@ -32,7 +32,11 @@ final class RemoveDuplicateTypesStrategy implements TypesManipulatorInterface
         $duplicateKeys = $this->detectDuplicateKeys($types);
 
         return $types->filter(
-            fn (Type $type): bool => !in_array(DuplicateTypesKey::forType($type, $this->namespaceMap), $duplicateKeys, true)
+            fn (Type $type): bool => !in_array(
+                DuplicateTypesKey::forType($type, $this->namespaceMap),
+                $duplicateKeys,
+                true
+            )
         );
     }
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/AbstractClassAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/AbstractClassAssemblerTest.php
@@ -7,6 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\AbstractClassAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -21,6 +22,8 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class AbstractClassAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
+
     #[Test]
     function it_is_an_assembler()
     {
@@ -62,9 +65,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace ='MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use Laminas\Code\Generator\FileGenerator;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -22,6 +23,8 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class ClassMapAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
+
     #[Test]
     function it_is_an_assembler()
     {
@@ -50,7 +53,6 @@ class ClassMapAssemblerTest extends TestCase
 
 namespace ClassMapNamespace;
 
-use MyNamespace as Type;
 use Soap\Encoding\ClassMap\ClassMapCollection;
 use Soap\Encoding\ClassMap\ClassMap;
 
@@ -59,14 +61,14 @@ class MyClassMap
     public static function types(): \Soap\Encoding\ClassMap\ClassMapCollection
     {
         return new ClassMapCollection(
-            new ClassMap('http://my-namespace.com', 'MyType', Type\MyType::class),
+            new ClassMap('http://my-namespace.com', 'MyType', \MyNamespace\MyType::class),
         );
     }
 
     public static function enums(): \Soap\Encoding\ClassMap\ClassMapCollection
     {
         return new ClassMapCollection(
-            new ClassMap('http://my-namespace.com', 'MyEnum', Type\MyEnum::class),
+            new ClassMap('http://my-namespace.com', 'MyEnum', \MyNamespace\MyEnum::class),
         );
     }
 }
@@ -82,14 +84,15 @@ CODE;
     private function createContext()
     {
         $file = new FileGenerator();
-        $typeMap = new TypeMap($namespace = 'MyNamespace', [
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $typeMap = new TypeMap($namespaces, [
             new Type(
-                $namespace,
+                $namespaces,
                 'MyType',
                 'MyType',
                 [
                     Property::fromMetaData(
-                        $namespace,
+                        $namespaces,
                         new MetaProperty('myProperty', XsdType::guess('string'))
                     ),
                 ],
@@ -97,7 +100,7 @@ CODE;
                     ->withXmlNamespace('http://my-namespace.com')
             ),
             new Type(
-                $namespace,
+                $namespaces,
                 'MyEnum',
                 'MyEnum',
                 [],
@@ -111,6 +114,6 @@ CODE;
             ),
         ]);
 
-        return new ClassMapContext($file, $typeMap, 'MyClassMap', 'ClassMapNamespace');
+        return new ClassMapContext($file, $typeMap, $this->createClassMapConfig('MyClassMap', 'ClassMapNamespace'));
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientConstructorAssemblerTest.php
@@ -7,11 +7,14 @@ use Phpro\SoapClient\CodeGenerator\Assembler\ClientConstructorAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\Exception\AssemblerException;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 class ClientConstructorAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
+
     #[Test]
     function it_is_an_assembler()
     {
@@ -31,12 +34,10 @@ class ClientConstructorAssemblerTest extends TestCase
     {
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
-        $typeNamespace = 'Vendor\\MyTypeNamespace';
 
         return new ClientContext(
             $class,
-            'MyClient',
-            $typeNamespace
+            $this->createClientConfig('MyClient', 'Vendor\\MyNamespace')
         );
     }
 
@@ -69,12 +70,12 @@ CODE;
     #[Test]
     function it_throws_an_exception_when_wrong_context_is_passed() {
         $clientMethodAssembler = new ClientConstructorAssembler();
-        $context = $this->createMock(ContextInterface::class);
+        $context = $this->createStub(ContextInterface::class);
         $this->expectException(AssemblerException::class);
         $this->expectExceptionMessage(sprintf(
                 'Phpro\SoapClient\CodeGenerator\Assembler\ClientConstructorAssembler::assemble '.
                 'expects an Phpro\SoapClient\CodeGenerator\Context\ClientContext as input %s given',
-                get_class($context)
+                $context::class
             )
         );
         $clientMethodAssembler->assemble($context);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -10,6 +10,7 @@ use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
 use Phpro\SoapClient\CodeGenerator\Model\Parameter;
 use Phpro\SoapClient\CodeGenerator\Model\ReturnType;
 use Phpro\SoapClient\Exception\AssemblerException;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Soap\Engine\Metadata\Model\MethodMeta;
@@ -23,6 +24,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class ClientMethodAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
     #[Test]
     function it_is_an_assembler()
     {
@@ -47,13 +49,14 @@ class ClientMethodAssemblerTest extends TestCase
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
+        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [
-                new Parameter('param', 'ParamType', $typeNamespace, XsdType::create('ParamType')),
+                new Parameter('param', 'ParamType', $namespaces, XsdType::create('ParamType')),
             ],
-            ReturnType::fromMetaData($typeNamespace, XsdType::create('ReturnType')),
-            $typeNamespace,
+            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnType')),
+            $namespaces,
             (new MethodMeta())->withDocs('This is an awesome function.')
         );
 
@@ -69,14 +72,15 @@ class ClientMethodAssemblerTest extends TestCase
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
+        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [
-                new Parameter('param', 'ParamType', $typeNamespace, XsdType::create('ParamType')),
-                new Parameter('param2', 'OtherParamType', $typeNamespace, XsdType::create('OtherParamType')),
+                new Parameter('param', 'ParamType', $namespaces, XsdType::create('ParamType')),
+                new Parameter('param2', 'OtherParamType', $namespaces, XsdType::create('OtherParamType')),
             ],
-            ReturnType::fromMetaData($typeNamespace, XsdType::create('ReturnType')),
-            $typeNamespace,
+            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnType')),
+            $namespaces,
             (new MethodMeta())->withDocs('This is an awesome function.')
         );
 
@@ -92,11 +96,12 @@ class ClientMethodAssemblerTest extends TestCase
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
+        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [],
-            ReturnType::fromMetaData($typeNamespace, XsdType::create('ReturnType')),
-            $typeNamespace,
+            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnType')),
+            $namespaces,
             new MethodMeta()
         );
 
@@ -233,13 +238,14 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
+        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
         $method = new ClientMethod(
             'Function_name',
             [
-                new Parameter('param', 'param_type', $typeNamespace, XsdType::create('param_type')),
+                new Parameter('param', 'param_type', $namespaces, XsdType::create('param_type')),
             ],
-            ReturnType::fromMetaData($typeNamespace, XsdType::create('return_type')),
-            $typeNamespace,
+            ReturnType::fromMetaData($namespaces, XsdType::create('return_type')),
+            $namespaces,
             new MethodMeta()
         );
 
@@ -281,7 +287,8 @@ CODE;
     #[Test]
     function it_throws_an_exception_when_wrong_context_is_passed() {
         $clientMethodAssembler = new ClientMethodAssembler();
-        $context = $this->createMock(ClientContext::class);
+        $clientConfig = $this->createClientConfig('TestClient', 'Test\\Namespace');
+        $context = new ClientContext(new ClassGenerator(), $clientConfig);
         $this->expectException(AssemblerException::class);
         $this->expectExceptionMessage(sprintf(
                 'Phpro\SoapClient\CodeGenerator\Assembler\ClientMethodAssembler::assemble '.
@@ -298,13 +305,14 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
+        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
         $method = new ClientMethod(
             'Function_name',
             [
-                new Parameter('param', 'string', $typeNamespace, XsdType::create('string')->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true))),
+                new Parameter('param', 'string', $namespaces, XsdType::create('string')->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true))),
             ],
-            ReturnType::fromMetaData($typeNamespace, XsdType::create('ReturnType')),
-            $typeNamespace,
+            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnType')),
+            $namespaces,
             new MethodMeta()
         );
 
@@ -354,13 +362,14 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
+        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [],
-            ReturnType::fromMetaData($typeNamespace, XsdType::create('string')->withMeta(
+            ReturnType::fromMetaData($namespaces, XsdType::create('string')->withMeta(
                 fn (TypeMeta $meta): TypeMeta => $meta->withIsSimple(true)
             )),
-            $typeNamespace,
+            $namespaces,
             new MethodMeta()
         );
 
@@ -405,16 +414,17 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
+        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [
-                new Parameter('param1', 'string', $typeNamespace, XsdType::create('string')),
-                new Parameter('param2', 'string', $typeNamespace, XsdType::create('string')),
+                new Parameter('param1', 'string', $namespaces, XsdType::create('string')),
+                new Parameter('param2', 'string', $namespaces, XsdType::create('string')),
             ],
-            ReturnType::fromMetaData($typeNamespace, XsdType::create('string')->withMeta(
+            ReturnType::fromMetaData($namespaces, XsdType::create('string')->withMeta(
                 fn (TypeMeta $meta): TypeMeta => $meta->withIsSimple(true)
             )),
-            $typeNamespace,
+            $namespaces,
             new MethodMeta()
         );
 
@@ -465,11 +475,12 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
+        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [],
-            ReturnType::fromMetaData($typeNamespace, XsdType::create('ReturnTypeElement')->withXmlTypeName('ReturnType')),
-            $typeNamespace,
+            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnTypeElement')->withXmlTypeName('ReturnType')),
+            $namespaces,
             new MethodMeta()
         );
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\ConstructorAssemblerOptions;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -22,6 +23,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class ConstructorAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
     #[Test]
     function it_is_an_assembler()
     {
@@ -73,10 +75,11 @@ CODE;
     {
         $assembler = new ConstructorAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop3', XsdType::guess('SomeClass'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop3', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
         $context =  new TypeContext($class, $type);
@@ -142,9 +145,10 @@ CODE;
     {
         $assembler = new ConstructorAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
             Property::fromMetaData(
-                $namespace,
+                $namespaces,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
@@ -182,9 +186,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
@@ -7,6 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\ExtendAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -21,6 +22,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class ExtendAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -85,9 +87,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendingTypeAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendingTypeAssemblerTest.php
@@ -6,6 +6,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
 use Phpro\SoapClient\CodeGenerator\Assembler\ExtendingTypeAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -19,6 +20,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class ExtendingTypeAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -82,7 +84,8 @@ CODE;
     {
         $assembler = new ExtendingTypeAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
 
         $context = new TypeContext($class, $type);
         $assembler->assemble($context);
@@ -105,7 +108,8 @@ CODE;
     {
         $assembler = new ExtendingTypeAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
             'type' => 'string',
             'namespace' => 'xsd',
             'isSimple' => true,
@@ -133,7 +137,8 @@ CODE;
     private function createContext(?string $importedNamespace = null)
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($importedNamespace ?? 'MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
+        $namespaces = $this->createTypeNamespaceMap($importedNamespace ?? 'MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
             'type' => 'MyBaseType',
             'namespace' => 'xxxx'
         ])));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FinalClassAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FinalClassAssemblerTest.php
@@ -7,6 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\FinalClassAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -21,6 +22,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class FinalClassAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
     #[Test]
     function it_is_an_assembler()
     {
@@ -62,9 +64,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace ='MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'), new TypeMeta());
 
         return new TypeContext($class, $type);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\FluentSetterAssemblerOptions;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -22,6 +23,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class FluentSetterAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
     #[Test]
     function it_is_an_assembler()
     {
@@ -184,9 +186,10 @@ CODE;
     {
         $assembler = new FluentSetterAssembler((new FluentSetterAssemblerOptions()));
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespace,
+                $namespaces,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
@@ -224,9 +227,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespace,
+                $namespaces,
                 new MetaProperty('prop1', XsdType::guess('string'))
             ),
         ], XsdType::create('MyType'));
@@ -240,8 +244,9 @@ CODE;
     private function createContextWithAnUnknownType()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            $property = Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('foobar'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('foobar'))),
         ], XsdType::create('MyType'));
 
         return new PropertyContext($class, $type, $property);
@@ -252,14 +257,16 @@ CODE;
      */
     private function createContextWithLongType()
     {
+        $longNamespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
         $properties = [
             'prop1' => Property::fromMetaData(
-                'This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever',
+                $longNamespaces,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\GetterAssemblerOptions;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -22,6 +23,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class GetterAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
     #[Test]
     function it_is_an_assembler()
     {
@@ -238,9 +240,10 @@ CODE;
     {
         $assembler = new GetterAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespace,
+                $namespaces,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
@@ -276,15 +279,17 @@ CODE;
      */
     private function createContext($propertyName = 'prop1')
     {
+        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
         $properties = [
-            'prop1' => Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string'))),
-            'prop2' => Property::fromMetaData('ns1', new MetaProperty('prop2', XsdType::guess('int'))),
-            'prop3' => Property::fromMetaData('ns1', new MetaProperty('prop3', XsdType::guess('bool'))),
-            'prop4' => Property::fromMetaData('ns1', new MetaProperty('prop4', XsdType::guess('My_Response'))),
+            'prop1' => Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            'prop2' => Property::fromMetaData($ns1Namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+            'prop3' => Property::fromMetaData($ns1Namespaces, new MetaProperty('prop3', XsdType::guess('bool'))),
+            'prop4' => Property::fromMetaData($ns1Namespaces, new MetaProperty('prop4', XsdType::guess('My_Response'))),
         ];
 
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties[$propertyName];
 
         return new PropertyContext($class, $type, $property);
@@ -295,14 +300,16 @@ CODE;
      */
     private function createContextWithLongType()
     {
+        $longNamespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
         $properties = [
             'prop1' => Property::fromMetaData(
-                'This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever',
+                $longNamespaces,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\ImmutableSetterAssemblerOptions;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -22,6 +23,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class ImmutableSetterAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -229,9 +231,10 @@ CODE;
     {
         $assembler = new ImmutableSetterAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespace,
+                $namespaces,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
@@ -271,8 +274,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [
-            $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
         ], XsdType::create('MyType'));
 
         return new PropertyContext($class, $type, $property);
@@ -283,14 +288,16 @@ CODE;
      */
     private function createContextWithLongType()
     {
+        $longNamespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
         $properties = [
             'prop1' => Property::fromMetaData(
-                'This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever',
+                $longNamespaces,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -22,6 +23,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class InterfaceAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -43,8 +45,10 @@ class InterfaceAssemblerTest extends TestCase
     {
         $assembler = new InterfaceAssembler('MyUsedClass');
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
-        $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string')));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
+        $property = Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string')));
         $context = new PropertyContext($class, $type, $property);
         $this->assertTrue($assembler->canAssemble($context));
     }
@@ -77,9 +81,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
@@ -7,6 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\IteratorAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -22,6 +23,7 @@ use function Psl\Fun\identity;
  */
 class IteratorAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -119,8 +121,9 @@ CODE;
     {
         $metaConfigurator ??= identity();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $metaConfigurator($meta
                     ->withIsList(true)
                     ->withMinOccurs(1)

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
@@ -7,6 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\JsonSerializableAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -21,6 +22,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class JsonSerializableAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -72,9 +74,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\PropertyAssemblerOptions;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -23,6 +24,8 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class PropertyAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
+
     #[Test]
     function it_is_an_assembler()
     {
@@ -188,9 +191,10 @@ CODE;
     {
         $assembler = new PropertyAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespace,
+                $namespaces,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
@@ -282,8 +286,9 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [
-            $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string')->withMeta(
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withDocs('Type specific docs')
             ))),
         ], XsdType::create('MyType'));
@@ -297,9 +302,10 @@ CODE;
     private function createContextWithLongType()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [
+        $namespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                'This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever',
+                $namespaces,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ], XsdType::create('MyType'));
@@ -312,8 +318,9 @@ CODE;
     private function createContextWithNullableType()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [
-            $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string')->withMeta(
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withDocs('Type specific docs')->withIsNullable(true)
             ))),
         ], XsdType::create('MyType'));

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyDefaultsAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyDefaultsAssemblerTest.php
@@ -6,6 +6,8 @@ use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
 use Phpro\SoapClient\CodeGenerator\Assembler\PropertyAssembler;
 use Phpro\SoapClient\CodeGenerator\Assembler\PropertyAssemblerOptions;
 use Phpro\SoapClient\CodeGenerator\Assembler\PropertyDefaultsAssembler;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
@@ -101,13 +103,15 @@ EOCODE,
 
     private static function configureProperty(XsdType $type): Property
     {
-        return Property::fromMetaData('ns1', new MetaProperty('prop1', $type));
+        $namespaces = TypeNamespaceMap::create(new Destination('/generated', 'ns1'));
+        return Property::fromMetaData($namespaces, new MetaProperty('prop1', $type));
     }
 
     private static function createContext(Property $property): PropertyContext
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [
+        $namespaces = TypeNamespaceMap::create(new Destination('/generated', 'MyNamespace'));
+        $type = new Type($namespaces, 'MyType', 'MyType', [
             $property
         ], XsdType::create('MyType'));
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/RequestAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/RequestAssemblerTest.php
@@ -7,6 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\RequestAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -21,6 +22,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class RequestAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -65,9 +67,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultAssemblerTest.php
@@ -7,6 +7,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\ResultAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -21,6 +22,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class ResultAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -65,9 +67,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespace, new MetaProperty('prop2', XsdType::guess('int'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\Type\MixedResult;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -22,6 +23,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class ResultProviderAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
     #[Test]
     function it_is_an_assembler()
     {
@@ -133,8 +135,9 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
-            Property::fromMetaData($namespace, new MetaProperty('prop1', XsdType::guess('SomeClass'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\SetterAssemblerOptions;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -22,6 +23,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class SetterAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -149,9 +151,10 @@ CODE;
     {
         $assembler = new SetterAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type($namespace = 'MyNamespace', 'MyType', 'MyType', [
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespace,
+                $namespaces,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
@@ -187,8 +190,10 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [
-            $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string'))),
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
+        $type = new Type($namespaces, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
         ], XsdType::create('MyType'));
 
         return new PropertyContext($class, $type, $property);
@@ -199,14 +204,16 @@ CODE;
      */
     private function createContextWithLongType()
     {
+        $longNamespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
         $properties = [
             'prop1' => Property::fromMetaData(
-                'This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever',
+                $longNamespaces,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
         return new PropertyContext($class, $type, $property);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/TraitAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/TraitAssemblerTest.php
@@ -6,6 +6,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
 use Phpro\SoapClient\CodeGenerator\Assembler\TraitAssembler;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -19,6 +20,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class TraitAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -87,7 +89,8 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
@@ -8,6 +8,7 @@ use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
+use PhproTest\SoapClient\Unit\CodeGenerator\ConfigurationHelper;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Laminas\Code\Generator\ClassGenerator;
@@ -22,6 +23,7 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class UseAssemblerTest extends TestCase
 {
+    use ConfigurationHelper;
 
     #[Test]
     function it_is_an_assembler()
@@ -43,8 +45,10 @@ class UseAssemblerTest extends TestCase
     {
         $assembler = new UseAssembler('MyUsedClass');
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
-        $property = Property::fromMetaData('ns1', new MetaProperty('prop1', XsdType::guess('string')));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
+        $property = Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string')));
         $context = new PropertyContext($class, $type, $property);
         $this->assertTrue($assembler->canAssemble($context));
     }
@@ -161,7 +165,8 @@ CODE;
     {
         $assembler = new UseAssembler('SomeOtherClass');
         $class = new ClassGenerator('MyType');
-        $type = new Type('', 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $namespaces = $this->createTypeNamespaceMap('');
+        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
         $context = new TypeContext($class, $type);
 
         $assembler->assemble($context);
@@ -206,7 +211,8 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $type = new Type('MyNamespace', 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
+        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
 
         return new TypeContext($class, $type);
     }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
@@ -4,9 +4,14 @@ namespace PhproTest\SoapClient\Unit\CodeGenerator;
 
 use Laminas\Code\Generator\ClassGenerator;
 use Phpro\SoapClient\CodeGenerator\ClientFactoryGenerator;
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientFactoryContext;
+use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use PHPUnit\Framework\TestCase;
 use Laminas\Code\Generator\FileGenerator;
 
@@ -64,12 +69,15 @@ class MyclientFactory
 
 
 BODY;
-        $clientContext = new ClientContext(new ClassGenerator(), 'Myclient', 'App\\Client');
+        $clientConfig = new ClientConfig('Myclient', new Destination('/app/client', 'App\\Client'));
+        $clientContext = new ClientContext(new ClassGenerator(), $clientConfig);
+
+        $typeNamespaceMap = TypeNamespaceMap::create(new Destination('/app/types', 'App\\Types'));
+        $classMapConfig = new ClassMapConfig('SomeClassmap', new Destination('/app/classmap', 'App\\Classmap'));
         $classMapContext = new ClassMapContext(
             new FileGenerator(),
-            new \Phpro\SoapClient\CodeGenerator\Model\TypeMap('App\\Types', []),
-            'SomeClassmap',
-            'App\\Classmap'
+            new TypeMap($typeNamespaceMap, []),
+            $classMapConfig
         );
         $context = new ClientFactoryContext($clientContext, $classMapContext);
         $generator = new ClientFactoryGenerator();

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/ClassMapConfigTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/ClassMapConfigTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Config;
+
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class ClassMapConfigTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed_with_name_and_destination(): void
+    {
+        $destination = new Destination('/src/Classmap', 'App\\Classmap');
+        $config = new ClassMapConfig('MyClassmap', $destination);
+
+        $this->assertSame('MyClassmap', $config->name);
+        $this->assertSame($destination, $config->destination);
+    }
+
+    #[Test]
+    public function it_generates_correct_file_path(): void
+    {
+        $destination = new Destination('/src/Classmap', 'App\\Classmap');
+        $config = new ClassMapConfig('MyClassmap', $destination);
+
+        $this->assertSame('/src/Classmap/MyClassmap.php', $config->path());
+    }
+
+    #[Test]
+    public function it_generates_correct_fully_qualified_class_name(): void
+    {
+        $destination = new Destination('/src/Classmap', 'App\\Classmap');
+        $config = new ClassMapConfig('MyClassmap', $destination);
+
+        $this->assertSame('App\\Classmap\\MyClassmap', $config->fqcn());
+    }
+
+    #[Test]
+    public function it_handles_nested_namespaces(): void
+    {
+        $destination = new Destination('/src/Classmap/Generated/V1', 'App\\Classmap\\Generated\\V1');
+        $config = new ClassMapConfig('SoapClassmap', $destination);
+
+        $this->assertSame('/src/Classmap/Generated/V1/SoapClassmap.php', $config->path());
+        $this->assertSame('App\\Classmap\\Generated\\V1\\SoapClassmap', $config->fqcn());
+    }
+
+    #[Test]
+    public function it_handles_simple_namespace(): void
+    {
+        $destination = new Destination('/src', 'App');
+        $config = new ClassMapConfig('Classmap', $destination);
+
+        $this->assertSame('/src/Classmap.php', $config->path());
+        $this->assertSame('App\\Classmap', $config->fqcn());
+    }
+
+    #[Test]
+    public function it_handles_path_without_leading_slash(): void
+    {
+        $destination = new Destination('src/Classmap', 'App\\Classmap');
+        $config = new ClassMapConfig('MyClassmap', $destination);
+
+        $this->assertSame('src/Classmap/MyClassmap.php', $config->path());
+    }
+
+    #[Test]
+    public function it_handles_trailing_slash_in_path(): void
+    {
+        $destination = new Destination('/src/Classmap/', 'App\\Classmap');
+        $config = new ClassMapConfig('MyClassmap', $destination);
+
+        $this->assertSame('/src/Classmap/MyClassmap.php', $config->path());
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/ClientConfigTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/ClientConfigTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Config;
+
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class ClientConfigTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed_with_name_and_destination(): void
+    {
+        $destination = new Destination('/src/Client', 'App\\Client');
+        $config = new ClientConfig('MyClient', $destination);
+
+        $this->assertSame('MyClient', $config->name);
+        $this->assertSame($destination, $config->destination);
+    }
+
+    #[Test]
+    public function it_generates_correct_file_path(): void
+    {
+        $destination = new Destination('/src/Client', 'App\\Client');
+        $config = new ClientConfig('MyClient', $destination);
+
+        $this->assertSame('/src/Client/MyClient.php', $config->path());
+    }
+
+    #[Test]
+    public function it_generates_correct_fully_qualified_class_name(): void
+    {
+        $destination = new Destination('/src/Client', 'App\\Client');
+        $config = new ClientConfig('MyClient', $destination);
+
+        $this->assertSame('App\\Client\\MyClient', $config->fqcn());
+    }
+
+    #[Test]
+    public function it_handles_nested_namespaces(): void
+    {
+        $destination = new Destination('/src/Client/Api/V1', 'App\\Client\\Api\\V1');
+        $config = new ClientConfig('SoapClient', $destination);
+
+        $this->assertSame('/src/Client/Api/V1/SoapClient.php', $config->path());
+        $this->assertSame('App\\Client\\Api\\V1\\SoapClient', $config->fqcn());
+    }
+
+    #[Test]
+    public function it_handles_simple_namespace(): void
+    {
+        $destination = new Destination('/src', 'App');
+        $config = new ClientConfig('Client', $destination);
+
+        $this->assertSame('/src/Client.php', $config->path());
+        $this->assertSame('App\\Client', $config->fqcn());
+    }
+
+    #[Test]
+    public function it_handles_path_without_leading_slash(): void
+    {
+        $destination = new Destination('src/Client', 'App\\Client');
+        $config = new ClientConfig('MyClient', $destination);
+
+        $this->assertSame('src/Client/MyClient.php', $config->path());
+    }
+
+    #[Test]
+    public function it_handles_trailing_slash_in_path(): void
+    {
+        $destination = new Destination('/src/Client/', 'App\\Client');
+        $config = new ClientConfig('MyClient', $destination);
+
+        $this->assertSame('/src/Client/MyClient.php', $config->path());
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/DestinationTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/DestinationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Config;
+
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class DestinationTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_constructed_with_path_and_namespace(): void
+    {
+        $destination = new Destination('/src/Type', 'App\\Type');
+
+        $this->assertSame('/src/Type', $destination->path);
+        $this->assertSame('App\\Type', $destination->namespace);
+    }
+
+    #[Test]
+    public function it_can_handle_nested_namespaces(): void
+    {
+        $destination = new Destination('/src/Type/Deep/Nested', 'App\\Type\\Deep\\Nested');
+
+        $this->assertSame('/src/Type/Deep/Nested', $destination->path);
+        $this->assertSame('App\\Type\\Deep\\Nested', $destination->namespace);
+    }
+
+    #[Test]
+    public function it_can_handle_root_namespace(): void
+    {
+        $destination = new Destination('/src', '\\');
+
+        $this->assertSame('/src', $destination->path);
+        $this->assertSame('\\', $destination->namespace);
+    }
+
+    #[Test]
+    public function it_can_handle_single_level_namespace(): void
+    {
+        $destination = new Destination('/src/Type', 'Type');
+
+        $this->assertSame('/src/Type', $destination->path);
+        $this->assertSame('Type', $destination->namespace);
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/TypeNamespaceMapTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/TypeNamespaceMapTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Config;
+
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Soap\Engine\Metadata\Model\XsdType;
+
+class TypeNamespaceMapTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_created_with_fallback_destination(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $map = TypeNamespaceMap::create($fallback);
+
+        $this->assertInstanceOf(TypeNamespaceMap::class, $map);
+    }
+
+    #[Test]
+    public function it_returns_fallback_destination_when_no_mapping_exists(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $map = TypeNamespaceMap::create($fallback);
+
+        $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertSame($fallback, $destination);
+    }
+
+    #[Test]
+    public function it_can_add_mapping_for_xml_namespace(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $customDestination = new Destination('/src/Custom', 'App\\Custom');
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withMapping('http://custom.example.com', $customDestination);
+
+        $type = XsdType::create('CustomType')->withXmlNamespace('http://custom.example.com');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertSame($customDestination, $destination);
+    }
+
+    #[Test]
+    public function it_can_add_multiple_mappings(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $custom1 = new Destination('/src/Custom1', 'App\\Custom1');
+        $custom2 = new Destination('/src/Custom2', 'App\\Custom2');
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withMapping('http://custom1.example.com', $custom1)
+            ->withMapping('http://custom2.example.com', $custom2);
+
+        $type1 = XsdType::create('Type1')->withXmlNamespace('http://custom1.example.com');
+        $type2 = XsdType::create('Type2')->withXmlNamespace('http://custom2.example.com');
+
+        $this->assertSame($custom1, $map->detectDestinationForType($type1));
+        $this->assertSame($custom2, $map->detectDestinationForType($type2));
+    }
+
+    #[Test]
+    public function it_returns_fallback_when_type_has_no_xml_namespace(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $custom = new Destination('/src/Custom', 'App\\Custom');
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withMapping('http://custom.example.com', $custom);
+
+        $type = XsdType::create('TypeWithoutNamespace');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertSame($fallback, $destination);
+    }
+
+    #[Test]
+    public function it_returns_fallback_when_xml_namespace_is_not_mapped(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $custom = new Destination('/src/Custom', 'App\\Custom');
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withMapping('http://custom.example.com', $custom);
+
+        $type = XsdType::create('OtherType')->withXmlNamespace('http://other.example.com');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertSame($fallback, $destination);
+    }
+
+    #[Test]
+    public function it_is_immutable_when_adding_mappings(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $custom = new Destination('/src/Custom', 'App\\Custom');
+
+        $map1 = TypeNamespaceMap::create($fallback);
+        $map2 = $map1->withMapping('http://custom.example.com', $custom);
+
+        // Original map should not have the mapping
+        $type = XsdType::create('Type')->withXmlNamespace('http://custom.example.com');
+        $this->assertSame($fallback, $map1->detectDestinationForType($type));
+
+        // New map should have the mapping
+        $this->assertSame($custom, $map2->detectDestinationForType($type));
+    }
+
+    #[Test]
+    public function it_can_handle_real_world_xml_namespaces(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $xoevDestination = new Destination('/src/Type/Xoev', 'App\\Type\\Xoev');
+        $gmlDestination = new Destination('/src/Type/Gml', 'App\\Type\\Gml');
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withMapping('http://xoev.de/schemata/xzufi/2_2_0', $xoevDestination)
+            ->withMapping('http://www.opengis.net/gml/3.2', $gmlDestination);
+
+        $xoevType = XsdType::create('XZuFiType')
+            ->withXmlNamespace('http://xoev.de/schemata/xzufi/2_2_0');
+        $gmlType = XsdType::create('PointType')
+            ->withXmlNamespace('http://www.opengis.net/gml/3.2');
+        $standardType = XsdType::create('StandardType')
+            ->withXmlNamespace('http://example.com/standard');
+
+        $this->assertSame($xoevDestination, $map->detectDestinationForType($xoevType));
+        $this->assertSame($gmlDestination, $map->detectDestinationForType($gmlType));
+        $this->assertSame($fallback, $map->detectDestinationForType($standardType));
+    }
+
+    #[Test]
+    public function it_can_override_existing_mapping(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $custom1 = new Destination('/src/Custom1', 'App\\Custom1');
+        $custom2 = new Destination('/src/Custom2', 'App\\Custom2');
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withMapping('http://custom.example.com', $custom1)
+            ->withMapping('http://custom.example.com', $custom2); // Override
+
+        $type = XsdType::create('Type')->withXmlNamespace('http://custom.example.com');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertSame($custom2, $destination);
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/TypeNamespaceMapTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/TypeNamespaceMapTest.php
@@ -4,6 +4,8 @@ namespace PhproTest\SoapClient\Unit\CodeGenerator\Config;
 
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\TypeNamespaceMapStrategyInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Soap\Engine\Metadata\Model\XsdType;
@@ -47,24 +49,6 @@ class TypeNamespaceMapTest extends TestCase
     }
 
     #[Test]
-    public function it_can_add_multiple_mappings(): void
-    {
-        $fallback = new Destination('/src/Type', 'App\\Type');
-        $custom1 = new Destination('/src/Custom1', 'App\\Custom1');
-        $custom2 = new Destination('/src/Custom2', 'App\\Custom2');
-
-        $map = TypeNamespaceMap::create($fallback)
-            ->withMapping('http://custom1.example.com', $custom1)
-            ->withMapping('http://custom2.example.com', $custom2);
-
-        $type1 = XsdType::create('Type1')->withXmlNamespace('http://custom1.example.com');
-        $type2 = XsdType::create('Type2')->withXmlNamespace('http://custom2.example.com');
-
-        $this->assertSame($custom1, $map->detectDestinationForType($type1));
-        $this->assertSame($custom2, $map->detectDestinationForType($type2));
-    }
-
-    #[Test]
     public function it_returns_fallback_when_type_has_no_xml_namespace(): void
     {
         $fallback = new Destination('/src/Type', 'App\\Type');
@@ -74,21 +58,6 @@ class TypeNamespaceMapTest extends TestCase
             ->withMapping('http://custom.example.com', $custom);
 
         $type = XsdType::create('TypeWithoutNamespace');
-        $destination = $map->detectDestinationForType($type);
-
-        $this->assertSame($fallback, $destination);
-    }
-
-    #[Test]
-    public function it_returns_fallback_when_xml_namespace_is_not_mapped(): void
-    {
-        $fallback = new Destination('/src/Type', 'App\\Type');
-        $custom = new Destination('/src/Custom', 'App\\Custom');
-
-        $map = TypeNamespaceMap::create($fallback)
-            ->withMapping('http://custom.example.com', $custom);
-
-        $type = XsdType::create('OtherType')->withXmlNamespace('http://other.example.com');
         $destination = $map->detectDestinationForType($type);
 
         $this->assertSame($fallback, $destination);
@@ -152,21 +121,6 @@ class TypeNamespaceMapTest extends TestCase
     }
 
     #[Test]
-    public function it_can_add_a_strategy(): void
-    {
-        $fallback = new Destination('/src/Type', 'App\\Type');
-        $strategyDestination = new Destination('/src/Strategy', 'App\\Strategy');
-
-        $map = TypeNamespaceMap::create($fallback)
-            ->withStrategy(fn (string $xmlns, Destination $fallback) => $strategyDestination);
-
-        $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
-        $destination = $map->detectDestinationForType($type);
-
-        $this->assertSame($strategyDestination, $destination);
-    }
-
-    #[Test]
     public function it_does_not_call_strategy_when_xmlns_is_in_map(): void
     {
         $fallback = new Destination('/src/Type', 'App\\Type');
@@ -175,7 +129,7 @@ class TypeNamespaceMapTest extends TestCase
 
         $map = TypeNamespaceMap::create($fallback)
             ->withMapping('http://mapped.example.com', $mapped)
-            ->withStrategy(function (string $xmlns, Destination $fallback) use (&$strategyCalled) {
+            ->withStrategy(function (string $xmlns, string $xmlNamespaceName, Destination $fallback) use (&$strategyCalled) {
                 $strategyCalled = true;
                 return new Destination('/src/Strategy', 'App\\Strategy');
             });
@@ -197,7 +151,7 @@ class TypeNamespaceMapTest extends TestCase
 
         $map = TypeNamespaceMap::create($fallback)
             ->withMapping('http://mapped.example.com', $mapped)
-            ->withStrategy(function (string $xmlns, Destination $fallback) use (&$strategyCalled, $strategyDestination) {
+            ->withStrategy(function (string $xmlns, string $xmlNamespaceName, Destination $fallback) use (&$strategyCalled, $strategyDestination) {
                 $strategyCalled = true;
                 return $strategyDestination;
             });
@@ -210,37 +164,29 @@ class TypeNamespaceMapTest extends TestCase
     }
 
     #[Test]
-    public function it_passes_xmlns_and_fallback_to_strategy(): void
+    public function it_passes_all_arguments_to_strategy(): void
     {
         $fallback = new Destination('/src/Type', 'App\\Type');
         $receivedXmlns = null;
+        $receivedNamespaceName = null;
         $receivedFallback = null;
 
         $map = TypeNamespaceMap::create($fallback)
-            ->withStrategy(function (string $xmlns, Destination $fb) use (&$receivedXmlns, &$receivedFallback) {
+            ->withStrategy(function (string $xmlns, string $xmlNamespaceName, Destination $fb) use (&$receivedXmlns, &$receivedNamespaceName, &$receivedFallback) {
                 $receivedXmlns = $xmlns;
+                $receivedNamespaceName = $xmlNamespaceName;
                 $receivedFallback = $fb;
                 return $fb;
             });
 
-        $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
+        $type = XsdType::create('SomeType')
+            ->withXmlNamespace('http://example.com/schema')
+            ->withXmlNamespaceName('ex');
         $map->detectDestinationForType($type);
 
         $this->assertSame('http://example.com/schema', $receivedXmlns);
+        $this->assertSame('ex', $receivedNamespaceName);
         $this->assertSame($fallback, $receivedFallback);
-    }
-
-    #[Test]
-    public function it_returns_fallback_when_no_strategy_and_xmlns_not_in_map(): void
-    {
-        $fallback = new Destination('/src/Type', 'App\\Type');
-
-        $map = TypeNamespaceMap::create($fallback);
-
-        $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
-        $destination = $map->detectDestinationForType($type);
-
-        $this->assertSame($fallback, $destination);
     }
 
     #[Test]
@@ -249,7 +195,7 @@ class TypeNamespaceMapTest extends TestCase
         $fallback = new Destination('/src/Type', 'App\\Type');
 
         $map = TypeNamespaceMap::create($fallback)
-            ->withStrategy(function (string $xmlns, Destination $fallback): Destination {
+            ->withStrategy(function (string $xmlns, string $xmlNamespaceName, Destination $fallback): Destination {
                 if (str_contains($xmlns, 'xoev.de')) {
                     return new Destination('/src/Type/Xoev', 'App\\Type\\Xoev');
                 }
@@ -273,7 +219,7 @@ class TypeNamespaceMapTest extends TestCase
         $strategyDestination = new Destination('/src/Strategy', 'App\\Strategy');
 
         $mapWithStrategy = TypeNamespaceMap::create($fallback)
-            ->withStrategy(fn (string $xmlns, Destination $fallback) => $strategyDestination);
+            ->withStrategy(fn (string $xmlns, string $xmlNamespaceName, Destination $fallback) => $strategyDestination);
 
         $mapWithoutStrategy = $mapWithStrategy->withStrategy(null);
 
@@ -284,13 +230,30 @@ class TypeNamespaceMapTest extends TestCase
     }
 
     #[Test]
+    public function it_accepts_a_strategy_interface_implementor(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $strategy = new PrefixBasedTypeNamespaceStrategy();
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withStrategy($strategy);
+
+        $type = XsdType::create('SomeType')
+            ->withXmlNamespace('http://example.com/schema')
+            ->withXmlNamespaceName('ex');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertEquals(new Destination('/src/Type/Ex', 'App\\Type\\Ex'), $destination);
+    }
+
+    #[Test]
     public function it_is_immutable_when_adding_strategy(): void
     {
         $fallback = new Destination('/src/Type', 'App\\Type');
         $strategyDestination = new Destination('/src/Strategy', 'App\\Strategy');
 
         $map1 = TypeNamespaceMap::create($fallback);
-        $map2 = $map1->withStrategy(fn (string $xmlns, Destination $fallback) => $strategyDestination);
+        $map2 = $map1->withStrategy(fn (string $xmlns, string $xmlNamespaceName, Destination $fallback) => $strategyDestination);
 
         $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/TypeNamespaceMapTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Config/TypeNamespaceMapTest.php
@@ -150,4 +150,154 @@ class TypeNamespaceMapTest extends TestCase
 
         $this->assertSame($custom2, $destination);
     }
+
+    #[Test]
+    public function it_can_add_a_strategy(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $strategyDestination = new Destination('/src/Strategy', 'App\\Strategy');
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withStrategy(fn (string $xmlns, Destination $fallback) => $strategyDestination);
+
+        $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertSame($strategyDestination, $destination);
+    }
+
+    #[Test]
+    public function it_does_not_call_strategy_when_xmlns_is_in_map(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $mapped = new Destination('/src/Mapped', 'App\\Mapped');
+        $strategyCalled = false;
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withMapping('http://mapped.example.com', $mapped)
+            ->withStrategy(function (string $xmlns, Destination $fallback) use (&$strategyCalled) {
+                $strategyCalled = true;
+                return new Destination('/src/Strategy', 'App\\Strategy');
+            });
+
+        $type = XsdType::create('MappedType')->withXmlNamespace('http://mapped.example.com');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertSame($mapped, $destination);
+        $this->assertFalse($strategyCalled);
+    }
+
+    #[Test]
+    public function it_calls_strategy_when_xmlns_is_not_in_map(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $mapped = new Destination('/src/Mapped', 'App\\Mapped');
+        $strategyDestination = new Destination('/src/Strategy', 'App\\Strategy');
+        $strategyCalled = false;
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withMapping('http://mapped.example.com', $mapped)
+            ->withStrategy(function (string $xmlns, Destination $fallback) use (&$strategyCalled, $strategyDestination) {
+                $strategyCalled = true;
+                return $strategyDestination;
+            });
+
+        $type = XsdType::create('UnmappedType')->withXmlNamespace('http://unmapped.example.com');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertSame($strategyDestination, $destination);
+        $this->assertTrue($strategyCalled);
+    }
+
+    #[Test]
+    public function it_passes_xmlns_and_fallback_to_strategy(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $receivedXmlns = null;
+        $receivedFallback = null;
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withStrategy(function (string $xmlns, Destination $fb) use (&$receivedXmlns, &$receivedFallback) {
+                $receivedXmlns = $xmlns;
+                $receivedFallback = $fb;
+                return $fb;
+            });
+
+        $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
+        $map->detectDestinationForType($type);
+
+        $this->assertSame('http://example.com/schema', $receivedXmlns);
+        $this->assertSame($fallback, $receivedFallback);
+    }
+
+    #[Test]
+    public function it_returns_fallback_when_no_strategy_and_xmlns_not_in_map(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+
+        $map = TypeNamespaceMap::create($fallback);
+
+        $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
+        $destination = $map->detectDestinationForType($type);
+
+        $this->assertSame($fallback, $destination);
+    }
+
+    #[Test]
+    public function it_can_use_strategy_to_calculate_destination_based_on_xmlns(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+
+        $map = TypeNamespaceMap::create($fallback)
+            ->withStrategy(function (string $xmlns, Destination $fallback): Destination {
+                if (str_contains($xmlns, 'xoev.de')) {
+                    return new Destination('/src/Type/Xoev', 'App\\Type\\Xoev');
+                }
+
+                return $fallback;
+            });
+
+        $xoevType = XsdType::create('XZuFiType')
+            ->withXmlNamespace('http://xoev.de/schemata/xzufi/2_2_0');
+        $otherType = XsdType::create('OtherType')
+            ->withXmlNamespace('http://example.com/other');
+
+        $this->assertEquals(new Destination('/src/Type/Xoev', 'App\\Type\\Xoev'), $map->detectDestinationForType($xoevType));
+        $this->assertSame($fallback, $map->detectDestinationForType($otherType));
+    }
+
+    #[Test]
+    public function it_can_remove_strategy_by_setting_null(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $strategyDestination = new Destination('/src/Strategy', 'App\\Strategy');
+
+        $mapWithStrategy = TypeNamespaceMap::create($fallback)
+            ->withStrategy(fn (string $xmlns, Destination $fallback) => $strategyDestination);
+
+        $mapWithoutStrategy = $mapWithStrategy->withStrategy(null);
+
+        $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
+
+        $this->assertSame($strategyDestination, $mapWithStrategy->detectDestinationForType($type));
+        $this->assertSame($fallback, $mapWithoutStrategy->detectDestinationForType($type));
+    }
+
+    #[Test]
+    public function it_is_immutable_when_adding_strategy(): void
+    {
+        $fallback = new Destination('/src/Type', 'App\\Type');
+        $strategyDestination = new Destination('/src/Strategy', 'App\\Strategy');
+
+        $map1 = TypeNamespaceMap::create($fallback);
+        $map2 = $map1->withStrategy(fn (string $xmlns, Destination $fallback) => $strategyDestination);
+
+        $type = XsdType::create('SomeType')->withXmlNamespace('http://example.com/schema');
+
+        // Original map should not use the strategy
+        $this->assertSame($fallback, $map1->detectDestinationForType($type));
+
+        // New map should use the strategy
+        $this->assertSame($strategyDestination, $map2->detectDestinationForType($type));
+    }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -26,12 +26,16 @@ use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
 
 return Config::create()
     ->setEngine(\$engine = DefaultEngineFactory::create(
         EngineOptions::defaults('wsdl.xml')
     ))
-    ->setTypeNamespaceMap(TypeNamespaceMap::create(new Destination('src/type', 'App\\\\Type')))
+    ->setTypeNamespaceMap(
+        TypeNamespaceMap::create(new Destination('src/type', 'App\\\\Type'))
+        // ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+    )
     ->setClient(new ClientConfig('Client', new Destination('src/client', 'App\\\\Client')))
     ->setClassMap(new ClassMapConfig('Classmap', new Destination('src/classmap', 'App\\\\Classmap')))
     ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
@@ -75,6 +79,91 @@ CONTENT;
 
         $typeDestination = new Destination('src/type', 'App\\Type');
         $context->setTypeDestination($typeDestination);
+
+        $clientConfig = new ClientConfig('Client', new Destination('src/client', 'App\\Client'));
+        $context->setClientConfig($clientConfig);
+
+        $classMapConfig = new ClassMapConfig('Classmap', new Destination('src/classmap', 'App\\Classmap'));
+        $context->setClassMapConfig($classMapConfig);
+
+        $generator = new ConfigGenerator();
+        $generated = $generator->generate(new FileGenerator(), $context);
+        self::assertEquals($expected, $generated);
+    }
+
+    public function testGenerateWithDetectedXmlNamespaces(): void
+    {
+        $expected = <<<CONTENT
+<?php
+
+use Phpro\SoapClient\CodeGenerator\Assembler;
+use Phpro\SoapClient\CodeGenerator\Rules;
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Config;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\Soap\EngineOptions;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
+
+return Config::create()
+    ->setEngine(\$engine = DefaultEngineFactory::create(
+        EngineOptions::defaults('wsdl.xml')
+    ))
+    ->setTypeNamespaceMap(
+        TypeNamespaceMap::create(new Destination('src/type', 'App\\\\Type'))
+        // ->withMapping('http://www.opengis.net/gml/3.2', new Destination('src/type/Gml', 'App\\\\Type\\\\Gml'))
+        // ->withMapping('http://xoev.de/schemata/xzufi/2_2_0', new Destination('src/type/Xzufi', 'App\\\\Type\\\\Xzufi'))
+        // ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+    )
+    ->setClient(new ClientConfig('Client', new Destination('src/client', 'App\\\\Client')))
+    ->setClassMap(new ClassMapConfig('Classmap', new Destination('src/classmap', 'App\\\\Classmap')))
+    ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
+    ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler(
+        new Assembler\ImmutableSetterAssemblerOptions()
+    )))
+    ->addRule(
+        new Rules\IsRequestRule(
+            \$engine->getMetadata(),
+            new Rules\MultiRule([
+                new Rules\AssembleRule(new Assembler\RequestAssembler()),
+                new Rules\AssembleRule(new Assembler\ConstructorAssembler(new Assembler\ConstructorAssemblerOptions())),
+            ])
+        )
+    )
+    ->addRule(
+        new Rules\IsResultRule(
+            \$engine->getMetadata(),
+            new Rules\MultiRule([
+                new Rules\AssembleRule(new Assembler\ResultAssembler()),
+            ])
+        )
+    )
+    ->addRule(
+        new Rules\IsExtendingTypeRule(
+            \$engine->getMetadata(),
+            new Rules\AssembleRule(new Assembler\ExtendingTypeAssembler())
+        )
+    )
+    ->addRule(
+        new Rules\IsAbstractTypeRule(
+            \$engine->getMetadata(),
+            new Rules\AssembleRule(new Assembler\AbstractClassAssembler())
+        )
+    )
+;
+
+CONTENT;
+        $context = new ConfigContext();
+        $context->setWsdl('wsdl.xml');
+
+        $typeDestination = new Destination('src/type', 'App\\Type');
+        $context->setTypeDestination($typeDestination);
+        $context->setDetectedXmlNamespaces([
+            'http://www.opengis.net/gml/3.2' => 'gml',
+            'http://xoev.de/schemata/xzufi/2_2_0' => 'xzufi',
+        ]);
 
         $clientConfig = new ClientConfig('Client', new Destination('src/client', 'App\\Client'));
         $context->setClientConfig($clientConfig);

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -2,6 +2,9 @@
 
 namespace PhproTest\SoapClient\Unit\CodeGenerator;
 
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\ConfigGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +19,11 @@ class ConfigGeneratorTest extends TestCase
 
 use Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Rules;
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 
@@ -24,14 +31,9 @@ return Config::create()
     ->setEngine(\$engine = DefaultEngineFactory::create(
         EngineOptions::defaults('wsdl.xml')
     ))
-    ->setTypeDestination('src/type')
-    ->setTypeNamespace('App\\\\Type')
-    ->setClientDestination('src/client')
-    ->setClientName('Client')
-    ->setClientNamespace('App\\\\Client')
-    ->setClassmapDestination('src/classmap')
-    ->setClassmapName('Classmap')
-    ->setClassmapNamespace('App\\\\Classmap')
+    ->setTypeNamespaceMap(TypeNamespaceMap::create(new Destination('src/type', 'App\\\\Type')))
+    ->setClient(new ClientConfig('Client', new Destination('src/client', 'App\\\\Client')))
+    ->setClassMap(new ClassMapConfig('Classmap', new Destination('src/classmap', 'App\\\\Classmap')))
     ->addRule(new Rules\AssembleRule(new Assembler\GetterAssembler(new Assembler\GetterAssemblerOptions())))
     ->addRule(new Rules\AssembleRule(new Assembler\ImmutableSetterAssembler(
         new Assembler\ImmutableSetterAssemblerOptions()
@@ -69,16 +71,16 @@ return Config::create()
 
 CONTENT;
         $context = new ConfigContext();
-        $context
-            ->setWsdl('wsdl.xml')
-            ->addSetter('setTypeDestination', 'src/type')
-            ->addSetter('setTypeNamespace', 'App\\\\Type')
-            ->addSetter('setClientDestination', 'src/client')
-            ->addSetter('setClientName', 'Client')
-            ->addSetter('setClientNamespace', 'App\\\\Client')
-            ->addSetter('setClassmapDestination', 'src/classmap')
-            ->addSetter('setClassmapName', 'Classmap')
-            ->addSetter('setClassmapNamespace', 'App\\\\Classmap');
+        $context->setWsdl('wsdl.xml');
+
+        $typeDestination = new Destination('src/type', 'App\\Type');
+        $context->setTypeDestination($typeDestination);
+
+        $clientConfig = new ClientConfig('Client', new Destination('src/client', 'App\\Client'));
+        $context->setClientConfig($clientConfig);
+
+        $classMapConfig = new ClassMapConfig('Classmap', new Destination('src/classmap', 'App\\Classmap'));
+        $context->setClassMapConfig($classMapConfig);
 
         $generator = new ConfigGenerator();
         $generated = $generator->generate(new FileGenerator(), $context);
@@ -92,7 +94,11 @@ CONTENT;
 
 use Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Rules;
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigurationHelper.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigurationHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator;
+
+use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
+use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+
+trait ConfigurationHelper
+{
+    private function createTypeNamespaceMap(string $namespace = 'Generated'): TypeNamespaceMap
+    {
+        return TypeNamespaceMap::create(new Destination('/generated', $namespace));
+    }
+
+    private function createDestination(string $path = '/generated', string $namespace = 'Generated'): Destination
+    {
+        return new Destination($path, $namespace);
+    }
+
+    private function createClientConfig(string $name = 'TestClient', string $namespace = 'Generated'): ClientConfig
+    {
+        return new ClientConfig($name, new Destination('/generated', $namespace));
+    }
+
+    private function createClassMapConfig(string $name = 'TestClassMap', string $namespace = 'Generated'): ClassMapConfig
+    {
+        return new ClassMapConfig($name, new Destination('/generated', $namespace));
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/EnumerationGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/EnumerationGeneratorTest.php
@@ -15,10 +15,11 @@ use Soap\Engine\Metadata\Model\XsdType;
 
 class EnumerationGeneratorTest extends TestCase
 {
+    use ConfigurationHelper;
     public function testStringBackedEnumGeneration(): void
     {
         $type = new Type(
-            'MyNamespace',
+            $this->createTypeNamespaceMap('MyNamespace'),
             'MyType',
             'MyType',
             [],
@@ -54,7 +55,7 @@ class EnumerationGeneratorTest extends TestCase
     public function testIntBackedEnumGeneration(): void
     {
         $type = new Type(
-            'MyNamespace',
+            $this->createTypeNamespaceMap('MyNamespace'),
             'MyType',
             'MyType',
             [],
@@ -88,7 +89,7 @@ class EnumerationGeneratorTest extends TestCase
     public function testBackedEnumDocblockGeneration(): void
     {
         $type = new Type(
-            'MyNamespace',
+            $this->createTypeNamespaceMap('MyNamespace'),
             'MyType',
             'MyType',
             [],

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace PhproTest\SoapClient\Unit\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -18,10 +20,15 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class PropertyTest extends TestCase
 {
+    private static function createTypeNamespaceMap(string $namespace): TypeNamespaceMap
+    {
+        return TypeNamespaceMap::create(new Destination('/generated', $namespace));
+    }
+
     #[Test]
     public function it_returns_mixed_type_post_php8(): void
     {
-        $property = new Property('test', 'mixed', 'App', XsdType::create('mixed'));
+        $property = new Property('test', 'mixed', self::createTypeNamespaceMap('App'), 'App', XsdType::create('mixed'));
         self::assertEquals('mixed', $property->getPhpType());
         self::assertEquals('mixed', $property->getType());
     }
@@ -30,7 +37,7 @@ class PropertyTest extends TestCase
     public function it_can_use_fqcn_to_3rd_party_classes_as_type_name(): void
     {
         $property = Property::fromMetaData(
-            'MyApp',
+            self::createTypeNamespaceMap('MyApp'),
             new EngineProperty(
                 'property',
                 $xsdType = XsdType::create(Option::class)
@@ -47,7 +54,7 @@ class PropertyTest extends TestCase
     public function it_can_use_a_php_built_in_class_as_type_name(): void
     {
         $property = Property::fromMetaData(
-            'MyApp',
+            self::createTypeNamespaceMap('MyApp'),
             new EngineProperty(
                 'property',
                 $xsdType = XsdType::create('\\'. \DateInterval::class)
@@ -71,7 +78,7 @@ class PropertyTest extends TestCase
     {
         yield 'known_simple_type' => [
             Property::fromMetaData(
-                'MyApp',
+                self::createTypeNamespaceMap('MyApp'),
                 new EngineProperty(
                     'property',
                     XsdType::create('string')
@@ -82,7 +89,7 @@ class PropertyTest extends TestCase
 
         yield 'known_simple_base_type' => [
             Property::fromMetaData(
-                'MyApp',
+                self::createTypeNamespaceMap('MyApp'),
                 new EngineProperty(
                     'property',
                     XsdType::create('language')
@@ -98,7 +105,7 @@ class PropertyTest extends TestCase
 
         yield 'known_simple_base_type_with_enums' => [
             Property::fromMetaData(
-                'MyApp',
+                self::createTypeNamespaceMap('MyApp'),
                 new EngineProperty(
                     'property',
                     XsdType::create('languageEnum')
@@ -115,7 +122,7 @@ class PropertyTest extends TestCase
 
         yield 'root namespace' => [
             Property::fromMetaData(
-                '',
+                self::createTypeNamespaceMap(''),
                 new EngineProperty(
                     'property',
                     XsdType::create('MyType')
@@ -126,7 +133,7 @@ class PropertyTest extends TestCase
 
         yield 'namespaced' => [
             Property::fromMetaData(
-                'MyApp',
+                self::createTypeNamespaceMap('MyApp'),
                 new EngineProperty(
                     'property',
                     XsdType::create('MyType')

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeNamespaceMap/Strategy/PrefixBasedTypeNamespaceStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeNamespaceMap/Strategy/PrefixBasedTypeNamespaceStrategyTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\TypeNamespaceMap\Strategy;
+
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\TypeNamespaceMapStrategyInterface;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class PrefixBasedTypeNamespaceStrategyTest extends TestCase
+{
+    #[Test]
+    public function it_implements_the_strategy_interface(): void
+    {
+        $strategy = new PrefixBasedTypeNamespaceStrategy();
+        $this->assertInstanceOf(TypeNamespaceMapStrategyInterface::class, $strategy);
+    }
+
+    #[Test]
+    public function it_appends_normalized_prefix_to_fallback(): void
+    {
+        $strategy = new PrefixBasedTypeNamespaceStrategy();
+        $fallback = new Destination('src/Type', 'App\\Type');
+
+        $result = $strategy('http://www.opengis.net/gml/3.2', 'gml', $fallback);
+
+        $this->assertEquals(new Destination('src/Type/Gml', 'App\\Type\\Gml'), $result);
+    }
+
+    #[Test]
+    public function it_returns_fallback_when_prefix_is_empty(): void
+    {
+        $strategy = new PrefixBasedTypeNamespaceStrategy();
+        $fallback = new Destination('src/Type', 'App\\Type');
+
+        $result = $strategy('http://example.com/schema', '', $fallback);
+
+        $this->assertSame($fallback, $result);
+    }
+
+    #[Test]
+    public function it_normalizes_hyphenated_prefixes(): void
+    {
+        $strategy = new PrefixBasedTypeNamespaceStrategy();
+        $fallback = new Destination('src/Type', 'App\\Type');
+
+        $result = $strategy('http://example.com/schema', 'my-prefix', $fallback);
+
+        $this->assertEquals(new Destination('src/Type/MyPrefix', 'App\\Type\\MyPrefix'), $result);
+    }
+
+    #[Test]
+    public function it_prefixes_leading_digit_segments(): void
+    {
+        $strategy = new PrefixBasedTypeNamespaceStrategy();
+        $fallback = new Destination('src/Type', 'App\\Type');
+
+        $result = $strategy('http://example.com/schema', '3d', $fallback);
+
+        $this->assertEquals(new Destination('src/Type/Ns3d', 'App\\Type\\Ns3d'), $result);
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Util/NormalizerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Util/NormalizerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\Util;
+
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class NormalizerTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, ?string}>
+     */
+    public static function provideNamespaceSegmentCases(): iterable
+    {
+        yield 'normal prefix' => ['gml', 'Gml'];
+        yield 'hyphenated' => ['my-prefix', 'MyPrefix'];
+        yield 'leading digit' => ['2way', 'Ns2way'];
+        yield 'reserved word' => ['list', 'ListType'];
+        yield 'empty string' => ['', null];
+        yield 'purely numeric' => ['123', 'Ns123'];
+        yield 'dotted' => ['my.prefix', 'MyPrefix'];
+        yield 'uppercase' => ['GML', 'GML'];
+    }
+
+    #[Test]
+    #[DataProvider('provideNamespaceSegmentCases')]
+    public function it_normalizes_namespace_segment(string $input, ?string $expected): void
+    {
+        $this->assertSame($expected, Normalizer::normalizeNamespaceSegment($input));
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/DuplicateTypesKeyTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/DuplicateTypesKeyTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\SoapClient\Unit\Soap\Metadata\Manipulators\DuplicateTypes;
+
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\DuplicateTypesKey;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Soap\Engine\Metadata\Collection\PropertyCollection;
+use Soap\Engine\Metadata\Model\Type;
+use Soap\Engine\Metadata\Model\XsdType;
+
+class DuplicateTypesKeyTest extends TestCase
+{
+    #[Test]
+    public function it_returns_normalized_name_without_namespace_map(): void
+    {
+        $type = new Type(XsdType::create('MyType'), new PropertyCollection());
+
+        $key = DuplicateTypesKey::forType($type, null);
+
+        self::assertEquals('MyType', $key);
+    }
+
+    #[Test]
+    public function it_normalizes_class_name(): void
+    {
+        $type = new Type(XsdType::create('my-type'), new PropertyCollection());
+
+        $key = DuplicateTypesKey::forType($type, null);
+
+        self::assertEquals('MyType', $key);
+    }
+
+    #[Test]
+    public function it_includes_target_namespace_with_namespace_map(): void
+    {
+        $type = new Type(
+            XsdType::create('MyType')->withXmlNamespace('http://ns-a.com'),
+            new PropertyCollection()
+        );
+
+        $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'))
+            ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'));
+
+        $key = DuplicateTypesKey::forType($type, $namespaceMap);
+
+        self::assertEquals('App\\Types\\A\\MyType', $key);
+    }
+
+    #[Test]
+    public function it_uses_fallback_namespace_for_unmapped_xmlns(): void
+    {
+        $type = new Type(
+            XsdType::create('MyType')->withXmlNamespace('http://unmapped.com'),
+            new PropertyCollection()
+        );
+
+        $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'))
+            ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'));
+
+        $key = DuplicateTypesKey::forType($type, $namespaceMap);
+
+        self::assertEquals('App\\Types\\MyType', $key);
+    }
+
+    #[Test]
+    public function same_name_different_xmlns_produces_different_keys(): void
+    {
+        $typeA = new Type(
+            XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
+            new PropertyCollection()
+        );
+        $typeB = new Type(
+            XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
+            new PropertyCollection()
+        );
+
+        $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'))
+            ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'))
+            ->withMapping('http://ns-b.com', new Destination('/path/b', 'App\\Types\\B'));
+
+        $keyA = DuplicateTypesKey::forType($typeA, $namespaceMap);
+        $keyB = DuplicateTypesKey::forType($typeB, $namespaceMap);
+
+        self::assertNotEquals($keyA, $keyB);
+        self::assertEquals('App\\Types\\A\\Item', $keyA);
+        self::assertEquals('App\\Types\\B\\Item', $keyB);
+    }
+
+    #[Test]
+    public function same_name_same_target_namespace_produces_same_key(): void
+    {
+        $typeA = new Type(
+            XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
+            new PropertyCollection()
+        );
+        $typeB = new Type(
+            XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
+            new PropertyCollection()
+        );
+
+        // Both namespaces map to fallback (no specific mappings)
+        $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'));
+
+        $keyA = DuplicateTypesKey::forType($typeA, $namespaceMap);
+        $keyB = DuplicateTypesKey::forType($typeB, $namespaceMap);
+
+        self::assertEquals($keyA, $keyB);
+        self::assertEquals('App\\Types\\Item', $keyA);
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategyTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhproTest\SoapClient\Unit\Soap\Metadata\Manipulators\DuplicateTypes;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\IntersectDuplicateTypesStrategy;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorInterface;
 use PHPUnit\Framework\TestCase;
@@ -17,10 +19,21 @@ use Soap\Engine\Metadata\Model\XsdType;
 
 class IntersectDuplicateTypesStrategyTest extends TestCase
 {
+    #[Test]
     public function it_is_a_types_manipulator(): void
     {
         $strategy = new IntersectDuplicateTypesStrategy();
         self::assertInstanceOf(TypesManipulatorInterface::class, $strategy);
+    }
+
+    #[Test]
+    public function it_provides_a_factory(): void
+    {
+        $factory = IntersectDuplicateTypesStrategy::create();
+        self::assertInstanceOf(\Closure::class, $factory);
+
+        $strategy = $factory(null);
+        self::assertInstanceOf(IntersectDuplicateTypesStrategy::class, $strategy);
     }
 
     #[Test]
@@ -66,5 +79,76 @@ class IntersectDuplicateTypesStrategyTest extends TestCase
             ],
             iterator_to_array($manipulated)
         );
+    }
+
+    #[Test]
+    public function it_keeps_types_with_same_name_but_different_target_namespace(): void
+    {
+        $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'))
+            ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'))
+            ->withMapping('http://ns-b.com', new Destination('/path/b', 'App\\Types\\B'));
+
+        $strategy = new IntersectDuplicateTypesStrategy($namespaceMap);
+
+        $types = new TypeCollection(
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
+                new PropertyCollection(new Property('propA', XsdType::create('string')))
+            ),
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
+                new PropertyCollection(new Property('propB', XsdType::create('string')))
+            ),
+        );
+
+        $manipulated = $strategy($types);
+
+        self::assertCount(2, iterator_to_array($manipulated));
+    }
+
+    #[Test]
+    public function it_still_intersects_types_in_same_target_namespace(): void
+    {
+        $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'));
+
+        $strategy = new IntersectDuplicateTypesStrategy($namespaceMap);
+
+        $types = new TypeCollection(
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
+                new PropertyCollection(new Property('propA', XsdType::create('string')))
+            ),
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
+                new PropertyCollection(new Property('propB', XsdType::create('string')))
+            ),
+        );
+
+        $manipulated = $strategy($types);
+
+        // Both map to fallback namespace, so they ARE duplicates
+        self::assertCount(1, iterator_to_array($manipulated));
+    }
+
+    #[Test]
+    public function it_behaves_as_before_without_namespace_map(): void
+    {
+        $strategy = new IntersectDuplicateTypesStrategy(); // No namespace map
+
+        $types = new TypeCollection(
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
+                new PropertyCollection()
+            ),
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
+                new PropertyCollection()
+            ),
+        );
+
+        $manipulated = $strategy($types);
+
+        // Without namespace map, these are considered duplicates (legacy behavior)
+        self::assertCount(1, iterator_to_array($manipulated));
     }
 }

--- a/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategyTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhproTest\SoapClient\Unit\Soap\Metadata\Manipulators\DuplicateTypes;
 
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\RemoveDuplicateTypesStrategy;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorInterface;
 use PHPUnit\Framework\TestCase;
@@ -15,6 +17,7 @@ use Soap\Engine\Metadata\Model\XsdType;
 
 class RemoveDuplicateTypesStrategyTest extends TestCase
 {
+    #[Test]
     public function it_is_a_types_manipulator(): void
     {
         $strategy = new RemoveDuplicateTypesStrategy();
@@ -22,7 +25,17 @@ class RemoveDuplicateTypesStrategyTest extends TestCase
     }
 
     #[Test]
-    public function it_can_intersect_duplicate_types(): void
+    public function it_provides_a_factory(): void
+    {
+        $factory = RemoveDuplicateTypesStrategy::create();
+        self::assertInstanceOf(\Closure::class, $factory);
+
+        $strategy = $factory(null);
+        self::assertInstanceOf(RemoveDuplicateTypesStrategy::class, $strategy);
+    }
+
+    #[Test]
+    public function it_can_remove_duplicate_types(): void
     {
         $strategy = new RemoveDuplicateTypesStrategy();
         $types = new TypeCollection(
@@ -48,5 +61,93 @@ class RemoveDuplicateTypesStrategyTest extends TestCase
             ],
             iterator_to_array($manipulated)
         );
+    }
+
+    #[Test]
+    public function it_keeps_types_with_same_name_but_different_target_namespace(): void
+    {
+        $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'))
+            ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'))
+            ->withMapping('http://ns-b.com', new Destination('/path/b', 'App\\Types\\B'));
+
+        $strategy = new RemoveDuplicateTypesStrategy($namespaceMap);
+
+        $types = new TypeCollection(
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
+                new PropertyCollection()
+            ),
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
+                new PropertyCollection()
+            ),
+            new Type(
+                XsdType::create('UniqueType')->withXmlNamespace('http://ns-a.com'),
+                new PropertyCollection()
+            ),
+        );
+
+        $manipulated = $strategy($types);
+
+        // All three should remain: two Items are in different target namespaces, UniqueType is unique
+        self::assertCount(3, iterator_to_array($manipulated));
+    }
+
+    #[Test]
+    public function it_still_removes_types_in_same_target_namespace(): void
+    {
+        $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'));
+
+        $strategy = new RemoveDuplicateTypesStrategy($namespaceMap);
+
+        $types = new TypeCollection(
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
+                new PropertyCollection()
+            ),
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
+                new PropertyCollection()
+            ),
+            new Type(
+                XsdType::create('UniqueType')->withXmlNamespace('http://ns-a.com'),
+                new PropertyCollection()
+            ),
+        );
+
+        $manipulated = $strategy($types);
+
+        // Both Items map to fallback namespace, so they ARE duplicates and get removed
+        // Only UniqueType remains
+        self::assertCount(1, iterator_to_array($manipulated));
+        self::assertEquals('UniqueType', iterator_to_array($manipulated)[0]->getName());
+    }
+
+    #[Test]
+    public function it_behaves_as_before_without_namespace_map(): void
+    {
+        $strategy = new RemoveDuplicateTypesStrategy(); // No namespace map
+
+        $types = new TypeCollection(
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
+                new PropertyCollection()
+            ),
+            new Type(
+                XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
+                new PropertyCollection()
+            ),
+            new Type(
+                XsdType::create('UniqueType'),
+                new PropertyCollection()
+            ),
+        );
+
+        $manipulated = $strategy($types);
+
+        // Without namespace map, Items are considered duplicates (legacy behavior)
+        // Only UniqueType remains
+        self::assertCount(1, iterator_to_array($manipulated));
+        self::assertEquals('UniqueType', iterator_to_array($manipulated)[0]->getName());
     }
 }


### PR DESCRIPTION
See https://github.com/phpro/soap-client/issues/571

This is a breaking change, since it introduces a new way of configuring the code generation.
The models and contexts also changed.

Example:


```php
use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
use Phpro\SoapClient\CodeGenerator\Config\Destination;
use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;

return Config::create()
    ->setEngine($engine = DefaultEngineFactory::create(
        EngineOptions::defaults('your.wsdl')
    ))
    ->setTypeNamespaceMap(
        TypeNamespaceMap::create(fallback: new Destination('src/Type', 'App\\Type'))
           // Explicit mappings (generated during wizard : config setup)
            ->withMapping('http://xoev.de/schemata/xzufi/2_2_0', new Destination('src/Type/Xoev', 'App\\Type\\Xoev'))
            ->withMapping('http://www.opengis.net/gml/3.2', new Destination('src/Type/Gml', 'App\\Type\\Gml'))
            ->withMapping('http://www.isotc211.org/2005/gmd', new Destination('src/Type/Gmd', 'App\\Type\\Gmd'))
            ->withMapping('http://www.isotc211.org/2005/gmc', new Destination('src/Type/Gmc', 'App\\Type\\Gmc'))
            ->withMapping('http://www.isotc211.org/2005/gco', new Destination('src/Type/Gco', 'App\\Type\\Gco'))
            ->withMapping('http://www.isotc211.org/2005/gss', new Destination('src/Type/Gss', 'App\\Type\\Gss'))
            ->withMapping('http://www.isotc211.org/2005/gts', new Destination('src/Type/Gts', 'App\\Type\\Gts'))
            ->withMapping('http://www.w3.org/1999/xlink', new Destination('src/Type/Xlink', 'App\\Type\\Xlink'))

            // You could also specify a strategy that will be used if no mapping is found:
            ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
    )
    ->setClient(new ClientConfig('MyClient', new Destination('src', 'App')))
    ->setClassMap(new ClassMapConfig('MyClassmap', new Destination('src', 'App')));
```

