### PR TITLE
GenConfigCommand - print wsdl loading exceptions when output is verbose

### DIFF
--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -2,7 +2,6 @@
 
 namespace Phpro\SoapClient\Console\Command;
 
-use Laminas\Code\Generator\FileGenerator;
 use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
@@ -19,6 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Laminas\Code\Generator\FileGenerator;
 
 class GenerateConfigCommand extends Command
 {
@@ -45,13 +45,13 @@ class GenerateConfigCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $context = new ConfigContext;
+        $context = new ConfigContext();
         $io = new SymfonyStyle($input, $output);
-        $required = new NotBlankValidator;
+        $required = new NotBlankValidator();
 
         // Ask for config location:
         $destination = $input->getOption('config');
-        if (! $destination) {
+        if (!$destination) {
             $destination = $io->ask(
                 'config location (Where to put the config, including .php)',
                 'config/soap-client.php'
@@ -62,6 +62,7 @@ class GenerateConfigCommand extends Command
         $context->setWsdl($wsdlUri);
 
         $io->warning('Attempting to load WSDL... (this might take a while)');
+
         try {
             $wsdl = $this->loadWsdl($wsdlUri);
         } catch (\Throwable $e) {
@@ -77,6 +78,7 @@ class GenerateConfigCommand extends Command
             $wsdl = null;
         }
 
+
         $context->setDetectedXmlNamespaces($wsdl?->namespaces->namespaceToNameMap ?? []);
         $context->setGenerateDocblocks($io->confirm('Should methods be generated with docblocks?', true));
         $name = $io->ask(
@@ -88,24 +90,24 @@ class GenerateConfigCommand extends Command
         $namespace = Normalizer::normalizeNamespace($io->ask('Namespace for your client', null, $required));
 
         // Create configuration objects
-        $typeDestination = new Destination($baseDir.DIRECTORY_SEPARATOR.'Type', $namespace.'\\Type');
+        $typeDestination = new Destination($baseDir . DIRECTORY_SEPARATOR . 'Type', $namespace . '\\Type');
         $context->setTypeDestination($typeDestination);
 
         $clientDestination = new Destination($baseDir, $namespace);
-        $clientConfig = new ClientConfig($name.'Client', $clientDestination);
+        $clientConfig = new ClientConfig($name . 'Client', $clientDestination);
         $context->setClientConfig($clientConfig);
 
-        $classMapConfig = new ClassMapConfig($name.'Classmap', $clientDestination);
+        $classMapConfig = new ClassMapConfig($name . 'Classmap', $clientDestination);
         $context->setClassMapConfig($classMapConfig);
 
         // Create the config
-        $generator = new ConfigGenerator;
-        $this->filesystem->putFileContents($destination, $generator->generate(new FileGenerator, $context));
-        $io->success('Config has been written to '.$destination);
+        $generator = new ConfigGenerator();
+        $this->filesystem->putFileContents($destination, $generator->generate(new FileGenerator(), $context));
+        $io->success('Config has been written to ' . $destination);
 
-        if (! $wsdl) {
+        if (!$wsdl) {
             $io->warning(
-                'The WSDL could not be loaded with default options.'.
+                'The WSDL could not be loaded with default options.' .
                 'You may need to configure custom engine options or verify the WSDL file manually before continuing.'
             );
 
@@ -117,9 +119,9 @@ class GenerateConfigCommand extends Command
 
     private function loadWsdl(string $wsdl): Wsdl1
     {
-        $options = EngineOptions::defaults($wsdl);
-        $loader = $options->getWsdlLoader();
+            $options = EngineOptions::defaults($wsdl);
+            $loader = $options->getWsdlLoader();
 
-        return (new Wsdl1Reader($loader))($wsdl);
+            return (new Wsdl1Reader($loader))($wsdl);
     }
 }

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -67,11 +67,9 @@ class GenerateConfigCommand extends Command
             $wsdl = $this->loadWsdl($wsdlUri);
         } catch (\Throwable $e) {
             $io->warning('Could not load the provided WSDL with default engine options.');
-            if ($output->isVerbose()) {
-                $io->error($e::class.': ' . $e->getMessage());
-            }
+            $io->error([$e::class,$e->getMessage()]);
             if ($output->isVeryVerbose()) {
-                $io->text($e->getTraceAsString());
+                $io->text(explode("\n", $e->getTraceAsString()));
             }
             $io->info('Continuing generating configuration...');
             $wsdl = null;

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -68,8 +68,7 @@ class GenerateConfigCommand extends Command
         } catch (\Throwable $e) {
             $io->warning('Could not load the provided WSDL with default engine options.');
             if ($output->isVerbose()) {
-                $io->text('<fg=red>'.$e::class.'</>');
-                $io->text($e->getMessage());
+                $io->error($e::class.': ' . $e->getMessage());
             }
             if ($output->isVeryVerbose()) {
                 $io->text($e->getTraceAsString());

--- a/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
+++ b/src/Phpro/SoapClient/Console/Command/GenerateConfigCommand.php
@@ -2,6 +2,7 @@
 
 namespace Phpro\SoapClient\Console\Command;
 
+use Laminas\Code\Generator\FileGenerator;
 use Phpro\SoapClient\CodeGenerator\Config\ClassMapConfig;
 use Phpro\SoapClient\CodeGenerator\Config\ClientConfig;
 use Phpro\SoapClient\CodeGenerator\Config\Destination;
@@ -18,7 +19,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Laminas\Code\Generator\FileGenerator;
 
 class GenerateConfigCommand extends Command
 {
@@ -45,13 +45,13 @@ class GenerateConfigCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $context = new ConfigContext();
+        $context = new ConfigContext;
         $io = new SymfonyStyle($input, $output);
-        $required = new NotBlankValidator();
+        $required = new NotBlankValidator;
 
         // Ask for config location:
         $destination = $input->getOption('config');
-        if (!$destination) {
+        if (! $destination) {
             $destination = $io->ask(
                 'config location (Where to put the config, including .php)',
                 'config/soap-client.php'
@@ -62,11 +62,19 @@ class GenerateConfigCommand extends Command
         $context->setWsdl($wsdlUri);
 
         $io->warning('Attempting to load WSDL... (this might take a while)');
-        $wsdl = $this->loadWsdl($wsdlUri);
-
-        if (!$wsdl) {
+        try {
+            $wsdl = $this->loadWsdl($wsdlUri);
+        } catch (\Throwable $e) {
             $io->warning('Could not load the provided WSDL with default engine options.');
+            if ($output->isVerbose()) {
+                $io->text('<fg=red>'.$e::class.'</>');
+                $io->text($e->getMessage());
+            }
+            if ($output->isVeryVerbose()) {
+                $io->text($e->getTraceAsString());
+            }
             $io->info('Continuing generating configuration...');
+            $wsdl = null;
         }
 
         $context->setDetectedXmlNamespaces($wsdl?->namespaces->namespaceToNameMap ?? []);
@@ -80,24 +88,24 @@ class GenerateConfigCommand extends Command
         $namespace = Normalizer::normalizeNamespace($io->ask('Namespace for your client', null, $required));
 
         // Create configuration objects
-        $typeDestination = new Destination($baseDir . DIRECTORY_SEPARATOR . 'Type', $namespace . '\\Type');
+        $typeDestination = new Destination($baseDir.DIRECTORY_SEPARATOR.'Type', $namespace.'\\Type');
         $context->setTypeDestination($typeDestination);
 
         $clientDestination = new Destination($baseDir, $namespace);
-        $clientConfig = new ClientConfig($name . 'Client', $clientDestination);
+        $clientConfig = new ClientConfig($name.'Client', $clientDestination);
         $context->setClientConfig($clientConfig);
 
-        $classMapConfig = new ClassMapConfig($name . 'Classmap', $clientDestination);
+        $classMapConfig = new ClassMapConfig($name.'Classmap', $clientDestination);
         $context->setClassMapConfig($classMapConfig);
 
         // Create the config
-        $generator = new ConfigGenerator();
-        $this->filesystem->putFileContents($destination, $generator->generate(new FileGenerator(), $context));
-        $io->success('Config has been written to ' . $destination);
+        $generator = new ConfigGenerator;
+        $this->filesystem->putFileContents($destination, $generator->generate(new FileGenerator, $context));
+        $io->success('Config has been written to '.$destination);
 
-        if (!$wsdl) {
+        if (! $wsdl) {
             $io->warning(
-                'The WSDL could not be loaded with default options.' .
+                'The WSDL could not be loaded with default options.'.
                 'You may need to configure custom engine options or verify the WSDL file manually before continuing.'
             );
 
@@ -107,15 +115,11 @@ class GenerateConfigCommand extends Command
         return self::SUCCESS;
     }
 
-    private function loadWsdl(string $wsdl): ?Wsdl1
+    private function loadWsdl(string $wsdl): Wsdl1
     {
-        try {
-            $options = EngineOptions::defaults($wsdl);
-            $loader = $options->getWsdlLoader();
+        $options = EngineOptions::defaults($wsdl);
+        $loader = $options->getWsdlLoader();
 
-            return (new Wsdl1Reader($loader))($wsdl);
-        } catch (\Throwable) {
-            return null;
-        }
+        return (new Wsdl1Reader($loader))($wsdl);
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

## Context
I spent some time debugging a local WSDL file  recently.  The path was incorrect but the exception was silently ignored, making it tedious to figure out what went wrong. The exception message pointed me straight to the issue.

I was using 5.x - I noticed the path issue I had was resolved in https://github.com/php-soap/wsdl/pull/35. _(thank you)_

## Changes
- Catch any thrown exception and output debug info on verbose runs during WSDL Loading in the GenerateConfigCommand
- `-v`  shows the exception class and message
- `-vv` also shows the stack trace

_Sorry for the formatting changes, without them I was unable to pass all pre-commit checks._
