### PR TITLE
feat: add support for symfony 8

### DIFF
--- a/.github/workflows/grumphp.yml
+++ b/.github/workflows/grumphp.yml
@@ -43,3 +43,6 @@ jobs:
                   git config --global user.name "Your Name"
             - name: Run the tests
               run: php vendor/bin/grumphp run --no-interaction
+              env:
+                PHP_CS_FIXER_IGNORE_ENV: 1
+                BOX_REQUIREMENT_CHECKER: 0

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         "php-soap/wsdl-reader": "~0.21",
         "psr/event-dispatcher": "^1.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "~5.4 || ~6.0 || ~7.0",
-        "symfony/event-dispatcher": "~5.4 || ~6.0 || ~7.0",
-        "symfony/filesystem": "~5.4 || ~6.0 || ~7.0",
-        "symfony/validator": "~5.4 || ~6.0 || ~7.0"
+        "symfony/console": "~5.4 || ~6.0 || ~7.0 || ~8.0",
+        "symfony/event-dispatcher": "~5.4 || ~6.0 || ~7.0 || ~8.0",
+        "symfony/filesystem": "~5.4 || ~6.0 || ~7.0 || ~8.0",
+        "symfony/validator": "~5.4 || ~6.0 || ~7.0 || ~8.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.5.0",
@@ -33,7 +33,7 @@
         "php-http/vcr-plugin": "^1.2",
         "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpro/grumphp-shim": "^2.17",
-        "phpspec/phpspec": "^8.0",
+        "phpspec/phpspec": "^8.2",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^12.4",

--- a/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
@@ -50,7 +50,7 @@ class GenerateClassmapCommand extends Command
     /**
      * Configure the command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::COMMAND_NAME)

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
@@ -51,7 +51,7 @@ class GenerateClientCommand extends Command
     /**
      * Configure the command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::COMMAND_NAME)

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
@@ -40,7 +40,7 @@ class GenerateClientFactoryCommand extends Command
     /**
      * Configure the command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::COMMAND_NAME)

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -32,7 +32,7 @@ class GenerateConfigCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::COMMAND_NAME)

--- a/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
@@ -54,7 +54,7 @@ class GenerateTypesCommand extends Command
     /**
      * Configure the command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::COMMAND_NAME)

--- a/src/Phpro/SoapClient/Console/Command/WizardCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/WizardCommand.php
@@ -17,7 +17,7 @@ class WizardCommand extends Command
     /**
      * Configure the command.
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName(self::COMMAND_NAME)


### PR DESCRIPTION
In this PR we add support for symfony 8.0


### Changelog

- Allow ~8.0 for symfony/* components
- Upgraded phpspec/phpspec from 8.0 to 8.2, see https://github.com/phpspec/phpspec/commit/3c94d2768ae34daf96de7bc2b2361a06f4fa0e14.
- add `void` as return type for `configure()` for all symfony commands

