### PR TITLE
Introduce CodingStandardsStrategy for customizable naming conventions

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,40 @@
 # V4 to V5
 
+## Coding standards strategy
+
+A new `CodingStandardsStrategyInterface` lets you customize naming conventions for all generated code.
+By default, `DefaultCodingStandardsStrategy` is used, which matches the existing `Normalizer` behavior -- no changes required for existing users.
+
+Configure it via `Config::setCodingStandards()`:
+
+```php
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
+use Phpro\SoapClient\CodeGenerator\Config\Config;
+
+return ($config = Config::create())
+    ->setCodingStandards(new MyCodingStandards())
+    ->setEngine(...)
+    ->setTypeNamespaceMap(...)
+    // ...
+```
+
+[Read more about coding standards customization.](/docs/code-generation/coding-standards.md)
+
+### Context classes require CodeGeneratorContext
+
+`TypeContext`, `PropertyContext`, `ClientMethodContext`, and `ClassMapContext` now require `CodeGeneratorContext` as an additional last constructor parameter and expose `getCodeGeneratorContext(): CodeGeneratorContext`.
+
+### New convenience methods on Property
+
+`Property` has new convenience methods that use the configured coding standards:
+
+- `$property->methodName(string $prefix)`: Generates an accessor method name (e.g. `methodName('with')` returns `withFirstName`).
+- `$property->parameterName()`: Normalizes the property name for use as a PHP parameter name.
+
+### Generated config pattern
+
+The generated configuration now uses `return ($config = Config::create())` so that `$config` can be referenced in nested calls (e.g. `$config->getCodingStandards()`).
+
 ## Configuration overhaul
 
 The configuration system has been significantly reworked.
@@ -102,7 +137,7 @@ A built-in `PrefixBasedTypeNamespaceStrategy` derives a sub-namespace from the X
 use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
 
 TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
-    ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+    ->withStrategy(new PrefixBasedTypeNamespaceStrategy($config->getCodingStandards()))
 ```
 
 With this strategy, a type in the `gml` xmlns prefix is automatically placed in `src/Type/Gml` with namespace `App\Type\Gml`.
@@ -112,14 +147,14 @@ Explicit `withMapping()` entries always take precedence over the strategy. You c
 ```php
 TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
     ->withMapping('http://special.example.com', new Destination('src/Type/Special', 'App\\Type\\Special'))
-    ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+    ->withStrategy(new PrefixBasedTypeNamespaceStrategy($config->getCodingStandards()))
 ```
 
 You can also implement a custom strategy via `TypeNamespaceMapStrategyInterface` or pass any callable.
 
 ### Duplicate type strategies are now namespace-aware
 
-The `IntersectDuplicateTypesStrategy` and `RemoveDuplicateTypesStrategy` now use a factory pattern (`create()`) that accepts the `TypeNamespaceMap`. When types map to different PHP namespaces, they are not considered duplicates.
+The `IntersectDuplicateTypesStrategy` and `RemoveDuplicateTypesStrategy` now use a factory pattern (`create()`) that accepts the `CodeGeneratorContext`. When types map to different PHP namespaces, they are not considered duplicates.
 
 ## Interactive config generator improvements
 

--- a/docs/code-generation/assemblers.md
+++ b/docs/code-generation/assemblers.md
@@ -613,4 +613,16 @@ Possible contexts:
 - `ClassMapContext`: Triggered during the `generate:classmap` command.
 - `TypeContext`: Triggered during the `generate:types` command for every type in the SOAP scheme.
 - `PropertyContext`: Triggered during the `generate:types` command for every property in a SOAP type.
-- 'FileContext': Triggered during every `generate:*` command.
+- `ClientMethodContext`: Triggered during the `generate:client` command for every method.
+- `FileContext`: Triggered during every `generate:*` command.
+
+`TypeContext`, `PropertyContext`, `ClientMethodContext`, and `ClassMapContext` expose a `getCodeGeneratorContext(): CodeGeneratorContext` method.
+Through the `CodeGeneratorContext`, you can access the `TypeNamespaceMap` and `CodingStandardsStrategyInterface`:
+
+```php
+// Access the namespace map:
+$context->getCodeGeneratorContext()->typeNamespaceMap;
+
+// Access the coding standards:
+$context->getCodeGeneratorContext()->codingStandards;
+```

--- a/docs/code-generation/coding-standards.md
+++ b/docs/code-generation/coding-standards.md
@@ -1,0 +1,155 @@
+# Coding standards
+
+The `CodingStandardsStrategyInterface` lets you customize how names are normalized during code generation.
+This is useful when your project has specific naming conventions that differ from the defaults.
+
+By default, `DefaultCodingStandardsStrategy` is used, which delegates to the built-in `Normalizer` methods.
+This matches the existing behavior, so no changes are needed for existing users.
+
+## Interface
+
+```php
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
+
+interface CodingStandardsStrategyInterface
+{
+    /**
+     * Convert SOAP type name to PHP class/enum name (e.g. "my-type" -> "MyType")
+     */
+    public function normalizeTypeName(string $name): string;
+
+    /**
+     * Convert SOAP operation name to PHP method name (e.g. "GetUsers" -> "getUsers")
+     */
+    public function normalizeOperationName(string $method): string;
+
+    /**
+     * Normalize XML namespace segment for PHP namespace (e.g. "my-prefix" -> "MyPrefix")
+     * Return null to skip the segment.
+     */
+    public function normalizeNamespaceSegment(string $segment): ?string;
+
+    /**
+     * Normalize enum value to PHP enum case name (e.g. "some-value" -> "SomeValue")
+     */
+    public function normalizeEnumCaseName(string $value): string;
+
+    /**
+     * Generate accessor method name from prefix + property name
+     * (e.g. "get" + "firstName" -> "getFirstName")
+     */
+    public function generatePropertyAccessorMethodName(string $prefix, string $property): string;
+
+    /**
+     * Normalize a parameter name for constructors and setters.
+     * Input is the fixed property name. Output is the parameter name for PHP code.
+     * This enables named arguments: new Foo(fooBar: 'x') while property stays $foo_bar.
+     */
+    public function normalizeParameterName(string $propertyName): string;
+}
+```
+
+## Configuration
+
+Configure coding standards via `Config::setCodingStandards()`.
+The generated config uses `return ($config = Config::create())` so that `$config` can be referenced in nested calls:
+
+```php
+use Phpro\SoapClient\CodeGenerator\Config\Config;
+use Phpro\SoapClient\CodeGenerator\Config\Destination;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
+
+return ($config = Config::create())
+    ->setCodingStandards(new MyCodingStandards())
+    ->setEngine(...)
+    ->setTypeNamespaceMap(
+        TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
+            ->withStrategy(new PrefixBasedTypeNamespaceStrategy($config->getCodingStandards()))
+    )
+    ->setClient(...)
+    ->setClassMap(...)
+;
+```
+
+When using `PrefixBasedTypeNamespaceStrategy`, pass the coding standards to its constructor so that namespace segments are normalized using the same strategy.
+
+## Creating a custom strategy
+
+Implement `CodingStandardsStrategyInterface` to define your own naming conventions:
+
+```php
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
+
+class MyCodingStandards implements CodingStandardsStrategyInterface
+{
+    public function normalizeTypeName(string $name): string
+    {
+        // e.g. prefix all types
+        return 'Soap' . ucfirst($name);
+    }
+
+    public function normalizeOperationName(string $method): string
+    {
+        return lcfirst($method);
+    }
+
+    public function normalizeNamespaceSegment(string $segment): ?string
+    {
+        return ucfirst($segment);
+    }
+
+    public function normalizeEnumCaseName(string $value): string
+    {
+        return strtoupper($value);
+    }
+
+    public function generatePropertyAccessorMethodName(string $prefix, string $property): string
+    {
+        return $prefix . ucfirst($property);
+    }
+
+    public function normalizeParameterName(string $propertyName): string
+    {
+        return lcfirst($propertyName);
+    }
+}
+```
+
+## Accessing coding standards in custom assemblers
+
+Inside a custom assembler, the `CodeGeneratorContext` is available through the assembler context:
+
+```php
+use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
+use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
+use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
+
+class MyAssembler implements AssemblerInterface
+{
+    public function canAssemble(ContextInterface $context): bool
+    {
+        return $context instanceof PropertyContext;
+    }
+
+    public function assemble(ContextInterface $context): void
+    {
+        assert($context instanceof PropertyContext);
+
+        $codingStandards = $context->getCodeGeneratorContext()->codingStandards;
+        $typeNamespaceMap = $context->getCodeGeneratorContext()->typeNamespaceMap;
+
+        // Use coding standards to generate a custom method name:
+        $methodName = $codingStandards->generatePropertyAccessorMethodName(
+            'has',
+            $context->getProperty()->getName()
+        );
+
+        // Or use the convenience methods on Property:
+        $getterName = $context->getProperty()->methodName('get');
+        $paramName = $context->getProperty()->parameterName();
+
+        // ...
+    }
+}
+```

--- a/docs/code-generation/configuration.md
+++ b/docs/code-generation/configuration.md
@@ -17,7 +17,7 @@ use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeName
 use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 
-return Config::create()
+return ($config = Config::create())
     ->setEngine(DefaultEngineFactory::create(
         EngineOptions::defaults($wsdl)
             ->withWsdlLoader(new FlatteningLoader(new StreamWrapperLoader()))
@@ -33,7 +33,7 @@ return Config::create()
             ->withMapping('http://www.xmlns.mapping', new Destination('src/Type/OtherDir', 'App\\Type\\OtherDir'))
             // Or use a strategy to automatically resolve destinations from xmlns prefixes:
             // This strategy will only be called for XML namespaces that don't have an explicit mapping configured.
-            ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+            ->withStrategy(new PrefixBasedTypeNamespaceStrategy($config->getCodingStandards()))
     )
     ->setClient(new ClientConfig('MySoapClient', new Destination('SoapClient', 'src/SoapClient')))
     ->setClassMap(new ClassMapConfig('AcmeClassmap', new Destination('Acme\\Classmap', 'src/acme/classmap')))
@@ -201,8 +201,15 @@ Config::create()
 ```
 
 The duplicate type strategies use a factory pattern (`create()`) that returns a closure.
-This closure receives the `TypeNamespaceMap` from the configuration, enabling namespace-aware duplicate detection.
+This closure receives the `CodeGeneratorContext` from the configuration, enabling namespace-aware duplicate detection.
 When types map to different PHP namespaces, they are not considered duplicates.
+
+**Coding standards**
+
+Use `setCodingStandards(CodingStandardsStrategyInterface)` to customize how names are normalized in generated code.
+By default, `DefaultCodingStandardsStrategy` is used, which matches the existing behavior.
+
+[Read more about coding standards customization.](coding-standards.md)
 
 **Enumeration options**
 

--- a/docs/code-generation/rules.md
+++ b/docs/code-generation/rules.md
@@ -261,4 +261,7 @@ Possible contexts:
 - `ClassMapContext`: Triggered during the `generate:classmap` command.
 - `TypeContext`: Triggered during the `generate:types` command for every type in the SOAP scheme.
 - `PropertyContext`: Triggered during the `generate:types` command for every property in a SOAP type.
+- `ClientMethodContext`: Triggered during the `generate:client` command for every method.
 - `FileContext`: Triggered during every generate command.
+
+`TypeContext`, `PropertyContext`, `ClientMethodContext`, and `ClassMapContext` expose `getCodeGeneratorContext(): CodeGeneratorContext` for accessing the `TypeNamespaceMap` and `CodingStandardsStrategyInterface`.

--- a/docs/drivers/metadata.md
+++ b/docs/drivers/metadata.md
@@ -71,7 +71,7 @@ return Config::create()
     // ...
 ```
 
-The `create()` factory method returns a closure that receives the `TypeNamespaceMap` from the configuration,
+The `create()` factory method returns a closure that receives the `CodeGeneratorContext` from the configuration,
 enabling the strategy to determine target PHP namespaces for each type.
 
 ### Type replacements

--- a/spec/Phpro/SoapClient/CodeGenerator/ClassMapGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/ClassMapGeneratorSpec.php
@@ -3,10 +3,12 @@
 namespace spec\Phpro\SoapClient\CodeGenerator;
 
 use Phpro\SoapClient\CodeGenerator\ClassMapGenerator;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\FileContext;
 use Phpro\SoapClient\CodeGenerator\GeneratorInterface;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
@@ -45,8 +47,10 @@ class ClassMapGeneratorSpec extends ObjectBehavior
         $ruleSet->applyRules(Argument::type(ClassMapContext::class))->shouldBeCalled();
         $ruleSet->applyRules(Argument::type(FileContext::class))->shouldBeCalled();
         $file->generate()->willReturn('code');
+        $namespaceMap = TypeNamespaceMap::create(new Destination('/app', 'App\\Mynamespace'));
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $this->generate($file, TypeMap::fromMetadata(
-            TypeNamespaceMap::create(new Destination('/app', 'App\\Mynamespace')),
+            $codeGeneratorContext,
             new TypeCollection(),
         ))->shouldReturn('code');
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/ClientGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/ClientGeneratorSpec.php
@@ -5,11 +5,13 @@ namespace spec\Phpro\SoapClient\CodeGenerator;
 use Laminas\Code\Generator\Exception\ClassNotFoundException;
 use Phpro\SoapClient\CodeGenerator\ClassMapGenerator;
 use Phpro\SoapClient\CodeGenerator\ClientGenerator;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\FileContext;
 use Phpro\SoapClient\CodeGenerator\GeneratorInterface;
 use Phpro\SoapClient\CodeGenerator\Model\Client;
@@ -52,11 +54,12 @@ class ClientGeneratorSpec extends ObjectBehavior
     function it_generates_clients(RuleSetInterface $ruleSet, FileGenerator $file, ClassGenerator $class)
     {
         $typeNamespaceMap = TypeNamespaceMap::create(new Destination('/app', ''));
+        $codeGeneratorContext = new CodeGeneratorContext($typeNamespaceMap, new DefaultCodingStandardsStrategy());
         $method = new ClientMethod(
             'Test',
-            [new Parameter('parameters', 'Test', $typeNamespaceMap, XsdType::create('Test'))],
-            ReturnType::fromMetaData($typeNamespaceMap, XsdType::create('TestResponse')),
-            $typeNamespaceMap,
+            [new Parameter('parameters', 'Test', $codeGeneratorContext, XsdType::create('Test'))],
+            ReturnType::fromMetaData($codeGeneratorContext, XsdType::create('TestResponse')),
+            $codeGeneratorContext,
             new MethodMeta()
         );
         $ruleSet->applyRules(Argument::type(ClientMethodContext::class))->shouldBeCalled();
@@ -77,11 +80,12 @@ class ClientGeneratorSpec extends ObjectBehavior
     function it_generates_clients_for_file_without_classes(RuleSetInterface $ruleSet, FileGenerator $file, ClassGenerator $class)
     {
         $typeNamespaceMap = TypeNamespaceMap::create(new Destination('/app', ''));
+        $codeGeneratorContext = new CodeGeneratorContext($typeNamespaceMap, new DefaultCodingStandardsStrategy());
         $method = new ClientMethod(
             'Test',
-            [new Parameter('parameters', 'Test', $typeNamespaceMap, XsdType::create('Test'))],
-            ReturnType::fromMetaData($typeNamespaceMap, XsdType::create('TestResponse')),
-            $typeNamespaceMap,
+            [new Parameter('parameters', 'Test', $codeGeneratorContext, XsdType::create('Test'))],
+            ReturnType::fromMetaData($codeGeneratorContext, XsdType::create('TestResponse')),
+            $codeGeneratorContext,
             new MethodMeta()
         );
 

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClassMapContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClassMapContextSpec.php
@@ -2,10 +2,12 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use PhpSpec\ObjectBehavior;
@@ -25,12 +27,13 @@ class ClassMapContextSpec extends ObjectBehavior
     {
         $typeDestination = new Destination('src/type', 'App\\Mynamespace');
         $namespaceMap = TypeNamespaceMap::create($typeDestination);
-        $this->typeMap = new TypeMap($namespaceMap, []);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $this->typeMap = new TypeMap($context, []);
 
         $classMapDestination = new Destination('src/classmap', 'App\\Mynamespace');
         $classMapConfig = new ClassMapConfig('ClassMap', $classMapDestination);
 
-        $this->beConstructedWith($fileGenerator, $this->typeMap, $classMapConfig);
+        $this->beConstructedWith($fileGenerator, $this->typeMap, $classMapConfig, $context);
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClientFactoryContextSpec.php
@@ -3,11 +3,13 @@
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
 use Laminas\Code\Generator\ClassGenerator;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use PhpSpec\ObjectBehavior;
@@ -28,11 +30,13 @@ class ClientFactoryContextSpec extends ObjectBehavior
         $classMapDestination = new Destination('src/classmap', 'App\\Classmap');
         $typeDestination = new Destination('src/type', 'ns');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($typeDestination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $classMapConfig = new ClassMapConfig('Myclassmap', $classMapDestination);
         $classMapContext = new ClassMapContext(
             new FileGenerator(),
-            new TypeMap($namespaceMap, []),
-            $classMapConfig
+            new TypeMap($context, []),
+            $classMapConfig,
+            $context
         );
         $this->beConstructedWith($clientContext, $classMapContext);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContextSpec.php
@@ -2,8 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
@@ -27,16 +29,17 @@ class ClientMethodContextSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'ParamNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
 
         $this->method = new ClientMethod(
             'testMethod',
             [],
-            ReturnType::fromMetaData($namespaceMap, XsdType::create('CreditResponse')),
-            $namespaceMap,
+            ReturnType::fromMetaData($context, XsdType::create('CreditResponse')),
+            $context,
             new MethodMeta()
         );
 
-        $this->beConstructedWith($class, $this->method);
+        $this->beConstructedWith($class, $this->method, $context);
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/PropertyContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/PropertyContextSpec.php
@@ -2,8 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
@@ -27,17 +29,18 @@ class PropertyContextSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
 
-        $this->property = new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
+        $this->property = new Property('prop1', 'string', $context, 'MyNamespace', XsdType::create('string'));
         $this->type = new Type(
-            $namespaceMap,
+            $context,
             'MyType',
             'MyType',
             [$this->property],
             XsdType::create('MyType')
         );
 
-        $this->beConstructedWith($class, $this->type, $this->property);
+        $this->beConstructedWith($class, $this->type, $this->property, $context);
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Context/TypeContextSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Context/TypeContextSpec.php
@@ -2,8 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Context;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
@@ -25,14 +27,15 @@ class TypeContextSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $this->type = new Type(
-            $namespaceMap,
+            $context,
             'MyType',
             'MyType',
             [],
             XsdType::create('MyType')
         );
-        $this->beConstructedWith($class, $this->type);
+        $this->beConstructedWith($class, $this->type, $context);
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ClientMethodSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ClientMethodSpec.php
@@ -2,8 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
 use Phpro\SoapClient\CodeGenerator\Model\ReturnType;
 use PhpSpec\ObjectBehavior;
@@ -22,11 +24,12 @@ class ClientMethodSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'ParamNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $this->beConstructedWith(
             'testMethod',
             [],
-            ReturnType::fromMetaData($namespaceMap, XsdType::create('CreditResponse')),
-            $namespaceMap,
+            ReturnType::fromMetaData($context, XsdType::create('CreditResponse')),
+            $context,
             new MethodMeta()
         );
     }
@@ -55,8 +58,9 @@ class ClientMethodSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'ParamNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $this->getReturnType()->shouldBeLike(
-            ReturnType::fromMetaData($namespaceMap, XsdType::create('CreditResponse'))
+            ReturnType::fromMetaData($context, XsdType::create('CreditResponse'))
         );
     }
 

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ParameterSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ParameterSpec.php
@@ -2,8 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Model\Parameter;
 use PhpSpec\ObjectBehavior;
 use Soap\Engine\Metadata\Model\TypeMeta;
@@ -21,7 +23,8 @@ class ParameterSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $this->beConstructedWith('MyParameter', 'MyParameterType', $namespaceMap, XsdType::create('MyParameter'));
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $this->beConstructedWith('MyParameter', 'MyParameterType', $context, XsdType::create('MyParameter'));
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/PropertySpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/PropertySpec.php
@@ -2,8 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use PhpSpec\ObjectBehavior;
 use Soap\Engine\Metadata\Model\TypeMeta;
@@ -21,7 +23,8 @@ class PropertySpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'My\Namespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $this->beConstructedWith('name', 'Type', $namespaceMap, 'My\Namespace', XsdType::create('Type'));
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $this->beConstructedWith('name', 'Type', $context, 'My\Namespace', XsdType::create('Type'));
     }
 
     function it_is_initializable()

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/ReturnTypeSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/ReturnTypeSpec.php
@@ -2,8 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Model\ReturnType;
 use PhpSpec\ObjectBehavior;
 use Soap\Engine\Metadata\Model\TypeMeta;
@@ -21,7 +23,8 @@ class ReturnTypeSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'My\Namespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $this->beConstructedWith('Type', $namespaceMap, XsdType::create('Type'));
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $this->beConstructedWith('Type', $context, XsdType::create('Type'));
     }
 
     function it_is_initializable()
@@ -38,9 +41,10 @@ class ReturnTypeSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'My\Namespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $this->beConstructedWith(
             'Type',
-            $namespaceMap,
+            $context,
             XsdType::create('Type')
                 ->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true))
         );
@@ -52,9 +56,10 @@ class ReturnTypeSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'My\Namespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $this->beConstructedWith(
             'Type',
-            $namespaceMap,
+            $context,
             XsdType::create('Type')
                 ->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true)->withExtends([
                     'isSimple' => true,
@@ -75,10 +80,11 @@ class ReturnTypeSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'My\Namespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $this->beConstructedThrough(
             'fromMetaData',
             [
-                $namespaceMap,
+                $context,
                 XsdType::create('ElementType')
                     ->withXmlTypeName('ComplexType')
             ]

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/TypeMapSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/TypeMapSpec.php
@@ -2,8 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
@@ -22,9 +24,10 @@ class TypeMapSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $this->beConstructedWith($namespaceMap, [
-            new Type($namespaceMap, 'type1', 'type1', [
-                new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $this->beConstructedWith($context, [
+            new Type($context, 'type1', 'type1', [
+                new Property('prop1', 'string', $context, 'MyNamespace', XsdType::create('string'))
             ], XsdType::create('MyType'))
         ]);
     }

--- a/spec/Phpro/SoapClient/CodeGenerator/Model/TypeSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Model/TypeSpec.php
@@ -2,8 +2,10 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
@@ -23,11 +25,12 @@ class TypeSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $this->beConstructedWith(
-            $namespaceMap,
+            $context,
             'myType',
             'MyType',
-            [new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))],
+            [new Property('prop1', 'string', $context, 'MyNamespace', XsdType::create('string'))],
             XsdType::create('MyType')
         );
     }
@@ -65,7 +68,8 @@ class TypeSpec extends ObjectBehavior
     {
         $destination = new Destination('my/some_dir', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $this->beConstructedWith($namespaceMap, 'my_type_3_2', Normalizer::normalizeClassname('my_type_3_2'), ['prop1' => 'string'], XsdType::create('MyType'));
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $this->beConstructedWith($context, 'my_type_3_2', Normalizer::normalizeClassname('my_type_3_2'), ['prop1' => 'string'], XsdType::create('MyType'));
         $this->getFileInfo()->getPathname()->shouldReturn('my/some_dir/MyType32.php');
     }
 
@@ -73,11 +77,12 @@ class TypeSpec extends ObjectBehavior
     {
         $destination = new Destination('my/some_dir', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $context = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $this->beConstructedWith(
-            $namespaceMap,
+            $context,
             'Final',
             Normalizer::normalizeClassname('Final'),
-            [new Property('xor', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))],
+            [new Property('xor', 'string', $context, 'MyNamespace', XsdType::create('string'))],
             XsdType::create('MyType')
         );
 

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/ClientMethodMatchesRuleSpec.php
@@ -3,8 +3,10 @@
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
 use Laminas\Code\Generator\ClassGenerator;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientMethodContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Model\ClientMethod;
@@ -48,14 +50,15 @@ class ClientMethodMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $method = new ClientMethod(
             'myClientMethod',
             [],
-            ReturnType::fromMetaData($namespaceMap, XsdType::create('string')),
-            $namespaceMap,
+            ReturnType::fromMetaData($codeGeneratorContext, XsdType::create('string')),
+            $codeGeneratorContext,
             new MethodMeta()
         );
-        $context = new ClientMethodContext(new ClassGenerator(), $method);
+        $context = new ClientMethodContext(new ClassGenerator(), $method, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -65,14 +68,15 @@ class ClientMethodMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $method = new ClientMethod(
             'myInvalidClientMethod',
             [],
-            ReturnType::fromMetaData($namespaceMap, XsdType::create('string')),
-            $namespaceMap,
+            ReturnType::fromMetaData($codeGeneratorContext, XsdType::create('string')),
+            $codeGeneratorContext,
             new MethodMeta()
         );
-        $context = new ClientMethodContext(new ClassGenerator(), $method);
+        $context = new ClientMethodContext(new ClassGenerator(), $method, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
@@ -82,14 +86,15 @@ class ClientMethodMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $method = new ClientMethod(
             'myClientMethod',
             [],
-            ReturnType::fromMetaData($namespaceMap, XsdType::create('string')),
-            $namespaceMap,
+            ReturnType::fromMetaData($codeGeneratorContext, XsdType::create('string')),
+            $codeGeneratorContext,
             new MethodMeta()
         );
-        $context = new ClientMethodContext(new ClassGenerator(), $method);
+        $context = new ClientMethodContext(new ClassGenerator(), $method, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRuleSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
@@ -60,8 +62,9 @@ class IsAbstractTypeRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -71,9 +74,10 @@ class IsAbstractTypeRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
-        $type = new Type($namespaceMap, 'MyAbstract', 'MyAbstract', [$property], XsdType::create('MyType'));
-        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $codeGeneratorContext, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($codeGeneratorContext, 'MyAbstract', 'MyAbstract', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -83,8 +87,9 @@ class IsAbstractTypeRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'NotAbstract', 'NotAbstract', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'NotAbstract', 'NotAbstract', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
@@ -94,8 +99,9 @@ class IsAbstractTypeRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'MyAbstract', 'MyAbstract', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRuleSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
@@ -63,8 +65,9 @@ class IsExtendingTypeRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'MyExtending', 'MyExtending', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'MyExtending', 'MyExtending', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -74,9 +77,10 @@ class IsExtendingTypeRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
-        $type = new Type($namespaceMap, 'MyExtending', 'MyExtending', [$property], XsdType::create('MyType'));
-        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $codeGeneratorContext, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($codeGeneratorContext, 'MyExtending', 'MyExtending', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -86,8 +90,9 @@ class IsExtendingTypeRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'NotExtending', 'NotExtending', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'NotExtending', 'NotExtending', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
@@ -97,8 +102,9 @@ class IsExtendingTypeRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'MyExtending', 'MyExtending', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'MyExtending', 'MyExtending', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRuleSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
@@ -58,8 +60,9 @@ class IsRequestRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'RequestType', 'RequestType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'RequestType', 'RequestType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -69,9 +72,10 @@ class IsRequestRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
-        $type = new Type($namespaceMap, 'RequestType', 'RequestType', [$property], XsdType::create('MyType'));
-        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $codeGeneratorContext, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($codeGeneratorContext, 'RequestType', 'RequestType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -81,8 +85,9 @@ class IsRequestRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
@@ -92,8 +97,9 @@ class IsRequestRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'RequestType', 'RequestType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'RequestType', 'RequestType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/IsResultRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/IsResultRuleSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
@@ -58,8 +60,9 @@ class IsResultRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'ResultType', 'ResultType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'ResultType', 'ResultType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -69,9 +72,10 @@ class IsResultRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
-        $type = new Type($namespaceMap, 'ResultType', 'ResultType', [$property], XsdType::create('MyType'));
-        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $codeGeneratorContext, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($codeGeneratorContext, 'ResultType', 'ResultType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -81,8 +85,9 @@ class IsResultRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
@@ -92,8 +97,9 @@ class IsResultRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'ResultType', 'ResultType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'ResultType', 'ResultType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/PropertynameMatchesRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/PropertynameMatchesRuleSpec.php
@@ -3,8 +3,10 @@
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
 use Laminas\Code\Generator\ClassGenerator;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
@@ -47,9 +49,10 @@ class PropertynameMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'ns1');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $property = new Property('myProperty', 'string', $namespaceMap, 'ns1', XsdType::create('string'));
-        $type = new Type($namespaceMap, 'MyType', 'MyType', [$property], XsdType::create('MyType'));
-        $context = new PropertyContext(new ClassGenerator(), $type, $property);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $property = new Property('myProperty', 'string', $codeGeneratorContext, 'ns1', XsdType::create('string'));
+        $type = new Type($codeGeneratorContext, 'MyType', 'MyType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new ClassGenerator(), $type, $property, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -59,9 +62,10 @@ class PropertynameMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'ns1');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $property = new Property('InvalidTypeName', 'string', $namespaceMap, 'ns1', XsdType::create('string'));
-        $type = new Type($namespaceMap, 'MyType', 'MyType', [$property], XsdType::create('MyType'));
-        $context = new PropertyContext(new ClassGenerator(), $type, $property);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $property = new Property('InvalidTypeName', 'string', $codeGeneratorContext, 'ns1', XsdType::create('string'));
+        $type = new Type($codeGeneratorContext, 'MyType', 'MyType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new ClassGenerator(), $type, $property, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
@@ -71,9 +75,10 @@ class PropertynameMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'ns1');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $property = new Property('MyProperty', 'string', $namespaceMap, 'ns1', XsdType::create('string'));
-        $type = new Type($namespaceMap, 'MyType', 'MyType', [$property], XsdType::create('MyType'));
-        $context = new PropertyContext(new ClassGenerator(), $type, $property);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $property = new Property('MyProperty', 'string', $codeGeneratorContext, 'ns1', XsdType::create('string'));
+        $type = new Type($codeGeneratorContext, 'MyType', 'MyType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new ClassGenerator(), $type, $property, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/TypeMapRuleSpec.php
@@ -3,6 +3,8 @@
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
 use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
@@ -50,8 +52,9 @@ class TypeMapRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'SomeType', 'SomeType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'SomeType', 'SomeType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $rule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -61,9 +64,10 @@ class TypeMapRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
-        $type = new Type($namespaceMap, 'SomeType', 'SomeType', [$property], XsdType::create('MyType'));
-        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $property = new \Phpro\SoapClient\CodeGenerator\Model\Property('prop1', 'string', $codeGeneratorContext, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($codeGeneratorContext, 'SomeType', 'SomeType', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $property, $codeGeneratorContext);
 
         $rule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -73,8 +77,9 @@ class TypeMapRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'UnknownType', 'UnknownType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'UnknownType', 'UnknownType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $defaultRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -84,8 +89,9 @@ class TypeMapRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'NullType', 'NullType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'NullType', 'NullType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $this->appliesToContext($context)->shouldReturn(false);
     }
@@ -94,8 +100,9 @@ class TypeMapRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'SomeType', 'SomeType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'SomeType', 'SomeType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $rule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);
@@ -105,8 +112,9 @@ class TypeMapRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'SomeType', 'SomeType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'SomeType', 'SomeType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $rule->apply($context)->shouldBeCalled();
         $this->apply($context);
@@ -116,8 +124,9 @@ class TypeMapRuleSpec extends ObjectBehavior
     {
         $destination = new \Phpro\SoapClient\CodeGenerator\Config\Destination('src/type', 'MyNamespace');
         $namespaceMap = \Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'UnknownType', 'UnknownType', [], XsdType::create('MyType'));
-        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'UnknownType', 'UnknownType', [], XsdType::create('MyType'));
+        $context = new TypeContext(new \Laminas\Code\Generator\ClassGenerator(), $type, $codeGeneratorContext);
 
         $defaultRule->apply($context)->shouldBeCalled();
         $this->apply($context);

--- a/spec/Phpro/SoapClient/CodeGenerator/Rules/TypenameMatchesRuleSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/Rules/TypenameMatchesRuleSpec.php
@@ -3,8 +3,10 @@
 namespace spec\Phpro\SoapClient\CodeGenerator\Rules;
 
 use Laminas\Code\Generator\ClassGenerator;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
@@ -48,8 +50,9 @@ class TypenameMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'TypeName', 'TypeName', [], XsdType::create('MyType'));
-        $context = new TypeContext(new ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'TypeName', 'TypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -59,9 +62,10 @@ class TypenameMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $property = new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'));
-        $type = new Type($namespaceMap, 'TypeName', 'TypeName', [$property], XsdType::create('MyType'));
-        $context = new PropertyContext(new ClassGenerator(), $type, $property);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $property = new Property('prop1', 'string', $codeGeneratorContext, 'MyNamespace', XsdType::create('string'));
+        $type = new Type($codeGeneratorContext, 'TypeName', 'TypeName', [$property], XsdType::create('MyType'));
+        $context = new PropertyContext(new ClassGenerator(), $type, $property, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(true);
@@ -71,8 +75,9 @@ class TypenameMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType'));
-        $context = new TypeContext(new ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'InvalidTypeName', 'InvalidTypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(true);
         $this->appliesToContext($context)->shouldReturn(false);
@@ -82,8 +87,9 @@ class TypenameMatchesRuleSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
-        $type = new Type($namespaceMap, 'TypeName', 'TypeName', [], XsdType::create('MyType'));
-        $context = new TypeContext(new ClassGenerator(), $type);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
+        $type = new Type($codeGeneratorContext, 'TypeName', 'TypeName', [], XsdType::create('MyType'));
+        $context = new TypeContext(new ClassGenerator(), $type, $codeGeneratorContext);
 
         $subRule->appliesToContext($context)->willReturn(false);
         $this->appliesToContext($context)->shouldReturn(false);

--- a/spec/Phpro/SoapClient/CodeGenerator/TypeGeneratorSpec.php
+++ b/spec/Phpro/SoapClient/CodeGenerator/TypeGeneratorSpec.php
@@ -3,8 +3,10 @@
 namespace spec\Phpro\SoapClient\CodeGenerator;
 
 use Laminas\Code\Generator\Exception\ClassNotFoundException;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\FileContext;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
@@ -48,11 +50,12 @@ class TypeGeneratorSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $type = new Type(
-            $namespaceMap,
+            $codeGeneratorContext,
             'MyType',
             'MyType',
-            [new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))],
+            [new Property('prop1', 'string', $codeGeneratorContext, 'MyNamespace', XsdType::create('string'))],
             XsdType::create('MyType')
         );
         $property = $type->getProperties()[0];
@@ -75,11 +78,12 @@ class TypeGeneratorSpec extends ObjectBehavior
     {
         $destination = new Destination('src/type', 'MyNamespace');
         $namespaceMap = TypeNamespaceMap::create($destination);
+        $codeGeneratorContext = new CodeGeneratorContext($namespaceMap, new DefaultCodingStandardsStrategy());
         $type = new Type(
-            $namespaceMap,
+            $codeGeneratorContext,
             'MyType',
             'MyType',
-            [new Property('prop1', 'string', $namespaceMap, 'MyNamespace', XsdType::create('string'))],
+            [new Property('prop1', 'string', $codeGeneratorContext, 'MyNamespace', XsdType::create('string'))],
             XsdType::create('MyType')
         );
         $property = $type->getProperties()[0];

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ClientMethodAssembler.php
@@ -44,8 +44,9 @@ class ClientMethodAssembler implements AssemblerInterface
         }
         $class = $context->getClass();
         $method = $context->getMethod();
+        $codingStandards = $context->getCodeGeneratorContext()->codingStandards;
         try {
-            $phpMethodName = Normalizer::normalizeMethodName($method->getMethodName());
+            $phpMethodName = $codingStandards->normalizeOperationName($method->getMethodName());
             $param = $this->createParamsFromContext($context);
             $class->removeMethod($phpMethodName);
             $docblock = $method->shouldGenerateAsMultiArgumentsRequest()

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ConstructorAssembler.php
@@ -84,7 +84,7 @@ class ConstructorAssembler implements AssemblerInterface
         $body = [];
         foreach ($entries as $entry) {
             $property = $entry['property'];
-            $param = new ParameterGenerator($property->getName());
+            $param = new ParameterGenerator($property->parameterName());
 
             if ($this->options->useTypeHints()) {
                 $param->setType($property->getPhpType());
@@ -95,12 +95,12 @@ class ConstructorAssembler implements AssemblerInterface
             }
 
             $constructor->setParameter($param);
-            $body[] = sprintf('$this->%1$s = $%1$s;', $property->getName());
+            $body[] = sprintf('$this->%s = $%s;', $property->getName(), $property->parameterName());
 
             if ($this->options->useDocBlocks()) {
                 $docblock->setTag([
                     'name' => 'param',
-                    'description' => sprintf('%s $%s', $property->getDocBlockType(), $property->getName())
+                    'description' => sprintf('%s $%s', $property->getDocBlockType(), $property->parameterName())
                 ]);
             }
         }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendingTypeAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ExtendingTypeAssembler.php
@@ -4,7 +4,6 @@ namespace Phpro\SoapClient\CodeGenerator\Assembler;
 
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\AssemblerException;
 
 /**
@@ -38,7 +37,7 @@ class ExtendingTypeAssembler implements AssemblerInterface
         }
 
         $namespace = $type->getNamespace();
-        $typeName = Normalizer::normalizeClassname($extending['type']);
+        $typeName = $type->getCodeGeneratorContext()->codingStandards->normalizeTypeName($extending['type']);
         $extendedClassName = sprintf('%s\\%s', $namespace, $typeName);
 
         try {

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/FluentSetterAssembler.php
@@ -6,9 +6,7 @@ use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\ParameterGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
-use Phpro\SoapClient\CodeGenerator\Model\Parameter;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
 
@@ -51,15 +49,16 @@ class FluentSetterAssembler implements AssemblerInterface
         $class = $context->getClass();
         $property = $context->getProperty();
         try {
-            $methodName = Normalizer::generatePropertyMethod('set', $property->getName());
+            $methodName = $property->methodName('set');
             $class->removeMethod($methodName);
 
             $methodGenerator = new MethodGenerator($methodName);
             $methodGenerator->setParameter($this->getParameter($property));
             $methodGenerator->setVisibility(MethodGenerator::VISIBILITY_PUBLIC);
             $methodGenerator->setBody(sprintf(
-                '$this->%1$s = $%1$s;%2$sreturn $this;',
+                '$this->%s = $%s;%sreturn $this;',
                 $property->getName(),
+                $property->parameterName(),
                 $class::LINE_FEED
             ));
             if ($this->options->useReturnType()) {
@@ -72,7 +71,11 @@ class FluentSetterAssembler implements AssemblerInterface
                         ->setTags([
                             [
                                 'name'        => 'param',
-                                'description' => sprintf('%s $%s', $property->getDocBlockType(), $property->getName()),
+                                'description' => sprintf(
+                                    '%s $%s',
+                                    $property->getDocBlockType(),
+                                    $property->parameterName()
+                                ),
                             ],
                             [
                                 'name'        => 'return',
@@ -89,7 +92,7 @@ class FluentSetterAssembler implements AssemblerInterface
 
     private function getParameter(Property $property): ParameterGenerator
     {
-        $param = (new ParameterGenerator($property->getName()));
+        $param = (new ParameterGenerator($property->parameterName()));
         if ($this->options->useTypeHints()) {
             $param->setType($property->getPhpType());
         }

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/GetterAssembler.php
@@ -6,7 +6,6 @@ use Laminas\Code\Generator\DocBlockGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
 use Soap\Engine\Metadata\Model\TypeMeta;
@@ -58,7 +57,7 @@ class GetterAssembler implements AssemblerInterface
 
         try {
             $prefix = $this->getPrefix($property);
-            $methodName = Normalizer::generatePropertyMethod($prefix, $property->getName());
+            $methodName = $property->methodName($prefix);
             $class->removeMethod($methodName);
 
             $methodGenerator = new MethodGenerator($methodName);

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/ImmutableSetterAssembler.php
@@ -6,7 +6,6 @@ use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\ParameterGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
 
@@ -55,16 +54,16 @@ class ImmutableSetterAssembler implements AssemblerInterface
         $class = $context->getClass();
         $property = $context->getProperty();
         try {
-            $methodName = Normalizer::generatePropertyMethod('with', $property->getName());
+            $methodName = $property->methodName('with');
             $class->removeMethod($methodName);
             $lines = [
                 sprintf('$new = clone $this;'),
-                sprintf('$new->%1$s = $%1$s;', $property->getName()),
+                sprintf('$new->%s = $%s;', $property->getName(), $property->parameterName()),
                 '',
                 sprintf('return $new;'),
             ];
 
-            $param = (new ParameterGenerator($property->getName()));
+            $param = (new ParameterGenerator($property->parameterName()));
             if ($this->options->useTypeHints()) {
                 $param->setType($property->getPhpType());
             }
@@ -82,7 +81,11 @@ class ImmutableSetterAssembler implements AssemblerInterface
                         ->setTags([
                             [
                                 'name' => 'param',
-                                'description' => sprintf('%s $%s', $property->getDocBlockType(), $property->getName()),
+                                'description' => sprintf(
+                                    '%s $%s',
+                                    $property->getDocBlockType(),
+                                    $property->parameterName()
+                                ),
                             ],
                             [
                                 'name' => 'return',

--- a/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Assembler/SetterAssembler.php
@@ -6,7 +6,6 @@ use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\ParameterGenerator;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Exception\AssemblerException;
 use Laminas\Code\Generator\MethodGenerator;
 
@@ -50,10 +49,10 @@ class SetterAssembler implements AssemblerInterface
         $class = $context->getClass();
         $property = $context->getProperty();
         try {
-            $methodName = Normalizer::generatePropertyMethod('set', $property->getName());
+            $methodName = $property->methodName('set');
             $class->removeMethod($methodName);
 
-            $param = (new ParameterGenerator($property->getName()));
+            $param = (new ParameterGenerator($property->parameterName()));
             if ($this->options->useTypeHints()) {
                 $param->setType($property->getPhpType());
             }
@@ -62,7 +61,7 @@ class SetterAssembler implements AssemblerInterface
             $methodGenerator->setReturnType('void');
             $methodGenerator->setParameter($param);
             $methodGenerator->setVisibility(MethodGenerator::VISIBILITY_PUBLIC);
-            $methodGenerator->setBody(sprintf('$this->%1$s = $%1$s;', $property->getName()));
+            $methodGenerator->setBody(sprintf('$this->%s = $%s;', $property->getName(), $property->parameterName()));
             if ($this->options->useDocBlocks()) {
                 $methodGenerator->setDocBlock(
                     (new DocBlockGenerator())
@@ -70,7 +69,11 @@ class SetterAssembler implements AssemblerInterface
                         ->setTags([
                             [
                                 'name' => 'param',
-                                'description' => sprintf('%s $%s', $property->getDocBlockType(), $property->getName()),
+                                'description' => sprintf(
+                                    '%s $%s',
+                                    $property->getDocBlockType(),
+                                    $property->parameterName()
+                                ),
                             ]
                         ])
                 );

--- a/src/Phpro/SoapClient/CodeGenerator/ClassMapGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClassMapGenerator.php
@@ -28,7 +28,9 @@ class ClassMapGenerator implements GeneratorInterface
      */
     public function generate(FileGenerator $file, $typeMap): string
     {
-        $this->ruleSet->applyRules(new ClassMapContext($file, $typeMap, $this->classMap));
+        $this->ruleSet->applyRules(
+            new ClassMapContext($file, $typeMap, $this->classMap, $typeMap->getCodeGeneratorContext())
+        );
         $this->ruleSet->applyRules(new FileContext($file));
 
         return $file->generate();

--- a/src/Phpro/SoapClient/CodeGenerator/ClientGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ClientGenerator.php
@@ -54,7 +54,7 @@ class ClientGenerator implements GeneratorInterface
 
         $methods = $client->getMethodMap();
         foreach ($methods->getMethods() as $method) {
-            $this->ruleSet->applyRules(new ClientMethodContext($class, $method));
+            $this->ruleSet->applyRules(new ClientMethodContext($class, $method, $method->getCodeGeneratorContext()));
         }
 
         $this->ruleSet->applyRules(new FileContext($file));

--- a/src/Phpro/SoapClient/CodeGenerator/CodingStandards/CodingStandardsStrategyInterface.php
+++ b/src/Phpro/SoapClient/CodeGenerator/CodingStandards/CodingStandardsStrategyInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\CodingStandards;
+
+interface CodingStandardsStrategyInterface
+{
+    /**
+     * Convert SOAP type name to PHP class/enum name (e.g. "my-type" -> "MyType")
+     *
+     * @param non-empty-string $name
+     * @return non-empty-string
+     */
+    public function normalizeTypeName(string $name): string;
+
+    /**
+     * Convert SOAP operation name to PHP method name (e.g. "GetUsers" -> "getUsers")
+     *
+     * @param non-empty-string $method
+     * @return non-empty-string
+     */
+    public function normalizeOperationName(string $method): string;
+
+    /**
+     * Normalize XML namespace segment for PHP namespace (e.g. "my-prefix" -> "MyPrefix")
+     */
+    public function normalizeNamespaceSegment(string $segment): ?string;
+
+    /**
+     * Normalize enum value to PHP enum case name (e.g. "some-value" -> "SomeValue")
+     *
+     * @return non-empty-string
+     */
+    public function normalizeEnumCaseName(string $value): string;
+
+    /**
+     * Generate accessor method name from prefix + property name (e.g. "get" + "firstName" -> "getFirstName")
+     *
+     * @param non-empty-string $prefix
+     * @param non-empty-string $property
+     * @return non-empty-string
+     */
+    public function generatePropertyAccessorMethodName(string $prefix, string $property): string;
+
+    /**
+     * Normalize a parameter name (for constructors, setters, etc.)
+     * Input is the fixed property name. Output is the parameter name for PHP code.
+     * Enables named arguments: new Foo(fooBar: 'x') while property stays $foo_bar.
+     *
+     * @param non-empty-string $propertyName
+     * @return non-empty-string
+     */
+    public function normalizeParameterName(string $propertyName): string;
+}

--- a/src/Phpro/SoapClient/CodeGenerator/CodingStandards/DefaultCodingStandardsStrategy.php
+++ b/src/Phpro/SoapClient/CodeGenerator/CodingStandards/DefaultCodingStandardsStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\CodingStandards;
+
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+
+final readonly class DefaultCodingStandardsStrategy implements CodingStandardsStrategyInterface
+{
+    public function normalizeTypeName(string $name): string
+    {
+        return Normalizer::normalizeClassname($name);
+    }
+
+    public function normalizeOperationName(string $method): string
+    {
+        return Normalizer::normalizeMethodName($method);
+    }
+
+    public function normalizeNamespaceSegment(string $segment): ?string
+    {
+        return Normalizer::normalizeNamespaceSegment($segment);
+    }
+
+    public function normalizeEnumCaseName(string $value): string
+    {
+        return Normalizer::normalizeEnumCaseName($value);
+    }
+
+    public function generatePropertyAccessorMethodName(string $prefix, string $property): string
+    {
+        return Normalizer::generatePropertyMethod($prefix, $property);
+    }
+
+    public function normalizeParameterName(string $propertyName): string
+    {
+        return $propertyName;
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Config/Config.php
@@ -4,6 +4,9 @@ namespace Phpro\SoapClient\CodeGenerator\Config;
 
 use Closure;
 use Phpro\SoapClient\CodeGenerator\Assembler;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleInterface;
 use Phpro\SoapClient\CodeGenerator\Rules\RuleSet;
@@ -34,7 +37,7 @@ final class Config
     protected ?Engine $engine = null;
 
     /**
-     * @var TypesManipulatorInterface|Closure(?TypeNamespaceMap): TypesManipulatorInterface
+     * @var TypesManipulatorInterface|Closure(CodeGeneratorContext): TypesManipulatorInterface
      */
     protected TypesManipulatorInterface|Closure $duplicateTypeIntersectStrategy;
 
@@ -46,9 +49,11 @@ final class Config
 
     protected ?ClassMapConfig $classMap = null;
     protected EnumerationGenerationStrategy $enumerationGenerationStrategy;
+    protected CodingStandardsStrategyInterface $codingStandards;
 
     public function __construct()
     {
+        $this->codingStandards = new DefaultCodingStandardsStrategy();
         $this->typeReplacementStrategy = TypeReplacers::defaults();
 
         // Working with duplicate types is hard (see FAQ).
@@ -185,7 +190,7 @@ final class Config
      *
      * @param (
      *  TypesManipulatorInterface|
-     *  Closure(?TypeNamespaceMap): TypesManipulatorInterface
+     *  Closure(CodeGeneratorContext): TypesManipulatorInterface
      * ) $duplicateTypeIntersectStrategy
      */
     public function setDuplicateTypeIntersectStrategy(
@@ -231,10 +236,32 @@ final class Config
         return $this->enumerationGenerationStrategy;
     }
 
+    public function setCodingStandards(CodingStandardsStrategyInterface $codingStandards): self
+    {
+        $this->codingStandards = $codingStandards;
+
+        return $this;
+    }
+
+    public function getCodingStandards(): CodingStandardsStrategyInterface
+    {
+        return $this->codingStandards;
+    }
+
+    public function getCodeGeneratorContext(): CodeGeneratorContext
+    {
+        return new CodeGeneratorContext(
+            $this->getTypeNamespaceMap(),
+            $this->codingStandards,
+        );
+    }
+
     private function resolveDuplicateTypeStrategy(): TypesManipulatorInterface
     {
         if ($this->duplicateTypeIntersectStrategy instanceof Closure) {
-            return ($this->duplicateTypeIntersectStrategy)($this->typeNamespaceMap);
+            return ($this->duplicateTypeIntersectStrategy)(
+                $this->getCodeGeneratorContext()
+            );
         }
 
         return $this->duplicateTypeIntersectStrategy;

--- a/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/ConfigGenerator.php
@@ -20,7 +20,7 @@ use Phpro\SoapClient\Soap\EngineOptions;
 class ConfigGenerator implements GeneratorInterface
 {
     const BODY = <<<BODY
-return Config::create()
+return (\$config = Config::create())
 
 BODY;
 
@@ -75,7 +75,7 @@ EOENGINE;
         }
 
         $lines[] = sprintf(
-            '%s%s// ->withStrategy(new PrefixBasedTypeNamespaceStrategy())',
+            '%s%s// ->withStrategy(new PrefixBasedTypeNamespaceStrategy($config->getCodingStandards()))',
             $indentation,
             $indentation
         );

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClassMapContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClassMapContext.php
@@ -11,7 +11,8 @@ final readonly class ClassMapContext implements ContextInterface
     public function __construct(
         private FileGenerator $file,
         private TypeMap $typeMap,
-        private ClassMapConfig $classMap
+        private ClassMapConfig $classMap,
+        private CodeGeneratorContext $codeGeneratorContext,
     ) {
     }
 
@@ -47,5 +48,10 @@ final readonly class ClassMapContext implements ContextInterface
     public function getFqcn(): string
     {
         return $this->classMap->fqcn();
+    }
+
+    public function getCodeGeneratorContext(): CodeGeneratorContext
+    {
+        return $this->codeGeneratorContext;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/ClientMethodContext.php
@@ -9,7 +9,8 @@ final readonly class ClientMethodContext implements ContextInterface
 {
     public function __construct(
         private ClassGenerator $class,
-        private ClientMethod $method
+        private ClientMethod $method,
+        private CodeGeneratorContext $codeGeneratorContext,
     ) {
     }
 
@@ -21,5 +22,10 @@ final readonly class ClientMethodContext implements ContextInterface
     public function getMethod(): ClientMethod
     {
         return $this->method;
+    }
+
+    public function getCodeGeneratorContext(): CodeGeneratorContext
+    {
+        return $this->codeGeneratorContext;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Context/CodeGeneratorContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/CodeGeneratorContext.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phpro\SoapClient\CodeGenerator\Context;
+
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
+use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+
+final readonly class CodeGeneratorContext
+{
+    public function __construct(
+        public TypeNamespaceMap $typeNamespaceMap,
+        public CodingStandardsStrategyInterface $codingStandards,
+    ) {
+    }
+}

--- a/src/Phpro/SoapClient/CodeGenerator/Context/PropertyContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/PropertyContext.php
@@ -11,7 +11,8 @@ final readonly class PropertyContext implements ContextInterface
     public function __construct(
         private ClassGenerator $class,
         private Type $type,
-        private Property $property
+        private Property $property,
+        private CodeGeneratorContext $codeGeneratorContext,
     ) {
     }
 
@@ -28,5 +29,10 @@ final readonly class PropertyContext implements ContextInterface
     public function getProperty(): Property
     {
         return $this->property;
+    }
+
+    public function getCodeGeneratorContext(): CodeGeneratorContext
+    {
+        return $this->codeGeneratorContext;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Context/TypeContext.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Context/TypeContext.php
@@ -9,7 +9,8 @@ final readonly class TypeContext implements ContextInterface
 {
     public function __construct(
         private ClassGenerator $class,
-        private Type $type
+        private Type $type,
+        private CodeGeneratorContext $codeGeneratorContext,
     ) {
     }
 
@@ -21,5 +22,10 @@ final readonly class TypeContext implements ContextInterface
     public function getType(): Type
     {
         return $this->type;
+    }
+
+    public function getCodeGeneratorContext(): CodeGeneratorContext
+    {
+        return $this->codeGeneratorContext;
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/EnumerationGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/EnumerationGenerator.php
@@ -3,8 +3,8 @@
 namespace Phpro\SoapClient\CodeGenerator;
 
 use Laminas\Code\Generator\DocBlockGenerator;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Laminas\Code\Generator\EnumGenerator\EnumGenerator;
 use Laminas\Code\Generator\FileGenerator;
 use Soap\Engine\Metadata\Model\XsdType;
@@ -33,16 +33,17 @@ class EnumerationGenerator implements GeneratorInterface
     {
         $xsdType = $type->getXsdType();
         $xsdMeta = $xsdType->getMeta();
+        $codingStandards = $type->getCodeGeneratorContext()->codingStandards;
         $enumType = match ($xsdType->getBaseType()) {
             'int', 'integer' => 'int',
             default => 'string',
         };
 
         $body = EnumGenerator::withConfig([
-            'name' => Normalizer::normalizeClassname($type->getName()),
+            'name' => $type->getName(),
             'backedCases' => [
                 'type' => $enumType,
-                'cases' => $this->buildCases($xsdType, $enumType),
+                'cases' => $this->buildCases($xsdType, $enumType, $codingStandards),
             ]
         ])->generate();
 
@@ -61,8 +62,11 @@ class EnumerationGenerator implements GeneratorInterface
      * @param 'string'|'int' $enumType
      * @return array<string, int|string>
      */
-    private function buildCases(XsdType $xsdType, string $enumType): array
-    {
+    private function buildCases(
+        XsdType $xsdType,
+        string $enumType,
+        CodingStandardsStrategyInterface $codingStandards
+    ): array {
         $enums = $xsdType->getMeta()->enums()->unwrapOr([]);
 
         return pull(
@@ -71,7 +75,7 @@ class EnumerationGenerator implements GeneratorInterface
                 'int' => int()->coerce($value),
                 'string' => $value,
             },
-            static fn(string $value): string => Normalizer::normalizeEnumCaseName($value)
+            static fn(string $value): string => $codingStandards->normalizeEnumCaseName($value)
         );
     }
 }

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethod.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethod.php
@@ -2,7 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Soap\Engine\Metadata\Model\Method as MetadataMethod;
 use Soap\Engine\Metadata\Model\MethodMeta;
 use Soap\Engine\Metadata\Model\Parameter as MetadataParameter;
@@ -21,27 +21,32 @@ final readonly class ClientMethod
         private string $methodName,
         private array $parameters,
         private ReturnType $returnType,
-        private TypeNamespaceMap $typeNamespaceMap,
-        private MethodMeta $meta
+        private CodeGeneratorContext $codeGeneratorContext,
+        private MethodMeta $meta,
     ) {
     }
 
     public static function fromMetadata(
-        TypeNamespaceMap $typeNamespaceMap,
-        MetadataMethod $method
+        CodeGeneratorContext $codeGeneratorContext,
+        MetadataMethod $method,
     ): self {
         return new self(
             non_empty_string()->assert($method->getName()),
             array_map(
-                function (MetadataParameter $parameter) use ($typeNamespaceMap) {
-                    return Parameter::fromMetadata($typeNamespaceMap, $parameter);
+                function (MetadataParameter $parameter) use ($codeGeneratorContext) {
+                    return Parameter::fromMetadata($codeGeneratorContext, $parameter);
                 },
                 iterator_to_array($method->getParameters())
             ),
-            ReturnType::fromMetaData($typeNamespaceMap, $method->getReturnType()),
-            $typeNamespaceMap,
-            $method->getMeta()
+            ReturnType::fromMetaData($codeGeneratorContext, $method->getReturnType()),
+            $codeGeneratorContext,
+            $method->getMeta(),
         );
+    }
+
+    public function getCodeGeneratorContext(): CodeGeneratorContext
+    {
+        return $this->codeGeneratorContext;
     }
 
     /**
@@ -63,11 +68,6 @@ final readonly class ClientMethod
     public function getMethodName(): string
     {
         return $this->methodName;
-    }
-
-    public function getTypeNamespaceMap(): TypeNamespaceMap
-    {
-        return $this->typeNamespaceMap;
     }
 
     public function getReturnType(): ReturnType

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethodMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ClientMethodMap.php
@@ -2,7 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Soap\Engine\Metadata\Collection\MethodCollection;
 use Soap\Engine\Metadata\Model\Method;
 
@@ -19,11 +19,11 @@ final readonly class ClientMethodMap
     }
 
     public static function fromMetadata(
-        TypeNamespaceMap $typeNamespaces,
-        MethodCollection $collection
+        CodeGeneratorContext $codeGeneratorContext,
+        MethodCollection $collection,
     ): self {
-        return new self($collection->map(function (Method $method) use ($typeNamespaces) {
-            return ClientMethod::fromMetadata($typeNamespaces, $method);
+        return new self($collection->map(function (Method $method) use ($codeGeneratorContext) {
+            return ClientMethod::fromMetadata($codeGeneratorContext, $method);
         }));
     }
 

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Parameter.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Parameter.php
@@ -2,7 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\TypeNameCalculator;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Soap\Engine\Metadata\Model\Parameter as MetadataParameter;
@@ -25,22 +25,24 @@ final readonly class Parameter
     public function __construct(
         private string $name,
         private string $type,
-        private TypeNamespaceMap $namespaces,
-        private XsdType $xsdType
+        private CodeGeneratorContext $codeGeneratorContext,
+        private XsdType $xsdType,
     ) {
         $this->meta = $xsdType->getMeta();
     }
 
-    public static function fromMetadata(TypeNamespaceMap $typeNamespaceMap, MetadataParameter $parameter): Parameter
-    {
+    public static function fromMetadata(
+        CodeGeneratorContext $codeGeneratorContext,
+        MetadataParameter $parameter,
+    ): Parameter {
         $type = $parameter->getType();
         $typeName = (new TypeNameCalculator())($type);
 
         return new self(
             Normalizer::normalizeProperty(non_empty_string()->assert($parameter->getName())),
             Normalizer::normalizeDataType(non_empty_string()->assert($typeName)),
-            $typeNamespaceMap,
-            $type
+            $codeGeneratorContext,
+            $type,
         );
     }
 
@@ -61,7 +63,9 @@ final readonly class Parameter
             return $this->type;
         }
 
-        return '\\'.$this->getNamespace().'\\'.Normalizer::normalizeClassname($this->type);
+        $normalized = $this->codeGeneratorContext->codingStandards->normalizeTypeName($this->type);
+
+        return '\\'.$this->getNamespace().'\\'.$normalized;
     }
 
     /**
@@ -69,7 +73,7 @@ final readonly class Parameter
      */
     public function getNamespace(): string
     {
-        return $this->namespaces->detectDestinationForType($this->xsdType)->namespace;
+        return $this->codeGeneratorContext->typeNamespaceMap->detectDestinationForType($this->xsdType)->namespace;
     }
 
     public function getXsdType(): XsdType

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Property.php
@@ -2,7 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\TypeNameCalculator;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\MetaTypeEnhancer;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\TypeEnhancer;
@@ -27,20 +27,22 @@ final class Property
     public function __construct(
         private readonly string $name,
         private readonly string $type,
-        private readonly TypeNamespaceMap $namespaces,
+        private readonly CodeGeneratorContext $codeGeneratorContext,
         private readonly string $namespace,
-        private readonly XsdType $xsdType
+        private readonly XsdType $xsdType,
     ) {
         $this->meta = $xsdType->getMeta();
         $this->typeEnhancer = new MetaTypeEnhancer($this->meta);
     }
 
-    public static function fromMetaData(TypeNamespaceMap $namespaces, MetadataProperty $property): self
-    {
+    public static function fromMetaData(
+        CodeGeneratorContext $codeGeneratorContext,
+        MetadataProperty $property,
+    ): self {
         $type = $property->getType();
         $typeName = $type->getName();
         $calculatedTypeName = Normalizer::normalizeDataType((new TypeNameCalculator())($type));
-        $namespace = $namespaces->detectDestinationForType($type)->namespace;
+        $namespace = $codeGeneratorContext->typeNamespaceMap->detectDestinationForType($type)->namespace;
 
         // This makes it possible to set FQCN as type names in the metadata through TypeReplacers.
         if (Normalizer::isConsideredExistingThirdPartyClass($typeName)) {
@@ -53,10 +55,15 @@ final class Property
         return new self(
             Normalizer::normalizeProperty(non_empty_string()->assert($property->getName())),
             non_empty_string()->assert($calculatedTypeName),
-            $namespaces,
+            $codeGeneratorContext,
             Normalizer::normalizeNamespace($namespace),
-            $type
+            $type,
         );
+    }
+
+    public function getCodeGeneratorContext(): CodeGeneratorContext
+    {
+        return $this->codeGeneratorContext;
     }
 
     /**
@@ -83,7 +90,7 @@ final class Property
             return $this->xsdType->getBaseType();
         }
 
-        $normalized = Normalizer::normalizeClassname($this->type);
+        $normalized = $this->codeGeneratorContext->codingStandards->normalizeTypeName($this->type);
 
         return $this->namespace !== ''
             ? '\\'.$this->namespace.'\\'.$normalized
@@ -111,7 +118,8 @@ final class Property
      */
     public function getterName(): string
     {
-        return Normalizer::generatePropertyMethod('get', $this->getName());
+        return $this->codeGeneratorContext->codingStandards
+            ->generatePropertyAccessorMethodName('get', $this->getName());
     }
 
     /**
@@ -119,7 +127,26 @@ final class Property
      */
     public function setterName(): string
     {
-        return Normalizer::generatePropertyMethod('set', $this->getName());
+        return $this->codeGeneratorContext->codingStandards
+            ->generatePropertyAccessorMethodName('set', $this->getName());
+    }
+
+    /**
+     * @param non-empty-string $prefix
+     * @return non-empty-string
+     */
+    public function methodName(string $prefix): string
+    {
+        return $this->codeGeneratorContext->codingStandards
+            ->generatePropertyAccessorMethodName($prefix, $this->getName());
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function parameterName(): string
+    {
+        return $this->codeGeneratorContext->codingStandards->normalizeParameterName($this->getName());
     }
 
     public function getXsdType(): XsdType
@@ -130,11 +157,6 @@ final class Property
     public function getMeta(): TypeMeta
     {
         return $this->meta;
-    }
-
-    public function getNamespaces(): TypeNamespaceMap
-    {
-        return $this->namespaces;
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/ReturnType.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\TypeEnhancer\Calculator\TypeNameCalculator;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Soap\Engine\Metadata\Model\TypeMeta;
@@ -22,14 +22,16 @@ final readonly class ReturnType
      */
     public function __construct(
         private string $type,
-        private TypeNamespaceMap $namespaces,
-        private XsdType $xsdType
+        private CodeGeneratorContext $codeGeneratorContext,
+        private XsdType $xsdType,
     ) {
         $this->meta = $xsdType->getMeta();
     }
 
-    public static function fromMetaData(TypeNamespaceMap $namespaces, XsdType $returnType): self
-    {
+    public static function fromMetaData(
+        CodeGeneratorContext $codeGeneratorContext,
+        XsdType $returnType,
+    ): self {
         // Element types that are referencing complex types, should result in the complexType according to ext-soap:
         $returnType = $returnType->copy($returnType->getXmlTypeName() ?: $returnType->getName());
 
@@ -37,8 +39,8 @@ final readonly class ReturnType
 
         return new self(
             Normalizer::normalizeDataType(non_empty_string()->assert($typeName)),
-            $namespaces,
-            $returnType
+            $codeGeneratorContext,
+            $returnType,
         );
     }
     /**
@@ -49,7 +51,7 @@ final readonly class ReturnType
         if (Normalizer::isKnownType($this->type)) {
             return $this->type;
         }
-        
+
         if ($this->meta->isSimple()->unwrapOr(false)) {
             return $this->meta->extends()
                 ->filter(static fn (array $extends): bool => $extends['isSimple'])
@@ -57,7 +59,9 @@ final readonly class ReturnType
                 ->unwrapOr('mixed');
         }
 
-        return '\\'.$this->getNamespace().'\\'.Normalizer::normalizeClassname($this->type);
+        $normalized = $this->codeGeneratorContext->codingStandards->normalizeTypeName($this->type);
+
+        return '\\'.$this->getNamespace().'\\'.$normalized;
     }
 
     /**
@@ -65,7 +69,7 @@ final readonly class ReturnType
      */
     public function getNamespace(): string
     {
-        return $this->namespaces->detectDestinationForType($this->xsdType)->namespace;
+        return $this->codeGeneratorContext->typeNamespaceMap->detectDestinationForType($this->xsdType)->namespace;
     }
 
     public function getXsdType(): XsdType

--- a/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/Type.php
@@ -2,7 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Soap\Engine\Metadata\Model\Property as MetadataProperty;
 use Soap\Engine\Metadata\Model\Type as MetadataType;
@@ -23,28 +23,30 @@ final readonly class Type
      * @param array<array-key, Property> $properties
      */
     public function __construct(
-        private TypeNamespaceMap $namespaces,
+        private CodeGeneratorContext $codeGeneratorContext,
         private string $xsdName,
         private string $name,
         private array $properties,
-        private XsdType $xsdType
+        private XsdType $xsdType,
     ) {
         $this->meta = $xsdType->getMeta();
     }
 
-    public static function fromMetadata(TypeNamespaceMap $namespaces, MetadataType $type): self
-    {
+    public static function fromMetadata(
+        CodeGeneratorContext $codeGeneratorContext,
+        MetadataType $type,
+    ): self {
         $xsdName = non_empty_string()->assert($type->getName());
 
         return new self(
-            $namespaces,
+            $codeGeneratorContext,
             $xsdName,
-            Normalizer::normalizeClassname($xsdName),
+            $codeGeneratorContext->codingStandards->normalizeTypeName($xsdName),
             array_map(
-                function (MetadataProperty $property) use ($namespaces) {
+                function (MetadataProperty $property) use ($codeGeneratorContext) {
                     return Property::fromMetaData(
-                        $namespaces,
-                        $property
+                        $codeGeneratorContext,
+                        $property,
                     );
                 },
                 iterator_to_array($type->getProperties())
@@ -53,12 +55,17 @@ final readonly class Type
         );
     }
 
+    public function getCodeGeneratorContext(): CodeGeneratorContext
+    {
+        return $this->codeGeneratorContext;
+    }
+
     /**
      * @return non-empty-string
      */
     public function getNamespace(): string
     {
-        return $this->namespaces->detectDestinationForType($this->xsdType)->namespace;
+        return $this->codeGeneratorContext->typeNamespaceMap->detectDestinationForType($this->xsdType)->namespace;
     }
 
     /**
@@ -79,8 +86,8 @@ final readonly class Type
 
     public function getFileInfo(): SplFileInfo
     {
-        $destination = $this->namespaces->detectDestinationForType($this->xsdType);
-        $name = Normalizer::normalizeClassname($this->getName());
+        $destination = $this->codeGeneratorContext->typeNamespaceMap->detectDestinationForType($this->xsdType);
+        $name = $this->getName();
         $path = rtrim($destination->path, '/\\').'/'.$name.'.php';
 
         return new SplFileInfo($path);

--- a/src/Phpro/SoapClient/CodeGenerator/Model/TypeMap.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Model/TypeMap.php
@@ -2,7 +2,7 @@
 
 namespace Phpro\SoapClient\CodeGenerator\Model;
 
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Soap\Engine\Metadata\Collection\TypeCollection;
 use Soap\Engine\Metadata\Model\Type as MetadataType;
 
@@ -15,24 +15,26 @@ final readonly class TypeMap
      * @param array<array-key, Type> $types
      */
     public function __construct(
-        private TypeNamespaceMap $namespaces,
+        private CodeGeneratorContext $codeGeneratorContext,
         private array $types
     ) {
     }
 
-    public static function fromMetadata(TypeNamespaceMap $namespaces, TypeCollection $types): self
-    {
+    public static function fromMetadata(
+        CodeGeneratorContext $codeGeneratorContext,
+        TypeCollection $types,
+    ): self {
         return new self(
-            $namespaces,
-            $types->map(function (MetadataType $type) use ($namespaces) {
-                return Type::fromMetadata($namespaces, $type);
+            $codeGeneratorContext,
+            $types->map(function (MetadataType $type) use ($codeGeneratorContext) {
+                return Type::fromMetadata($codeGeneratorContext, $type);
             })
         );
     }
 
-    public function getNamespaces(): TypeNamespaceMap
+    public function getCodeGeneratorContext(): CodeGeneratorContext
     {
-        return $this->namespaces;
+        return $this->codeGeneratorContext;
     }
 
     /**

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/IsAbstractTypeRule.php
@@ -4,28 +4,25 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\CodeGenerator\Rules;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Soap\Engine\Metadata\Metadata;
 use Soap\Engine\Metadata\Model\Type;
 use function Psl\Type\non_empty_string;
 
 class IsAbstractTypeRule implements RuleInterface
 {
-    private Metadata $metadata;
-    private RuleInterface $subRule;
-
     /**
      * @var list<string>|null
      */
     private $abstractTypes = null;
 
-    public function __construct(Metadata $metadata, RuleInterface $subRule)
-    {
-        $this->metadata = $metadata;
-        $this->subRule = $subRule;
+    public function __construct(
+        private Metadata $metadata,
+        private RuleInterface $subRule,
+    ) {
     }
 
     public function appliesToContext(ContextInterface $context): bool
@@ -35,7 +32,8 @@ class IsAbstractTypeRule implements RuleInterface
         }
 
         $type = $context->getType();
-        if (!in_array($type->getName(), $this->listAbstractTypes(), true)) {
+        $codingStandards = $context->getCodeGeneratorContext()->codingStandards;
+        if (!in_array($type->getName(), $this->listAbstractTypes($codingStandards), true)) {
             return false;
         }
 
@@ -50,7 +48,7 @@ class IsAbstractTypeRule implements RuleInterface
     /**
      * @return list<string>
      */
-    private function listAbstractTypes(): array
+    private function listAbstractTypes(CodingStandardsStrategyInterface $codingStandards): array
     {
         if (null === $this->abstractTypes) {
             $this->abstractTypes = $this->metadata->getTypes()->reduce(
@@ -58,14 +56,14 @@ class IsAbstractTypeRule implements RuleInterface
                  * @param list<string> $abstractTypes
                  * @return list<string>
                  */
-                static function (array $abstractTypes, Type $type): array {
+                static function (array $abstractTypes, Type $type) use ($codingStandards): array {
                     if (!$type->getXsdType()->getMeta()->isAbstract()->unwrapOr(false)) {
                         return $abstractTypes;
                     }
 
                     return [
                         ...$abstractTypes,
-                        Normalizer::normalizeClassname(non_empty_string()->assert($type->getName())),
+                        $codingStandards->normalizeTypeName(non_empty_string()->assert($type->getName())),
                     ];
                 },
                 []

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/IsExtendingTypeRule.php
@@ -4,28 +4,25 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\CodeGenerator\Rules;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Soap\Engine\Metadata\Metadata;
 use Soap\Engine\Metadata\Model\Type;
 use function Psl\Type\non_empty_string;
 
 class IsExtendingTypeRule implements RuleInterface
 {
-    private Metadata $metadata;
-    private RuleInterface $subRule;
-
     /**
      * @var list<string>|null
      */
     private $extendingTypes = null;
 
-    public function __construct(Metadata $metadata, RuleInterface $subRule)
-    {
-        $this->metadata = $metadata;
-        $this->subRule = $subRule;
+    public function __construct(
+        private Metadata $metadata,
+        private RuleInterface $subRule,
+    ) {
     }
 
     public function appliesToContext(ContextInterface $context): bool
@@ -35,7 +32,8 @@ class IsExtendingTypeRule implements RuleInterface
         }
 
         $type = $context->getType();
-        if (!in_array($type->getName(), $this->listExtendingTypes(), true)) {
+        $codingStandards = $context->getCodeGeneratorContext()->codingStandards;
+        if (!in_array($type->getName(), $this->listExtendingTypes($codingStandards), true)) {
             return false;
         }
 
@@ -50,7 +48,7 @@ class IsExtendingTypeRule implements RuleInterface
     /**
      * @return list<string>
      */
-    private function listExtendingTypes(): array
+    private function listExtendingTypes(CodingStandardsStrategyInterface $codingStandards): array
     {
         if (null === $this->extendingTypes) {
             $this->extendingTypes = $this->metadata->getTypes()->reduce(
@@ -58,14 +56,14 @@ class IsExtendingTypeRule implements RuleInterface
                  * @param list<string> $extendingTypes
                  * @return list<string>
                  */
-                static function (array $extendingTypes, Type $type): array {
+                static function (array $extendingTypes, Type $type) use ($codingStandards): array {
                     if (!$type->getXsdType()->getMeta()->extends()->unwrapOr(false)) {
                         return $extendingTypes;
                     }
 
                     return [
                         ...$extendingTypes,
-                        Normalizer::normalizeClassname(non_empty_string()->assert($type->getName()))
+                        $codingStandards->normalizeTypeName(non_empty_string()->assert($type->getName()))
                     ];
                 },
                 []

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/IsRequestRule.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\CodeGenerator\Rules;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Soap\Metadata\Detector\RequestTypesDetector;
 use Soap\Engine\Metadata\Metadata;
 use function Psl\Type\non_empty_string;
@@ -15,24 +15,14 @@ use function Psl\Type\non_empty_string;
 class IsRequestRule implements RuleInterface
 {
     /**
-     * @var Metadata
-     */
-    private $metadata;
-
-    /**
-     * @var RuleInterface
-     */
-    private $subRule;
-
-    /**
      * @var array|null
      */
     private $requestTypes;
 
-    public function __construct(Metadata $metadata, RuleInterface $subRule)
-    {
-        $this->metadata = $metadata;
-        $this->subRule = $subRule;
+    public function __construct(
+        private Metadata $metadata,
+        private RuleInterface $subRule,
+    ) {
     }
 
     public function appliesToContext(ContextInterface $context): bool
@@ -42,7 +32,8 @@ class IsRequestRule implements RuleInterface
         }
 
         $type = $context->getType();
-        if (!in_array($type->getName(), $this->listRequestTypes(), true)) {
+        $codingStandards = $context->getCodeGeneratorContext()->codingStandards;
+        if (!in_array($type->getName(), $this->listRequestTypes($codingStandards), true)) {
             return false;
         }
 
@@ -54,13 +45,11 @@ class IsRequestRule implements RuleInterface
         $this->subRule->apply($context);
     }
 
-    private function listRequestTypes(): array
+    private function listRequestTypes(CodingStandardsStrategyInterface $codingStandards): array
     {
         if (null === $this->requestTypes) {
             $this->requestTypes = array_map(
-                static function (string $type) {
-                    return Normalizer::normalizeClassname(non_empty_string()->assert($type));
-                },
+                fn (string $type) => $codingStandards->normalizeTypeName(non_empty_string()->assert($type)),
                 (new RequestTypesDetector())($this->metadata->getMethods())
             );
         }

--- a/src/Phpro/SoapClient/CodeGenerator/Rules/IsResultRule.php
+++ b/src/Phpro/SoapClient/CodeGenerator/Rules/IsResultRule.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\CodeGenerator\Rules;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
 use Phpro\SoapClient\CodeGenerator\Context\ContextInterface;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Context\TypeContext;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 use Phpro\SoapClient\Soap\Metadata\Detector\ResponseTypesDetector;
 use Soap\Engine\Metadata\Metadata;
 use function Psl\Type\non_empty_string;
@@ -15,24 +15,14 @@ use function Psl\Type\non_empty_string;
 class IsResultRule implements RuleInterface
 {
     /**
-     * @var Metadata
-     */
-    private $metadata;
-
-    /**
-     * @var RuleInterface
-     */
-    private $subRule;
-
-    /**
      * @var array|null
      */
     private $responseTypes;
 
-    public function __construct(Metadata $metadata, RuleInterface $subRule)
-    {
-        $this->metadata = $metadata;
-        $this->subRule = $subRule;
+    public function __construct(
+        private Metadata $metadata,
+        private RuleInterface $subRule,
+    ) {
     }
 
     public function appliesToContext(ContextInterface $context): bool
@@ -42,7 +32,8 @@ class IsResultRule implements RuleInterface
         }
 
         $type = $context->getType();
-        if (!in_array($type->getName(), $this->listResponseTypes(), true)) {
+        $codingStandards = $context->getCodeGeneratorContext()->codingStandards;
+        if (!in_array($type->getName(), $this->listResponseTypes($codingStandards), true)) {
             return false;
         }
 
@@ -54,13 +45,11 @@ class IsResultRule implements RuleInterface
         $this->subRule->apply($context);
     }
 
-    private function listResponseTypes(): array
+    private function listResponseTypes(CodingStandardsStrategyInterface $codingStandards): array
     {
         if (null === $this->responseTypes) {
             $this->responseTypes = array_map(
-                static function (string $type) {
-                    return Normalizer::normalizeClassname(non_empty_string()->assert($type));
-                },
+                fn (string $type) => $codingStandards->normalizeTypeName(non_empty_string()->assert($type)),
                 (new ResponseTypesDetector())($this->metadata->getMethods())
             );
         }

--- a/src/Phpro/SoapClient/CodeGenerator/TypeGenerator.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeGenerator.php
@@ -47,11 +47,12 @@ class TypeGenerator implements GeneratorInterface
         $class->setNamespaceName($type->getNamespace());
         $class->setName($type->getName());
 
-        $this->ruleSet->applyRules(new TypeContext($class, $type));
+        $context = $type->getCodeGeneratorContext();
+        $this->ruleSet->applyRules(new TypeContext($class, $type, $context));
         $this->ruleSet->applyRules(new FileContext($file));
 
         foreach ($type->getProperties() as $property) {
-            $this->ruleSet->applyRules(new PropertyContext($class, $type, $property));
+            $this->ruleSet->applyRules(new PropertyContext($class, $type, $property, $context));
         }
 
         $file->setClass($class);

--- a/src/Phpro/SoapClient/CodeGenerator/TypeNamespaceMap/Strategy/PrefixBasedTypeNamespaceStrategy.php
+++ b/src/Phpro/SoapClient/CodeGenerator/TypeNamespaceMap/Strategy/PrefixBasedTypeNamespaceStrategy.php
@@ -2,14 +2,20 @@
 
 namespace Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
 
 final readonly class PrefixBasedTypeNamespaceStrategy implements TypeNamespaceMapStrategyInterface
 {
+    public function __construct(
+        private CodingStandardsStrategyInterface $codingStandards = new DefaultCodingStandardsStrategy(),
+    ) {
+    }
+
     public function __invoke(string $xmlns, string $xmlNamespaceName, Destination $fallback): Destination
     {
-        $segment = Normalizer::normalizeNamespaceSegment($xmlNamespaceName);
+        $segment = $this->codingStandards->normalizeNamespaceSegment($xmlNamespaceName);
         if ($segment === null) {
             return $fallback;
         }

--- a/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClassmapCommand.php
@@ -50,8 +50,9 @@ class GenerateClassmapCommand extends Command
         // All types should be listed with namespace and name, even if that means there will be a duplicate entry.
         $config->setDuplicateTypeIntersectStrategy(new TypesManipulatorChain());
 
+        $generatorContext = $config->getCodeGeneratorContext();
         $typeMap = TypeMap::fromMetadata(
-            $config->getTypeNamespaceMap(),
+            $generatorContext,
             $config->getManipulatedMetadata()->getTypes(),
         );
 

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientCommand.php
@@ -46,8 +46,9 @@ class GenerateClientCommand extends Command
 
         $clientConfig = $config->getClient();
         $destination = $clientConfig->path();
+        $generatorContext = $config->getCodeGeneratorContext();
         $methodMap = ClientMethodMap::fromMetadata(
-            $config->getTypeNamespaceMap(),
+            $generatorContext,
             $config->getManipulatedMetadata()->getMethods(),
         );
 

--- a/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateClientFactoryCommand.php
@@ -45,10 +45,12 @@ class GenerateClientFactoryCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $config = $this->getConfigHelper()->load($input);
+        $generatorContext = $config->getCodeGeneratorContext();
         $classmapContext = new ClassMapContext(
             new FileGenerator(),
-            new TypeMap($config->getTypeNamespaceMap(), []),
+            new TypeMap($generatorContext, []),
             $config->getClassMap(),
+            $generatorContext,
         );
         $clientContext = new ClientContext(
             new ClassGenerator(),

--- a/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateTypesCommand.php
@@ -51,8 +51,9 @@ class GenerateTypesCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         $config = $this->getConfigHelper()->load($input);
+        $generatorContext = $config->getCodeGeneratorContext();
         $typeMap = TypeMap::fromMetadata(
-            $config->getTypeNamespaceMap(),
+            $generatorContext,
             $config->getManipulatedMetadata()->getTypes(),
         );
 

--- a/src/Phpro/SoapClient/Soap/Metadata/Detector/DuplicateTypeNamesDetector.php
+++ b/src/Phpro/SoapClient/Soap/Metadata/Detector/DuplicateTypeNamesDetector.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap\Metadata\Detector;
 
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Soap\Engine\Metadata\Collection\TypeCollection;
 use Soap\Engine\Metadata\Model\Type;
 use function Psl\Type\non_empty_string;
 
 final class DuplicateTypeNamesDetector
 {
+    public function __construct(
+        private CodingStandardsStrategyInterface $codingStandards = new DefaultCodingStandardsStrategy(),
+    ) {
+    }
+
     /**
      * @param TypeCollection $types
      *
@@ -18,11 +24,13 @@ final class DuplicateTypeNamesDetector
      */
     public function __invoke(TypeCollection $types): array
     {
+        $codingStandards = $this->codingStandards;
+
         return array_keys(
             array_filter(
                 array_count_values($types->map(
-                    static function (Type $type): string {
-                        return Normalizer::normalizeClassname(non_empty_string()->assert($type->getName()));
+                    static function (Type $type) use ($codingStandards): string {
+                        return $codingStandards->normalizeTypeName(non_empty_string()->assert($type->getName()));
                     }
                 )),
                 static function (int $count): bool {

--- a/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/DuplicateTypesKey.php
+++ b/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/DuplicateTypesKey.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes;
 
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
-use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Soap\Engine\Metadata\Model\Type;
 use function Psl\Type\non_empty_string;
 
@@ -13,18 +12,14 @@ final class DuplicateTypesKey
 {
     /**
      * Generates a unique key for grouping/detecting duplicate types.
-     * When namespace map is provided, types in different target PHP namespaces
+     * When context is provided, types in different target PHP namespaces
      * are NOT considered duplicates (they produce different keys).
      */
-    public static function forType(Type $type, ?TypeNamespaceMap $namespaceMap): string
+    public static function forType(Type $type, CodeGeneratorContext $context): string
     {
-        $normalizedName = Normalizer::normalizeClassname(non_empty_string()->assert($type->getName()));
-
-        if ($namespaceMap === null) {
-            return $normalizedName;
-        }
-
-        $destination = $namespaceMap->detectDestinationForType($type->getXsdType());
+        $codingStandards = $context->codingStandards;
+        $normalizedName = $codingStandards->normalizeTypeName(non_empty_string()->assert($type->getName()));
+        $destination = $context->typeNamespaceMap->detectDestinationForType($type->getXsdType());
 
         return $destination->namespace . '\\' . $normalizedName;
     }

--- a/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategy.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes;
 
 use Closure;
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorInterface;
 use Soap\Engine\Metadata\Collection\PropertyCollection;
 use Soap\Engine\Metadata\Collection\TypeCollection;
@@ -23,25 +23,25 @@ use function Psl\Vec\values;
 final class IntersectDuplicateTypesStrategy implements TypesManipulatorInterface
 {
     public function __construct(
-        private ?TypeNamespaceMap $namespaceMap = null
+        private CodeGeneratorContext $context,
     ) {
     }
 
     /**
-     * Factory that returns a closure - Config will call it with the namespace map.
+     * Factory that returns a closure - Config will call it with the context.
      *
-     * @return Closure(?TypeNamespaceMap): self
+     * @return Closure(CodeGeneratorContext): self
      */
     public static function create(): Closure
     {
-        return static fn (?TypeNamespaceMap $map) => new self($map);
+        return static fn (CodeGeneratorContext $context) => new self($context);
     }
 
     public function __invoke(TypeCollection $allTypes): TypeCollection
     {
         return new TypeCollection(...array_values($allTypes->reduce(
             function (array $result, Type $type) use ($allTypes): array {
-                $key = DuplicateTypesKey::forType($type, $this->namespaceMap);
+                $key = DuplicateTypesKey::forType($type, $this->context);
                 if (array_key_exists($key, $result)) {
                     return $result;
                 }
@@ -71,7 +71,7 @@ final class IntersectDuplicateTypesStrategy implements TypesManipulatorInterface
 
     private function fetchAllTypesWithSameKey(TypeCollection $types, string $key): TypeCollection
     {
-        return $types->filter(fn (Type $type): bool => DuplicateTypesKey::forType($type, $this->namespaceMap) === $key);
+        return $types->filter(fn (Type $type): bool => DuplicateTypesKey::forType($type, $this->context) === $key);
     }
 
     private function uniqueProperties(PropertyCollection ...$types): PropertyCollection

--- a/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
+++ b/src/Phpro/SoapClient/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategy.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes;
 
 use Closure;
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorInterface;
 use Soap\Engine\Metadata\Collection\TypeCollection;
 use Soap\Engine\Metadata\Model\Type;
@@ -13,18 +13,18 @@ use Soap\Engine\Metadata\Model\Type;
 final class RemoveDuplicateTypesStrategy implements TypesManipulatorInterface
 {
     public function __construct(
-        private ?TypeNamespaceMap $namespaceMap = null
+        private CodeGeneratorContext $context
     ) {
     }
 
     /**
-     * Factory that returns a closure - Config will call it with the namespace map.
+     * Factory that returns a closure - Config will call it with the context.
      *
-     * @return Closure(?TypeNamespaceMap): self
+     * @return Closure(CodeGeneratorContext): self
      */
     public static function create(): Closure
     {
-        return static fn (?TypeNamespaceMap $map) => new self($map);
+        return static fn (CodeGeneratorContext $context) => new self($context);
     }
 
     public function __invoke(TypeCollection $types): TypeCollection
@@ -33,7 +33,7 @@ final class RemoveDuplicateTypesStrategy implements TypesManipulatorInterface
 
         return $types->filter(
             fn (Type $type): bool => !in_array(
-                DuplicateTypesKey::forType($type, $this->namespaceMap),
+                DuplicateTypesKey::forType($type, $this->context),
                 $duplicateKeys,
                 true
             )
@@ -47,7 +47,7 @@ final class RemoveDuplicateTypesStrategy implements TypesManipulatorInterface
     {
         $keyCounts = [];
         foreach ($types as $type) {
-            $key = DuplicateTypesKey::forType($type, $this->namespaceMap);
+            $key = DuplicateTypesKey::forType($type, $this->context);
             $keyCounts[$key] = ($keyCounts[$key] ?? 0) + 1;
         }
 

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/AbstractClassAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/AbstractClassAssemblerTest.php
@@ -65,12 +65,12 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($context, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClassMapAssemblerTest.php
@@ -84,15 +84,15 @@ CODE;
     private function createContext()
     {
         $file = new FileGenerator();
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $typeMap = new TypeMap($namespaces, [
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $typeMap = new TypeMap($context, [
             new Type(
-                $namespaces,
+                $context,
                 'MyType',
                 'MyType',
                 [
                     Property::fromMetaData(
-                        $namespaces,
+                        $context,
                         new MetaProperty('myProperty', XsdType::guess('string'))
                     ),
                 ],
@@ -100,7 +100,7 @@ CODE;
                     ->withXmlNamespace('http://my-namespace.com')
             ),
             new Type(
-                $namespaces,
+                $context,
                 'MyEnum',
                 'MyEnum',
                 [],
@@ -114,6 +114,6 @@ CODE;
             ),
         ]);
 
-        return new ClassMapContext($file, $typeMap, $this->createClassMapConfig('MyClassMap', 'ClassMapNamespace'));
+        return new ClassMapContext($file, $typeMap, $this->createClassMapConfig('MyClassMap', 'ClassMapNamespace'), $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ClientMethodAssemblerTest.php
@@ -49,18 +49,18 @@ class ClientMethodAssemblerTest extends TestCase
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
-        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
+        $context = $this->createCodeGeneratorContext($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [
-                new Parameter('param', 'ParamType', $namespaces, XsdType::create('ParamType')),
+                new Parameter('param', 'ParamType', $context, XsdType::create('ParamType')),
             ],
-            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnType')),
-            $namespaces,
+            ReturnType::fromMetaData($context, XsdType::create('ReturnType')),
+            $context,
             (new MethodMeta())->withDocs('This is an awesome function.')
         );
 
-        return new ClientMethodContext($class, $method);
+        return new ClientMethodContext($class, $method, $context);
     }
 
     /**
@@ -72,19 +72,19 @@ class ClientMethodAssemblerTest extends TestCase
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
-        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
+        $context = $this->createCodeGeneratorContext($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [
-                new Parameter('param', 'ParamType', $namespaces, XsdType::create('ParamType')),
-                new Parameter('param2', 'OtherParamType', $namespaces, XsdType::create('OtherParamType')),
+                new Parameter('param', 'ParamType', $context, XsdType::create('ParamType')),
+                new Parameter('param2', 'OtherParamType', $context, XsdType::create('OtherParamType')),
             ],
-            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnType')),
-            $namespaces,
+            ReturnType::fromMetaData($context, XsdType::create('ReturnType')),
+            $context,
             (new MethodMeta())->withDocs('This is an awesome function.')
         );
 
-        return new ClientMethodContext($class, $method);
+        return new ClientMethodContext($class, $method, $context);
     }
 
     /**
@@ -96,16 +96,16 @@ class ClientMethodAssemblerTest extends TestCase
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
-        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
+        $context = $this->createCodeGeneratorContext($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [],
-            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnType')),
-            $namespaces,
+            ReturnType::fromMetaData($context, XsdType::create('ReturnType')),
+            $context,
             new MethodMeta()
         );
 
-        return new ClientMethodContext($class, $method);
+        return new ClientMethodContext($class, $method, $context);
     }
 
     #[Test]
@@ -238,18 +238,18 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
-        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
+        $context = $this->createCodeGeneratorContext($typeNamespace);
         $method = new ClientMethod(
             'Function_name',
             [
-                new Parameter('param', 'param_type', $namespaces, XsdType::create('param_type')),
+                new Parameter('param', 'param_type', $context, XsdType::create('param_type')),
             ],
-            ReturnType::fromMetaData($namespaces, XsdType::create('return_type')),
-            $namespaces,
+            ReturnType::fromMetaData($context, XsdType::create('return_type')),
+            $context,
             new MethodMeta()
         );
 
-        $context = new ClientMethodContext($class, $method);
+        $context = new ClientMethodContext($class, $method, $context);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -305,18 +305,18 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
-        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
+        $context = $this->createCodeGeneratorContext($typeNamespace);
         $method = new ClientMethod(
             'Function_name',
             [
-                new Parameter('param', 'string', $namespaces, XsdType::create('string')->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true))),
+                new Parameter('param', 'string', $context, XsdType::create('string')->withMeta(static fn (TypeMeta $meta) => $meta->withIsSimple(true))),
             ],
-            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnType')),
-            $namespaces,
+            ReturnType::fromMetaData($context, XsdType::create('ReturnType')),
+            $context,
             new MethodMeta()
         );
 
-        $context = new ClientMethodContext($class, $method);
+        $context = new ClientMethodContext($class, $method, $context);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -362,18 +362,18 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
-        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
+        $context = $this->createCodeGeneratorContext($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [],
-            ReturnType::fromMetaData($namespaces, XsdType::create('string')->withMeta(
+            ReturnType::fromMetaData($context, XsdType::create('string')->withMeta(
                 fn (TypeMeta $meta): TypeMeta => $meta->withIsSimple(true)
             )),
-            $namespaces,
+            $context,
             new MethodMeta()
         );
 
-        $context = new ClientMethodContext($class, $method);
+        $context = new ClientMethodContext($class, $method, $context);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -414,21 +414,21 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
-        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
+        $context = $this->createCodeGeneratorContext($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [
-                new Parameter('param1', 'string', $namespaces, XsdType::create('string')),
-                new Parameter('param2', 'string', $namespaces, XsdType::create('string')),
+                new Parameter('param1', 'string', $context, XsdType::create('string')),
+                new Parameter('param2', 'string', $context, XsdType::create('string')),
             ],
-            ReturnType::fromMetaData($namespaces, XsdType::create('string')->withMeta(
+            ReturnType::fromMetaData($context, XsdType::create('string')->withMeta(
                 fn (TypeMeta $meta): TypeMeta => $meta->withIsSimple(true)
             )),
-            $namespaces,
+            $context,
             new MethodMeta()
         );
 
-        $context = new ClientMethodContext($class, $method);
+        $context = new ClientMethodContext($class, $method, $context);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -475,16 +475,16 @@ CODE;
         $class = new ClassGenerator();
         $class->setName('Vendor\\MyNamespace\\MyClient');
         $typeNamespace = 'Vendor\\MyTypeNamespace';
-        $namespaces = $this->createTypeNamespaceMap($typeNamespace);
+        $context = $this->createCodeGeneratorContext($typeNamespace);
         $method = new ClientMethod(
             'functionName',
             [],
-            ReturnType::fromMetaData($namespaces, XsdType::create('ReturnTypeElement')->withXmlTypeName('ReturnType')),
-            $namespaces,
+            ReturnType::fromMetaData($context, XsdType::create('ReturnTypeElement')->withXmlTypeName('ReturnType')),
+            $context,
             new MethodMeta()
         );
 
-        $context = new ClientMethodContext($class, $method);
+        $context = new ClientMethodContext($class, $method, $context);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ConstructorAssemblerTest.php
@@ -76,14 +76,14 @@ CODE;
     {
         $assembler = new ConstructorAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop3', XsdType::guess('SomeClass'))),
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop2', XsdType::guess('int'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop3', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
-        $context =  new TypeContext($class, $type);
+        $context =  new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -146,17 +146,17 @@ CODE;
     {
         $assembler = new ConstructorAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
             Property::fromMetaData(
-                $namespaces,
+                $codeGenContext,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
             ),
         ], XsdType::create('MyType'));
 
-        $context =  new TypeContext($class, $type);
+        $context =  new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -188,14 +188,14 @@ CODE;
             (new ConstructorAssemblerOptions())->withDefaultValues(DefaultValuesStrategy::None)
         );
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop3', XsdType::guess('SomeClass'))),
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop2', XsdType::guess('int'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop3', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
-        $context = new TypeContext($class, $type);
+        $context = new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -229,19 +229,19 @@ CODE;
     {
         $assembler = new ConstructorAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('name', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('contact', XsdType::guess('Contact')->withMeta(
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('name', XsdType::guess('string'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('contact', XsdType::guess('Contact')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withIsNullable(true)
             ))),
-            Property::fromMetaData($namespaces, new MetaProperty('address', XsdType::guess('Address'))),
-            Property::fromMetaData($namespaces, new MetaProperty('note', XsdType::guess('string')->withMeta(
+            Property::fromMetaData($codeGenContext, new MetaProperty('address', XsdType::guess('Address'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('note', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withIsNullable(true)
             ))),
         ], XsdType::create('MyType'));
 
-        $context = new TypeContext($class, $type);
+        $context = new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -277,15 +277,15 @@ CODE;
     {
         $assembler = new ConstructorAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('address', XsdType::guess('Address'))),
-            Property::fromMetaData($namespaces, new MetaProperty('contact', XsdType::guess('Contact')->withMeta(
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('address', XsdType::guess('Address'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('contact', XsdType::guess('Contact')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withIsNullable(true)
             ))),
         ], XsdType::create('MyType'));
 
-        $context = new TypeContext($class, $type);
+        $context = new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -319,13 +319,13 @@ CODE;
             (new ConstructorAssemblerOptions())->withTypeHints(false)->withDefaultValues(DefaultValuesStrategy::All)
         );
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('SomeClass'))),
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop2', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
-        $context = new TypeContext($class, $type);
+        $context = new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -359,13 +359,13 @@ CODE;
             (new ConstructorAssemblerOptions())->withOptionalValue()
         );
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('SomeClass'))),
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop2', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
-        $context = new TypeContext($class, $type);
+        $context = new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -399,13 +399,13 @@ CODE;
             (new ConstructorAssemblerOptions())->withOptionalValue()->withDefaultValues(DefaultValuesStrategy::None)
         );
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('SomeClass'))),
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop2', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
-        $context = new TypeContext($class, $type);
+        $context = new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -439,14 +439,14 @@ CODE;
             (new ConstructorAssemblerOptions())->withDefaultValues(DefaultValuesStrategy::All)
         );
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop3', XsdType::guess('SomeClass'))),
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop2', XsdType::guess('int'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop3', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
-        $context = new TypeContext($class, $type);
+        $context = new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -481,12 +481,12 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $codeGenContext);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendAssemblerTest.php
@@ -87,12 +87,12 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($codeGenContext, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $codeGenContext);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendingTypeAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ExtendingTypeAssemblerTest.php
@@ -84,10 +84,10 @@ CODE;
     {
         $assembler = new ExtendingTypeAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [], XsdType::create('MyType'));
 
-        $context = new TypeContext($class, $type);
+        $context = new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -108,14 +108,14 @@ CODE;
     {
         $assembler = new ExtendingTypeAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
             'type' => 'string',
             'namespace' => 'xsd',
             'isSimple' => true,
         ])));
 
-        $context = new TypeContext($class, $type);
+        $context = new TypeContext($class, $type, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -137,12 +137,12 @@ CODE;
     private function createContext(?string $importedNamespace = null)
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap($importedNamespace ?? 'MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
+        $codeGenContext = $this->createCodeGeneratorContext($importedNamespace ?? 'MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [], XsdType::create('MyType')->withMeta(static fn (TypeMeta $meta) => $meta->withExtends([
             'type' => 'MyBaseType',
             'namespace' => 'xxxx'
         ])));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $codeGenContext);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FinalClassAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FinalClassAssemblerTest.php
@@ -64,12 +64,12 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($context, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'), new TypeMeta());
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/FluentSetterAssemblerTest.php
@@ -186,17 +186,17 @@ CODE;
     {
         $assembler = new FluentSetterAssembler((new FluentSetterAssemblerOptions()));
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespaces,
+                $codeGenContext,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
             ),
         ], XsdType::create('MyType'));
 
-        $context =  new PropertyContext($class, $type, $property);
+        $context =  new PropertyContext($class, $type, $property, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -227,15 +227,15 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespaces,
+                $context,
                 new MetaProperty('prop1', XsdType::guess('string'))
             ),
         ], XsdType::create('MyType'));
 
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 
     /**
@@ -244,12 +244,12 @@ CODE;
     private function createContextWithAnUnknownType()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            $property = Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('foobar'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('foobar'))),
         ], XsdType::create('MyType'));
 
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 
     /**
@@ -257,17 +257,17 @@ CODE;
      */
     private function createContextWithLongType()
     {
-        $longNamespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
+        $longContext = $this->createCodeGeneratorContext('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
         $properties = [
             'prop1' => Property::fromMetaData(
-                $longNamespaces,
+                $longContext,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/GetterAssemblerTest.php
@@ -240,17 +240,17 @@ CODE;
     {
         $assembler = new GetterAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespaces,
+                $codeGenContext,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
             ),
         ], XsdType::create('MyType'));
 
-        $context =  new PropertyContext($class, $type, $property);
+        $context =  new PropertyContext($class, $type, $property, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -279,20 +279,20 @@ CODE;
      */
     private function createContext($propertyName = 'prop1')
     {
-        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
+        $ns1Context = $this->createCodeGeneratorContext('ns1');
         $properties = [
-            'prop1' => Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            'prop2' => Property::fromMetaData($ns1Namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
-            'prop3' => Property::fromMetaData($ns1Namespaces, new MetaProperty('prop3', XsdType::guess('bool'))),
-            'prop4' => Property::fromMetaData($ns1Namespaces, new MetaProperty('prop4', XsdType::guess('My_Response'))),
+            'prop1' => Property::fromMetaData($ns1Context, new MetaProperty('prop1', XsdType::guess('string'))),
+            'prop2' => Property::fromMetaData($ns1Context, new MetaProperty('prop2', XsdType::guess('int'))),
+            'prop3' => Property::fromMetaData($ns1Context, new MetaProperty('prop3', XsdType::guess('bool'))),
+            'prop4' => Property::fromMetaData($ns1Context, new MetaProperty('prop4', XsdType::guess('My_Response'))),
         ];
 
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties[$propertyName];
 
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 
     /**
@@ -300,17 +300,17 @@ CODE;
      */
     private function createContextWithLongType()
     {
-        $longNamespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
+        $longContext = $this->createCodeGeneratorContext('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
         $properties = [
             'prop1' => Property::fromMetaData(
-                $longNamespaces,
+                $longContext,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ImmutableSetterAssemblerTest.php
@@ -231,17 +231,17 @@ CODE;
     {
         $assembler = new ImmutableSetterAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespaces,
+                $codeGenContext,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
             ),
         ], XsdType::create('MyType'));
 
-        $context =  new PropertyContext($class, $type, $property);
+        $context =  new PropertyContext($class, $type, $property, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -274,13 +274,13 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            $property = Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $ns1Context = $this->createCodeGeneratorContext('ns1');
+        $type = new Type($context, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($ns1Context, new MetaProperty('prop1', XsdType::guess('string'))),
         ], XsdType::create('MyType'));
 
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 
     /**
@@ -288,17 +288,17 @@ CODE;
      */
     private function createContextWithLongType()
     {
-        $longNamespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
+        $longContext = $this->createCodeGeneratorContext('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
         $properties = [
             'prop1' => Property::fromMetaData(
-                $longNamespaces,
+                $longContext,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/InterfaceAssemblerTest.php
@@ -45,11 +45,11 @@ class InterfaceAssemblerTest extends TestCase
     {
         $assembler = new InterfaceAssembler('MyUsedClass');
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
-        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
-        $property = Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string')));
-        $context = new PropertyContext($class, $type, $property);
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $ns1Context = $this->createCodeGeneratorContext('ns1');
+        $property = Property::fromMetaData($ns1Context, new MetaProperty('prop1', XsdType::guess('string')));
+        $context = new PropertyContext($class, $type, $property, $codeGenContext);
         $this->assertTrue($assembler->canAssemble($context));
     }
 
@@ -81,12 +81,12 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($context, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/IteratorAssemblerTest.php
@@ -121,9 +121,9 @@ CODE;
     {
         $metaConfigurator ??= identity();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $metaConfigurator($meta
                     ->withIsList(true)
                     ->withMinOccurs(1)
@@ -131,6 +131,6 @@ CODE;
             )))),
         ], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/JsonSerializableAssemblerTest.php
@@ -74,12 +74,12 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($context, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/PropertyAssemblerTest.php
@@ -6,8 +6,7 @@ use Phpro\SoapClient\CodeGenerator\Assembler\AssemblerInterface;
 use Phpro\SoapClient\CodeGenerator\Assembler\PropertyAssembler;
 use Phpro\SoapClient\CodeGenerator\Assembler\PropertyAssemblerOptions;
 use Phpro\SoapClient\CodeGenerator\Config\DefaultValuesStrategy;
-use Phpro\SoapClient\CodeGenerator\Config\Destination;
-use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Context\PropertyContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
@@ -194,19 +193,19 @@ CODE;
     {
         $assembler = new PropertyAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespaces,
+                $context,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
             ),
         ], XsdType::create('MyType'));
 
-        $context =  new PropertyContext($class, $type, $property);
-        $assembler->assemble($context);
-        $code = $context->getClass()->generate();
+        $propertyContext =  new PropertyContext($class, $type, $property, $context);
+        $assembler->assemble($propertyContext);
+        $code = $propertyContext->getClass()->generate();
 
         $expected = <<<CODE
 namespace MyNamespace;
@@ -416,14 +415,14 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            $property = Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withDocs('Type specific docs')
             ))),
         ], XsdType::create('MyType'));
 
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 
     /**
@@ -432,14 +431,14 @@ CODE;
     private function createContextWithLongType()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
+        $context = $this->createCodeGeneratorContext('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
+        $type = new Type($context, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespaces,
+                $context,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ], XsdType::create('MyType'));
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 
     /**
@@ -448,37 +447,37 @@ CODE;
     private function createContextWithNullableType()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            $property = Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withDocs('Type specific docs')->withIsNullable(true)
             ))),
         ], XsdType::create('MyType'));
 
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 
     private function createContextWithNullableComplexType(): PropertyContext
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            $property = Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('SomeClass')->withMeta(
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('SomeClass')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withIsNullable(true)
             ))),
         ], XsdType::create('MyType'));
 
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 
     private function createContextWithComplexType(): PropertyContext
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            $property = Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('SomeClass'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/RequestAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/RequestAssemblerTest.php
@@ -67,12 +67,12 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($context, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultAssemblerTest.php
@@ -67,12 +67,12 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
-            Property::fromMetaData($namespaces, new MetaProperty('prop2', XsdType::guess('int'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('string'))),
+            Property::fromMetaData($context, new MetaProperty('prop2', XsdType::guess('int'))),
         ], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/ResultProviderAssemblerTest.php
@@ -135,11 +135,11 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            Property::fromMetaData($namespaces, new MetaProperty('prop1', XsdType::guess('SomeClass'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [
+            Property::fromMetaData($context, new MetaProperty('prop1', XsdType::guess('SomeClass'))),
         ], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/SetterAssemblerTest.php
@@ -151,17 +151,17 @@ CODE;
     {
         $assembler = new SetterAssembler();
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
+        $codeGenContext = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($codeGenContext, 'MyType', 'MyType', [
             $property = Property::fromMetaData(
-                $namespaces,
+                $codeGenContext,
                 new MetaProperty('prop1', XsdType::guess('string')->withMeta(
                     static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
                 ))
             ),
         ], XsdType::create('MyType'));
 
-        $context =  new PropertyContext($class, $type, $property);
+        $context =  new PropertyContext($class, $type, $property, $codeGenContext);
         $assembler->assemble($context);
 
         $code = $context->getClass()->generate();
@@ -190,13 +190,13 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
-        $type = new Type($namespaces, 'MyType', 'MyType', [
-            $property = Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string'))),
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $ns1Context = $this->createCodeGeneratorContext('ns1');
+        $type = new Type($context, 'MyType', 'MyType', [
+            $property = Property::fromMetaData($ns1Context, new MetaProperty('prop1', XsdType::guess('string'))),
         ], XsdType::create('MyType'));
 
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 
     /**
@@ -204,17 +204,17 @@ CODE;
      */
     private function createContextWithLongType()
     {
-        $longNamespaces = $this->createTypeNamespaceMap('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
+        $longContext = $this->createCodeGeneratorContext('This\\Is\\My\\Very\\Very\\Long\\Namespace\\And\\Class\\Name\\That\\Should\\Not\\Never\\Ever');
         $properties = [
             'prop1' => Property::fromMetaData(
-                $longNamespaces,
+                $longContext,
                 new MetaProperty('prop1', XsdType::guess('Wrap'))
             ),
         ];
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', array_values($properties), XsdType::create('MyType'));
         $property = $properties['prop1'];
-        return new PropertyContext($class, $type, $property);
+        return new PropertyContext($class, $type, $property, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/TraitAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/TraitAssemblerTest.php
@@ -89,9 +89,9 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Assembler/UseAssemblerTest.php
@@ -45,12 +45,12 @@ class UseAssemblerTest extends TestCase
     {
         $assembler = new UseAssembler('MyUsedClass');
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
-        $ns1Namespaces = $this->createTypeNamespaceMap('ns1');
-        $property = Property::fromMetaData($ns1Namespaces, new MetaProperty('prop1', XsdType::guess('string')));
-        $context = new PropertyContext($class, $type, $property);
-        $this->assertTrue($assembler->canAssemble($context));
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $ns1Context = $this->createCodeGeneratorContext('ns1');
+        $property = Property::fromMetaData($ns1Context, new MetaProperty('prop1', XsdType::guess('string')));
+        $propertyContext = new PropertyContext($class, $type, $property, $context);
+        $this->assertTrue($assembler->canAssemble($propertyContext));
     }
 
     #[Test]
@@ -165,13 +165,13 @@ CODE;
     {
         $assembler = new UseAssembler('SomeOtherClass');
         $class = new ClassGenerator('MyType');
-        $namespaces = $this->createTypeNamespaceMap('');
-        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
-        $context = new TypeContext($class, $type);
+        $context = $this->createCodeGeneratorContext('');
+        $type = new Type($context, 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $typeContext = new TypeContext($class, $type, $context);
 
-        $assembler->assemble($context);
+        $assembler->assemble($typeContext);
 
-        $code = $context->getClass()->generate();
+        $code = $typeContext->getClass()->generate();
         $expected = <<<CODE
 class MyType
 {
@@ -211,9 +211,9 @@ CODE;
     private function createContext()
     {
         $class = new ClassGenerator('MyType', 'MyNamespace');
-        $namespaces = $this->createTypeNamespaceMap('MyNamespace');
-        $type = new Type($namespaces, 'MyType', 'MyType', [], XsdType::create('MyType'));
+        $context = $this->createCodeGeneratorContext('MyNamespace');
+        $type = new Type($context, 'MyType', 'MyType', [], XsdType::create('MyType'));
 
-        return new TypeContext($class, $type);
+        return new TypeContext($class, $type, $context);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ClientFactoryGeneratorTest.php
@@ -4,6 +4,7 @@ namespace PhproTest\SoapClient\Unit\CodeGenerator;
 
 use Laminas\Code\Generator\ClassGenerator;
 use Phpro\SoapClient\CodeGenerator\ClientFactoryGenerator;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
@@ -11,6 +12,7 @@ use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\CodeGenerator\Context\ClassMapContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientContext;
 use Phpro\SoapClient\CodeGenerator\Context\ClientFactoryContext;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Model\TypeMap;
 use PHPUnit\Framework\TestCase;
 use Laminas\Code\Generator\FileGenerator;
@@ -73,11 +75,13 @@ BODY;
         $clientContext = new ClientContext(new ClassGenerator(), $clientConfig);
 
         $typeNamespaceMap = TypeNamespaceMap::create(new Destination('/app/types', 'App\\Types'));
+        $codeGeneratorContext = new CodeGeneratorContext($typeNamespaceMap, new DefaultCodingStandardsStrategy());
         $classMapConfig = new ClassMapConfig('SomeClassmap', new Destination('/app/classmap', 'App\\Classmap'));
         $classMapContext = new ClassMapContext(
             new FileGenerator(),
-            new TypeMap($typeNamespaceMap, []),
-            $classMapConfig
+            new TypeMap($codeGeneratorContext, []),
+            $classMapConfig,
+            $codeGeneratorContext
         );
         $context = new ClientFactoryContext($clientContext, $classMapContext);
         $generator = new ClientFactoryGenerator();

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/CodingStandards/DefaultCodingStandardsStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/CodingStandards/DefaultCodingStandardsStrategyTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace PhproTest\SoapClient\Unit\CodeGenerator\CodingStandards;
+
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
+use Phpro\SoapClient\CodeGenerator\Util\Normalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class DefaultCodingStandardsStrategyTest extends TestCase
+{
+    private DefaultCodingStandardsStrategy $strategy;
+
+    protected function setUp(): void
+    {
+        $this->strategy = new DefaultCodingStandardsStrategy();
+    }
+
+    #[Test]
+    public function it_implements_coding_standards_strategy_interface(): void
+    {
+        $this->assertInstanceOf(CodingStandardsStrategyInterface::class, $this->strategy);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideTypeNameCases(): iterable
+    {
+        yield 'simple' => ['MyType', 'MyType'];
+        yield 'snake_case' => ['my_type', 'MyType'];
+        yield 'hyphenated' => ['my-type', 'MyType'];
+        yield 'reserved keyword' => ['list', 'ListType'];
+    }
+
+    #[Test]
+    #[DataProvider('provideTypeNameCases')]
+    public function it_normalizes_type_name(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->strategy->normalizeTypeName($input));
+        $this->assertSame(Normalizer::normalizeClassname($input), $this->strategy->normalizeTypeName($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideOperationNameCases(): iterable
+    {
+        yield 'PascalCase' => ['GetUsers', 'getUsers'];
+        yield 'camelCase' => ['getUsers', 'getUsers'];
+        yield 'snake_case' => ['get_users', 'get_users'];
+        yield 'reserved keyword' => ['list', 'listCall'];
+    }
+
+    #[Test]
+    #[DataProvider('provideOperationNameCases')]
+    public function it_normalizes_operation_name(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->strategy->normalizeOperationName($input));
+        $this->assertSame(Normalizer::normalizeMethodName($input), $this->strategy->normalizeOperationName($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string}>
+     */
+    public static function provideNamespaceSegmentCases(): iterable
+    {
+        yield 'normal prefix' => ['gml', 'Gml'];
+        yield 'hyphenated' => ['my-prefix', 'MyPrefix'];
+        yield 'leading digit' => ['2way', 'Ns2way'];
+        yield 'empty string' => ['', null];
+    }
+
+    #[Test]
+    #[DataProvider('provideNamespaceSegmentCases')]
+    public function it_normalizes_namespace_segment(string $input, ?string $expected): void
+    {
+        $this->assertSame($expected, $this->strategy->normalizeNamespaceSegment($input));
+        $this->assertSame(
+            Normalizer::normalizeNamespaceSegment($input),
+            $this->strategy->normalizeNamespaceSegment($input)
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideEnumCaseNameCases(): iterable
+    {
+        yield 'simple' => ['Active', 'Active'];
+        yield 'hyphenated' => ['some-value', 'someValue'];
+        yield 'empty' => ['', 'Empty'];
+        yield 'numeric' => ['42', 'Value_42'];
+    }
+
+    #[Test]
+    #[DataProvider('provideEnumCaseNameCases')]
+    public function it_normalizes_enum_case_name(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->strategy->normalizeEnumCaseName($input));
+        $this->assertSame(Normalizer::normalizeEnumCaseName($input), $this->strategy->normalizeEnumCaseName($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function providePropertyAccessorMethodNameCases(): iterable
+    {
+        yield 'getter' => ['get', 'firstName', 'getFirstName'];
+        yield 'setter' => ['set', 'firstName', 'setFirstName'];
+        yield 'with prefix' => ['with', 'firstName', 'withFirstName'];
+    }
+
+    #[Test]
+    #[DataProvider('providePropertyAccessorMethodNameCases')]
+    public function it_generates_property_accessor_method_name(
+        string $prefix,
+        string $property,
+        string $expected
+    ): void {
+        $this->assertSame($expected, $this->strategy->generatePropertyAccessorMethodName($prefix, $property));
+        $this->assertSame(
+            Normalizer::generatePropertyMethod($prefix, $property),
+            $this->strategy->generatePropertyAccessorMethodName($prefix, $property)
+        );
+    }
+
+    #[Test]
+    public function it_returns_property_name_as_parameter_name(): void
+    {
+        $this->assertSame('firstName', $this->strategy->normalizeParameterName('firstName'));
+        $this->assertSame('some_prop', $this->strategy->normalizeParameterName('some_prop'));
+    }
+}

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigGeneratorTest.php
@@ -28,13 +28,13 @@ use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
 
-return Config::create()
+return (\$config = Config::create())
     ->setEngine(\$engine = DefaultEngineFactory::create(
         EngineOptions::defaults('wsdl.xml')
     ))
     ->setTypeNamespaceMap(
         TypeNamespaceMap::create(new Destination('src/type', 'App\\\\Type'))
-        // ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+        // ->withStrategy(new PrefixBasedTypeNamespaceStrategy(\$config->getCodingStandards()))
     )
     ->setClient(new ClientConfig('Client', new Destination('src/client', 'App\\\\Client')))
     ->setClassMap(new ClassMapConfig('Classmap', new Destination('src/classmap', 'App\\\\Classmap')))
@@ -107,7 +107,7 @@ use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
 
-return Config::create()
+return (\$config = Config::create())
     ->setEngine(\$engine = DefaultEngineFactory::create(
         EngineOptions::defaults('wsdl.xml')
     ))
@@ -115,7 +115,7 @@ return Config::create()
         TypeNamespaceMap::create(new Destination('src/type', 'App\\\\Type'))
         // ->withMapping('http://www.opengis.net/gml/3.2', new Destination('src/type/Gml', 'App\\\\Type\\\\Gml'))
         // ->withMapping('http://xoev.de/schemata/xzufi/2_2_0', new Destination('src/type/Xzufi', 'App\\\\Type\\\\Xzufi'))
-        // ->withStrategy(new PrefixBasedTypeNamespaceStrategy())
+        // ->withStrategy(new PrefixBasedTypeNamespaceStrategy(\$config->getCodingStandards()))
     )
     ->setClient(new ClientConfig('Client', new Destination('src/client', 'App\\\\Client')))
     ->setClassMap(new ClassMapConfig('Classmap', new Destination('src/classmap', 'App\\\\Classmap')))
@@ -191,7 +191,7 @@ use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
 use Phpro\SoapClient\Soap\EngineOptions;
 use Phpro\SoapClient\Soap\DefaultEngineFactory;
 
-return Config::create()
+return (\$config = Config::create())
     ->setEngine(\$engine = DefaultEngineFactory::create(
         EngineOptions::defaults('wsdl.xml')
     ))

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigurationHelper.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/ConfigurationHelper.php
@@ -4,16 +4,26 @@ declare(strict_types=1);
 
 namespace PhproTest\SoapClient\Unit\CodeGenerator;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 
 trait ConfigurationHelper
 {
     private function createTypeNamespaceMap(string $namespace = 'Generated'): TypeNamespaceMap
     {
         return TypeNamespaceMap::create(new Destination('/generated', $namespace));
+    }
+
+    private function createCodeGeneratorContext(string $namespace = 'Generated'): CodeGeneratorContext
+    {
+        return new CodeGeneratorContext(
+            $this->createTypeNamespaceMap($namespace),
+            new DefaultCodingStandardsStrategy(),
+        );
     }
 
     private function createDestination(string $path = '/generated', string $namespace = 'Generated'): Destination

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/EnumerationGeneratorTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/EnumerationGeneratorTest.php
@@ -2,14 +2,10 @@
 
 namespace PhproTest\SoapClient\Unit\CodeGenerator;
 
-use Phpro\SoapClient\CodeGenerator\ConfigGenerator;
-use Phpro\SoapClient\CodeGenerator\Context\ConfigContext;
 use Phpro\SoapClient\CodeGenerator\EnumerationGenerator;
-use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Model\Type;
 use PHPUnit\Framework\TestCase;
 use Laminas\Code\Generator\FileGenerator;
-use Soap\Engine\Metadata\Model\Property as MetaProperty;
 use Soap\Engine\Metadata\Model\TypeMeta;
 use Soap\Engine\Metadata\Model\XsdType;
 
@@ -19,7 +15,7 @@ class EnumerationGeneratorTest extends TestCase
     public function testStringBackedEnumGeneration(): void
     {
         $type = new Type(
-            $this->createTypeNamespaceMap('MyNamespace'),
+            $this->createCodeGeneratorContext('MyNamespace'),
             'MyType',
             'MyType',
             [],
@@ -55,7 +51,7 @@ class EnumerationGeneratorTest extends TestCase
     public function testIntBackedEnumGeneration(): void
     {
         $type = new Type(
-            $this->createTypeNamespaceMap('MyNamespace'),
+            $this->createCodeGeneratorContext('MyNamespace'),
             'MyType',
             'MyType',
             [],
@@ -89,7 +85,7 @@ class EnumerationGeneratorTest extends TestCase
     public function testBackedEnumDocblockGeneration(): void
     {
         $type = new Type(
-            $this->createTypeNamespaceMap('MyNamespace'),
+            $this->createCodeGeneratorContext('MyNamespace'),
             'MyType',
             'MyType',
             [],

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Model/PropertyTest.php
@@ -2,8 +2,10 @@
 
 namespace PhproTest\SoapClient\Unit\CodeGenerator\Model;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -20,15 +22,18 @@ use Soap\Engine\Metadata\Model\XsdType;
  */
 class PropertyTest extends TestCase
 {
-    private static function createTypeNamespaceMap(string $namespace): TypeNamespaceMap
+    private static function createCodeGeneratorContext(string $namespace): CodeGeneratorContext
     {
-        return TypeNamespaceMap::create(new Destination('/generated', $namespace));
+        return new CodeGeneratorContext(
+            TypeNamespaceMap::create(new Destination('/generated', $namespace)),
+            new DefaultCodingStandardsStrategy(),
+        );
     }
 
     #[Test]
     public function it_returns_mixed_type_post_php8(): void
     {
-        $property = new Property('test', 'mixed', self::createTypeNamespaceMap('App'), 'App', XsdType::create('mixed'));
+        $property = new Property('test', 'mixed', self::createCodeGeneratorContext('App'), 'App', XsdType::create('mixed'));
         self::assertEquals('mixed', $property->getPhpType());
         self::assertEquals('mixed', $property->getType());
     }
@@ -37,7 +42,7 @@ class PropertyTest extends TestCase
     public function it_can_use_fqcn_to_3rd_party_classes_as_type_name(): void
     {
         $property = Property::fromMetaData(
-            self::createTypeNamespaceMap('MyApp'),
+            self::createCodeGeneratorContext('MyApp'),
             new EngineProperty(
                 'property',
                 $xsdType = XsdType::create(Option::class)
@@ -54,7 +59,7 @@ class PropertyTest extends TestCase
     public function it_can_use_a_php_built_in_class_as_type_name(): void
     {
         $property = Property::fromMetaData(
-            self::createTypeNamespaceMap('MyApp'),
+            self::createCodeGeneratorContext('MyApp'),
             new EngineProperty(
                 'property',
                 $xsdType = XsdType::create('\\'. \DateInterval::class)
@@ -78,7 +83,7 @@ class PropertyTest extends TestCase
     {
         yield 'known_simple_type' => [
             Property::fromMetaData(
-                self::createTypeNamespaceMap('MyApp'),
+                self::createCodeGeneratorContext('MyApp'),
                 new EngineProperty(
                     'property',
                     XsdType::create('string')
@@ -89,7 +94,7 @@ class PropertyTest extends TestCase
 
         yield 'known_simple_base_type' => [
             Property::fromMetaData(
-                self::createTypeNamespaceMap('MyApp'),
+                self::createCodeGeneratorContext('MyApp'),
                 new EngineProperty(
                     'property',
                     XsdType::create('language')
@@ -105,7 +110,7 @@ class PropertyTest extends TestCase
 
         yield 'known_simple_base_type_with_enums' => [
             Property::fromMetaData(
-                self::createTypeNamespaceMap('MyApp'),
+                self::createCodeGeneratorContext('MyApp'),
                 new EngineProperty(
                     'property',
                     XsdType::create('languageEnum')
@@ -122,7 +127,7 @@ class PropertyTest extends TestCase
 
         yield 'root namespace' => [
             Property::fromMetaData(
-                self::createTypeNamespaceMap(''),
+                self::createCodeGeneratorContext(''),
                 new EngineProperty(
                     'property',
                     XsdType::create('MyType')
@@ -133,7 +138,7 @@ class PropertyTest extends TestCase
 
         yield 'namespaced' => [
             Property::fromMetaData(
-                self::createTypeNamespaceMap('MyApp'),
+                self::createCodeGeneratorContext('MyApp'),
                 new EngineProperty(
                     'property',
                     XsdType::create('MyType')

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/Provider/ScalarDefaultProviderTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/Provider/ScalarDefaultProviderTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PhproTest\SoapClient\Unit\CodeGenerator\Provider;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\CodeGenerator\Model\Property;
 use Phpro\SoapClient\CodeGenerator\Provider\ScalarDefaultProvider;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -34,34 +36,34 @@ class ScalarDefaultProviderTest extends TestCase
 
     public static function provideDefaults(): iterable
     {
-        $namespaces = TypeNamespaceMap::create(new Destination('/generated', 'ns1'));
+        $context = new CodeGeneratorContext(TypeNamespaceMap::create(new Destination('/generated', 'ns1')), new DefaultCodingStandardsStrategy());
 
         yield 'string' => [
-            Property::fromMetaData($namespaces, new MetaProperty('prop', XsdType::create('string'))),
+            Property::fromMetaData($context, new MetaProperty('prop', XsdType::create('string'))),
             true,
             '',
         ];
 
         yield 'int' => [
-            Property::fromMetaData($namespaces, new MetaProperty('prop', XsdType::create('int'))),
+            Property::fromMetaData($context, new MetaProperty('prop', XsdType::create('int'))),
             true,
             0,
         ];
 
         yield 'bool' => [
-            Property::fromMetaData($namespaces, new MetaProperty('prop', XsdType::create('bool'))),
+            Property::fromMetaData($context, new MetaProperty('prop', XsdType::create('bool'))),
             true,
             false,
         ];
 
         yield 'float' => [
-            Property::fromMetaData($namespaces, new MetaProperty('prop', XsdType::create('float'))),
+            Property::fromMetaData($context, new MetaProperty('prop', XsdType::create('float'))),
             true,
             0.0,
         ];
 
         yield 'array (list)' => [
-            Property::fromMetaData($namespaces, new MetaProperty('prop', XsdType::guess('string')->withMeta(
+            Property::fromMetaData($context, new MetaProperty('prop', XsdType::guess('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withIsList(true)
             ))),
             true,
@@ -69,13 +71,13 @@ class ScalarDefaultProviderTest extends TestCase
         ];
 
         yield 'mixed' => [
-            Property::fromMetaData($namespaces, new MetaProperty('prop', XsdType::create('mixed'))),
+            Property::fromMetaData($context, new MetaProperty('prop', XsdType::create('mixed'))),
             true,
             null,
         ];
 
         yield 'nullable complex type' => [
-            Property::fromMetaData($namespaces, new MetaProperty('prop', XsdType::create('SomeClass')->withMeta(
+            Property::fromMetaData($context, new MetaProperty('prop', XsdType::create('SomeClass')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withIsNullable(true)
             ))),
             true,
@@ -83,12 +85,12 @@ class ScalarDefaultProviderTest extends TestCase
         ];
 
         yield 'non-nullable complex type' => [
-            Property::fromMetaData($namespaces, new MetaProperty('prop', XsdType::create('SomeClass'))),
+            Property::fromMetaData($context, new MetaProperty('prop', XsdType::create('SomeClass'))),
             false,
         ];
 
         yield 'nullable scalar (nullable check wins)' => [
-            Property::fromMetaData($namespaces, new MetaProperty('prop', XsdType::create('string')->withMeta(
+            Property::fromMetaData($context, new MetaProperty('prop', XsdType::create('string')->withMeta(
                 static fn (TypeMeta $meta): TypeMeta => $meta->withIsNullable(true)
             ))),
             true,

--- a/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeNamespaceMap/Strategy/PrefixBasedTypeNamespaceStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/CodeGenerator/TypeNamespaceMap/Strategy/PrefixBasedTypeNamespaceStrategyTest.php
@@ -2,14 +2,17 @@
 
 namespace PhproTest\SoapClient\Unit\CodeGenerator\TypeNamespaceMap\Strategy;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\PrefixBasedTypeNamespaceStrategy;
 use Phpro\SoapClient\CodeGenerator\TypeNamespaceMap\Strategy\TypeNamespaceMapStrategyInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class PrefixBasedTypeNamespaceStrategyTest extends TestCase
 {
+    use ProphecyTrait;
     #[Test]
     public function it_implements_the_strategy_interface(): void
     {
@@ -59,5 +62,33 @@ class PrefixBasedTypeNamespaceStrategyTest extends TestCase
         $result = $strategy('http://example.com/schema', '3d', $fallback);
 
         $this->assertEquals(new Destination('src/Type/Ns3d', 'App\\Type\\Ns3d'), $result);
+    }
+
+    #[Test]
+    public function it_uses_custom_coding_standards_strategy(): void
+    {
+        $codingStandards = $this->prophesize(CodingStandardsStrategyInterface::class);
+        $codingStandards->normalizeNamespaceSegment('gml')->willReturn('GML');
+
+        $strategy = new PrefixBasedTypeNamespaceStrategy($codingStandards->reveal());
+        $fallback = new Destination('src/Type', 'App\\Type');
+
+        $result = $strategy('http://www.opengis.net/gml/3.2', 'gml', $fallback);
+
+        $this->assertEquals(new Destination('src/Type/GML', 'App\\Type\\GML'), $result);
+    }
+
+    #[Test]
+    public function it_returns_fallback_when_custom_coding_standards_returns_null(): void
+    {
+        $codingStandards = $this->prophesize(CodingStandardsStrategyInterface::class);
+        $codingStandards->normalizeNamespaceSegment('skip')->willReturn(null);
+
+        $strategy = new PrefixBasedTypeNamespaceStrategy($codingStandards->reveal());
+        $fallback = new Destination('src/Type', 'App\\Type');
+
+        $result = $strategy('http://example.com/schema', 'skip', $fallback);
+
+        $this->assertSame($fallback, $result);
     }
 }

--- a/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/DuplicateTypesKeyTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/DuplicateTypesKeyTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PhproTest\SoapClient\Unit\Soap\Metadata\Manipulators\DuplicateTypes;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\DuplicateTypesKey;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -15,24 +17,34 @@ use Soap\Engine\Metadata\Model\XsdType;
 
 class DuplicateTypesKeyTest extends TestCase
 {
+    private function createContext(?TypeNamespaceMap $namespaceMap = null): CodeGeneratorContext
+    {
+        return new CodeGeneratorContext(
+            $namespaceMap ?? TypeNamespaceMap::create(new Destination('/generated', 'Generated')),
+            new DefaultCodingStandardsStrategy(),
+        );
+    }
+
     #[Test]
-    public function it_returns_normalized_name_without_namespace_map(): void
+    public function it_returns_namespaced_normalized_name(): void
     {
         $type = new Type(XsdType::create('MyType'), new PropertyCollection());
+        $context = $this->createContext();
 
-        $key = DuplicateTypesKey::forType($type, null);
+        $key = DuplicateTypesKey::forType($type, $context);
 
-        self::assertEquals('MyType', $key);
+        self::assertEquals('Generated\\MyType', $key);
     }
 
     #[Test]
     public function it_normalizes_class_name(): void
     {
         $type = new Type(XsdType::create('my-type'), new PropertyCollection());
+        $context = $this->createContext();
 
-        $key = DuplicateTypesKey::forType($type, null);
+        $key = DuplicateTypesKey::forType($type, $context);
 
-        self::assertEquals('MyType', $key);
+        self::assertEquals('Generated\\MyType', $key);
     }
 
     #[Test]
@@ -46,7 +58,9 @@ class DuplicateTypesKeyTest extends TestCase
         $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'))
             ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'));
 
-        $key = DuplicateTypesKey::forType($type, $namespaceMap);
+        $context = $this->createContext($namespaceMap);
+
+        $key = DuplicateTypesKey::forType($type, $context);
 
         self::assertEquals('App\\Types\\A\\MyType', $key);
     }
@@ -62,7 +76,9 @@ class DuplicateTypesKeyTest extends TestCase
         $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'))
             ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'));
 
-        $key = DuplicateTypesKey::forType($type, $namespaceMap);
+        $context = $this->createContext($namespaceMap);
+
+        $key = DuplicateTypesKey::forType($type, $context);
 
         self::assertEquals('App\\Types\\MyType', $key);
     }
@@ -83,8 +99,10 @@ class DuplicateTypesKeyTest extends TestCase
             ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'))
             ->withMapping('http://ns-b.com', new Destination('/path/b', 'App\\Types\\B'));
 
-        $keyA = DuplicateTypesKey::forType($typeA, $namespaceMap);
-        $keyB = DuplicateTypesKey::forType($typeB, $namespaceMap);
+        $context = $this->createContext($namespaceMap);
+
+        $keyA = DuplicateTypesKey::forType($typeA, $context);
+        $keyB = DuplicateTypesKey::forType($typeB, $context);
 
         self::assertNotEquals($keyA, $keyB);
         self::assertEquals('App\\Types\\A\\Item', $keyA);
@@ -105,9 +123,10 @@ class DuplicateTypesKeyTest extends TestCase
 
         // Both namespaces map to fallback (no specific mappings)
         $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'));
+        $context = $this->createContext($namespaceMap);
 
-        $keyA = DuplicateTypesKey::forType($typeA, $namespaceMap);
-        $keyB = DuplicateTypesKey::forType($typeB, $namespaceMap);
+        $keyA = DuplicateTypesKey::forType($typeA, $context);
+        $keyB = DuplicateTypesKey::forType($typeB, $context);
 
         self::assertEquals($keyA, $keyB);
         self::assertEquals('App\\Types\\Item', $keyA);

--- a/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/IntersectDuplicateTypesStrategyTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PhproTest\SoapClient\Unit\Soap\Metadata\Manipulators\DuplicateTypes;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\IntersectDuplicateTypesStrategy;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorInterface;
 use PHPUnit\Framework\TestCase;
@@ -19,10 +21,18 @@ use Soap\Engine\Metadata\Model\XsdType;
 
 class IntersectDuplicateTypesStrategyTest extends TestCase
 {
+    private function createContext(?TypeNamespaceMap $namespaceMap = null): CodeGeneratorContext
+    {
+        return new CodeGeneratorContext(
+            $namespaceMap ?? TypeNamespaceMap::create(new Destination('/generated', 'Generated')),
+            new DefaultCodingStandardsStrategy(),
+        );
+    }
+
     #[Test]
     public function it_is_a_types_manipulator(): void
     {
-        $strategy = new IntersectDuplicateTypesStrategy();
+        $strategy = new IntersectDuplicateTypesStrategy($this->createContext());
         self::assertInstanceOf(TypesManipulatorInterface::class, $strategy);
     }
 
@@ -32,14 +42,14 @@ class IntersectDuplicateTypesStrategyTest extends TestCase
         $factory = IntersectDuplicateTypesStrategy::create();
         self::assertInstanceOf(\Closure::class, $factory);
 
-        $strategy = $factory(null);
+        $strategy = $factory($this->createContext());
         self::assertInstanceOf(IntersectDuplicateTypesStrategy::class, $strategy);
     }
 
     #[Test]
     public function it_can_intersect_duplicate_types(): void
     {
-        $strategy = new IntersectDuplicateTypesStrategy();
+        $strategy = new IntersectDuplicateTypesStrategy($this->createContext());
         $types = new TypeCollection(
             new Type(XsdType::create('file'), new PropertyCollection(
                 new Property('prop1', XsdType::create('string')),
@@ -88,7 +98,7 @@ class IntersectDuplicateTypesStrategyTest extends TestCase
             ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'))
             ->withMapping('http://ns-b.com', new Destination('/path/b', 'App\\Types\\B'));
 
-        $strategy = new IntersectDuplicateTypesStrategy($namespaceMap);
+        $strategy = new IntersectDuplicateTypesStrategy($this->createContext($namespaceMap));
 
         $types = new TypeCollection(
             new Type(
@@ -111,7 +121,7 @@ class IntersectDuplicateTypesStrategyTest extends TestCase
     {
         $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'));
 
-        $strategy = new IntersectDuplicateTypesStrategy($namespaceMap);
+        $strategy = new IntersectDuplicateTypesStrategy($this->createContext($namespaceMap));
 
         $types = new TypeCollection(
             new Type(
@@ -127,28 +137,6 @@ class IntersectDuplicateTypesStrategyTest extends TestCase
         $manipulated = $strategy($types);
 
         // Both map to fallback namespace, so they ARE duplicates
-        self::assertCount(1, iterator_to_array($manipulated));
-    }
-
-    #[Test]
-    public function it_behaves_as_before_without_namespace_map(): void
-    {
-        $strategy = new IntersectDuplicateTypesStrategy(); // No namespace map
-
-        $types = new TypeCollection(
-            new Type(
-                XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
-                new PropertyCollection()
-            ),
-            new Type(
-                XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
-                new PropertyCollection()
-            ),
-        );
-
-        $manipulated = $strategy($types);
-
-        // Without namespace map, these are considered duplicates (legacy behavior)
         self::assertCount(1, iterator_to_array($manipulated));
     }
 }

--- a/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategyTest.php
+++ b/test/PhproTest/SoapClient/Unit/Soap/Metadata/Manipulators/DuplicateTypes/RemoveDuplicateTypesStrategyTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace PhproTest\SoapClient\Unit\Soap\Metadata\Manipulators\DuplicateTypes;
 
+use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
 use Phpro\SoapClient\CodeGenerator\Config\TypeNamespaceMap;
+use Phpro\SoapClient\CodeGenerator\Context\CodeGeneratorContext;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\DuplicateTypes\RemoveDuplicateTypesStrategy;
 use Phpro\SoapClient\Soap\Metadata\Manipulators\TypesManipulatorInterface;
 use PHPUnit\Framework\TestCase;
@@ -17,10 +19,18 @@ use Soap\Engine\Metadata\Model\XsdType;
 
 class RemoveDuplicateTypesStrategyTest extends TestCase
 {
+    private function createContext(?TypeNamespaceMap $namespaceMap = null): CodeGeneratorContext
+    {
+        return new CodeGeneratorContext(
+            $namespaceMap ?? TypeNamespaceMap::create(new Destination('/generated', 'Generated')),
+            new DefaultCodingStandardsStrategy(),
+        );
+    }
+
     #[Test]
     public function it_is_a_types_manipulator(): void
     {
-        $strategy = new RemoveDuplicateTypesStrategy();
+        $strategy = new RemoveDuplicateTypesStrategy($this->createContext());
         self::assertInstanceOf(TypesManipulatorInterface::class, $strategy);
     }
 
@@ -30,14 +40,14 @@ class RemoveDuplicateTypesStrategyTest extends TestCase
         $factory = RemoveDuplicateTypesStrategy::create();
         self::assertInstanceOf(\Closure::class, $factory);
 
-        $strategy = $factory(null);
+        $strategy = $factory($this->createContext());
         self::assertInstanceOf(RemoveDuplicateTypesStrategy::class, $strategy);
     }
 
     #[Test]
     public function it_can_remove_duplicate_types(): void
     {
-        $strategy = new RemoveDuplicateTypesStrategy();
+        $strategy = new RemoveDuplicateTypesStrategy($this->createContext());
         $types = new TypeCollection(
             new Type(XsdType::create('file'), new PropertyCollection()),
             new Type(XsdType::create('file'), new PropertyCollection()),
@@ -70,7 +80,7 @@ class RemoveDuplicateTypesStrategyTest extends TestCase
             ->withMapping('http://ns-a.com', new Destination('/path/a', 'App\\Types\\A'))
             ->withMapping('http://ns-b.com', new Destination('/path/b', 'App\\Types\\B'));
 
-        $strategy = new RemoveDuplicateTypesStrategy($namespaceMap);
+        $strategy = new RemoveDuplicateTypesStrategy($this->createContext($namespaceMap));
 
         $types = new TypeCollection(
             new Type(
@@ -98,7 +108,7 @@ class RemoveDuplicateTypesStrategyTest extends TestCase
     {
         $namespaceMap = TypeNamespaceMap::create(new Destination('/path', 'App\\Types'));
 
-        $strategy = new RemoveDuplicateTypesStrategy($namespaceMap);
+        $strategy = new RemoveDuplicateTypesStrategy($this->createContext($namespaceMap));
 
         $types = new TypeCollection(
             new Type(
@@ -118,34 +128,6 @@ class RemoveDuplicateTypesStrategyTest extends TestCase
         $manipulated = $strategy($types);
 
         // Both Items map to fallback namespace, so they ARE duplicates and get removed
-        // Only UniqueType remains
-        self::assertCount(1, iterator_to_array($manipulated));
-        self::assertEquals('UniqueType', iterator_to_array($manipulated)[0]->getName());
-    }
-
-    #[Test]
-    public function it_behaves_as_before_without_namespace_map(): void
-    {
-        $strategy = new RemoveDuplicateTypesStrategy(); // No namespace map
-
-        $types = new TypeCollection(
-            new Type(
-                XsdType::create('Item')->withXmlNamespace('http://ns-a.com'),
-                new PropertyCollection()
-            ),
-            new Type(
-                XsdType::create('Item')->withXmlNamespace('http://ns-b.com'),
-                new PropertyCollection()
-            ),
-            new Type(
-                XsdType::create('UniqueType'),
-                new PropertyCollection()
-            ),
-        );
-
-        $manipulated = $strategy($types);
-
-        // Without namespace map, Items are considered duplicates (legacy behavior)
         // Only UniqueType remains
         self::assertCount(1, iterator_to_array($manipulated));
         self::assertEquals('UniqueType', iterator_to_array($manipulated)[0]->getName());


### PR DESCRIPTION
  ## Summary

  - Adds `CodingStandardsStrategyInterface` allowing users to customize how SOAP types, operations, namespaces, enum cases, and parameters are named in generated PHP code
  - Introduces `CodeGeneratorContext` value object that bundles `TypeNamespaceMap` + `CodingStandardsStrategyInterface`, replacing raw `TypeNamespaceMap` throughout the model/assembler/rule layers
  - Default behavior is unchanged (`DefaultCodingStandardsStrategy` delegates to existing `Normalizer`)
  - Generated config now uses `return ($config = Config::create())` pattern so `$config->getCodingStandards()` is accessible in nested fluent calls

  ## Example: PER-compatible coding standards

❗ It's just an example - You might need to change things.
Also consider that some SOAP services might have properties that resolve to the same name. For example your service can have 2 properties named: foo_bar and fooBar wich will both resolve to fooBar. This will cause conflicts. That's why we have our default coding strategy.

  ```php
  use Phpro\SoapClient\CodeGenerator\CodingStandards\CodingStandardsStrategyInterface;
  use Phpro\SoapClient\CodeGenerator\CodingStandards\DefaultCodingStandardsStrategy;

  final readonly class PerCodingStandards implements CodingStandardsStrategyInterface
  {
      private DefaultCodingStandardsStrategy $default;

      public function __construct()
      {
          $this->default = new DefaultCodingStandardsStrategy();
      }

      public function normalizeTypeName(string $name): string
      {
          return $this->default->normalizeTypeName($name);
      }

      public function normalizeOperationName(string $name): string
      {
          return $this->default->normalizeOperationName($name);
      }

      public function normalizeNamespaceSegment(string $name): ?string
      {
          return $this->default->normalizeNamespaceSegment($name);
      }

      public function normalizeEnumCaseName(string $value): string
      {
          return $this->default->normalizeEnumCaseName($value);
      }

      public function generatePropertyAccessorMethodName(string $prefix, string $property): string
      {
          // PER: camelCase accessors based on camelCase parameter name
          return $prefix . ucfirst($this->normalizeParameterName($property));
      }

      public function normalizeParameterName(string $propertyName): string
      {
          // PER: camelCase parameters (e.g. "first_name" -> "firstName")
          return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $propertyName))));
      }
  }
  ```

  Usage in config:
  ```php
  return ($config = Config::create())
      ->setCodingStandards(new PerCodingStandards())
      ->setEngine($engine = DefaultEngineFactory::create(
          EngineOptions::defaults('service.wsdl')
      ))
      ->setTypeNamespaceMap(
          TypeNamespaceMap::create(new Destination('src/Type', 'App\\Type'))
          ->withStrategy(new PrefixBasedTypeNamespaceStrategy($config->getCodingStandards()))
      )
      // ...
  ```

  This generates `$this->first_name = $firstName;` and `getFirstName()` / `withFirstName()` accessors — keeping SOAP property names stable while using PER-compliant camelCase for parameters and methods.

