### PR TITLE
Sync console application version & add release Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  tag            to modify the version and tag"
+
+tag:
+	$(if $(TAG),,$(error TAG is not defined. Pass via "make tag TAG=6.2.0"))
+	@echo Tagging $(TAG)
+	sed -i '' -e "s/APP_VERSION = '.*'/APP_VERSION = '$(TAG)'/" src/Phpro/SoapClient/Console/Application.php
+	php -l src/Phpro/SoapClient/Console/Application.php
+	git add -A
+	git commit -m '$(TAG) release' -n
+	git tag -s '$(TAG)' -m 'Version $(TAG)'

--- a/src/Phpro/SoapClient/Console/Application.php
+++ b/src/Phpro/SoapClient/Console/Application.php
@@ -20,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class Application extends SymfonyApplication
 {
     const APP_NAME = 'SoapClient';
-    const APP_VERSION = '5.0.0';
+    const APP_VERSION = '6.1.0';
 
     /**
      * Set up application:


### PR DESCRIPTION
## Problem

The console application reported a hardcoded version (`5.0.0`) that drifted from the released git tags, so `./bin/soap-client` printed a stale version. (Fixes #611)

```
$ ./bin/soap-client
SoapClient 5.0.0
```

## Changes

- Bump `Application::APP_VERSION` to `6.1.0` to match the latest release.
- Add a `Makefile` `tag` target (modelled on [phpro/grumphp](https://github.com/phpro/grumphp/blob/v2.x/Makefile)) that rewrites `APP_VERSION`, lints the file, commits and creates a **signed tag without the `v` prefix** — matching the current tag convention — so the constant and the git tag stay in sync by construction:

```sh
make tag TAG=6.2.0
```